### PR TITLE
Extend phone numbers to support text

### DIFF
--- a/components/Form/PhoneInput/PhoneInput.tsx
+++ b/components/Form/PhoneInput/PhoneInput.tsx
@@ -10,9 +10,17 @@ const PhoneInput = ({ rules, ...props }: Props): React.ReactElement => (
         value: 5,
         message: 'Invalid phone number',
       },
+      // this should be removed when the BE
+      // fix the inconsistencies in phone numbers
+      pattern: {
+        value: /^[\d\s+]+$/,
+        message: 'Move text to phone type box',
+      },
       ...rules,
     }}
-    type="number"
+    // this should be reenable when the BE
+    // fix the inconsistencies in phone numbers
+    // type="number"
   />
 );
 


### PR DESCRIPTION
**What**  
This is needed to support "re-population" of the input on _edit person_.

At the moment the data is not in a good shape and often there is text inside the number field.

<img width="472" alt="Screenshot 2021-04-28 at 10 12 04" src="https://user-images.githubusercontent.com/435399/116378971-e3396800-a812-11eb-87ea-93282a41f2ef.png">

