### PR TITLE
aligned warning notes BE names

### DIFF
--- a/components/AddForm/AddForm.tsx
+++ b/components/AddForm/AddForm.tsx
@@ -22,12 +22,20 @@ const AddForm = ({ person }: { person: Resident }): React.ReactElement => {
           },
         ]
       : [];
+  const betaForms = user.hasAdminPermissions
+    ? [
+        {
+          text: 'Warning Note',
+          value: `/people/${person.id}/warning-notes/add`,
+        },
+      ]
+    : [];
   return (
     <>
       <div className="govuk-form-group">
         <Autocomplete
           name="formList"
-          options={[...internalForms, ...forms]}
+          options={[...internalForms, ...forms, ...betaForms]}
           label="Choose a form"
           placeholder="Select or type form name"
           onChange={(value) => setUrl(value as string)}

--- a/components/AddForm/__snapshots__/AddForm.spec.tsx.snap
+++ b/components/AddForm/__snapshots__/AddForm.spec.tsx.snap
@@ -61,6 +61,16 @@ exports[`AddForm component should render children forms 1`] = `
         >
           Foo - Child
         </li>
+        <li
+          aria-selected="false"
+          class="suggestion"
+          data-testid="formList_2"
+          id="downshift-1-item-2"
+          role="option"
+          style="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);"
+        >
+          Warning Note
+        </li>
       </ul>
     </div>
   </div>

--- a/components/WarningNote/WarningNotes.tsx
+++ b/components/WarningNote/WarningNotes.tsx
@@ -28,10 +28,10 @@ export const WarningBox = ({ notes, personId }: Props): React.ReactElement => {
           {notes.map((note) => (
             <div key={note.id} className={styles.note}>
               <dl className={styles.noteDetails}>
-                {note.type && (
+                {note.noteType && (
                   <>
                     <dt>Type</dt>
-                    <dd>{note.type}</dd>
+                    <dd>{note.noteType}</dd>
                   </>
                 )}
                 {note.startDate && (

--- a/data/forms/warning-note-review.tsx
+++ b/data/forms/warning-note-review.tsx
@@ -34,7 +34,7 @@ const formSteps: FormStep[] = [
       </span>,
       {
         component: 'TextInput',
-        name: 'discussedWithManager',
+        name: 'managerName',
         label: 'Manager’s name',
         rules: { required: true },
       },

--- a/data/forms/warning-note.tsx
+++ b/data/forms/warning-note.tsx
@@ -166,7 +166,7 @@ const WARNING_TYPE_ADULTS: Array<FormComponentStep> = [
   </div>,
   {
     component: 'Radios',
-    name: 'type',
+    name: 'noteType',
     label: 'Select warning type',
     options: WARNING_TYPES_ADULTS,
     rules: { required: true },
@@ -223,7 +223,7 @@ const WARNING_TYPE_CHILDREN: Array<FormComponentStep> = [
   </div>,
   {
     component: 'Radios',
-    name: 'type',
+    name: 'noteType',
     label: 'Select warning type',
     options: WARNING_TYPES_CHILDREN,
     rules: { required: true },
@@ -370,7 +370,7 @@ const DISCUSSED_WITH_MANAGER: Array<FormComponentStep> = [
   </div>,
   {
     component: 'TextInput',
-    name: 'discussedWithManager',
+    name: 'managerName',
     label: 'Manager’s name',
     rules: { required: true },
   },

--- a/factories/warningNotes.ts
+++ b/factories/warningNotes.ts
@@ -5,12 +5,12 @@ import { WarningNote } from 'types';
 export const warningNoteFactory = Factory.define<WarningNote>(
   ({ sequence }) => ({
     id: sequence,
-    type: 'Risk to Staff',
+    noteType: 'Risk to Staff',
     startDate: new Date(2020, 11, 22),
     createdBy: 'Foo',
     disclosedWithIndividual: false,
     undisclosedDetails: 'nope',
-    discussedWithManager: 'the big boss',
+    managerName: 'the big boss',
     discussedWithManagerDate: new Date(2020, 11, 12),
     reviewDate: new Date(2021, 1, 1),
     notes: 'a lot to talk about',
@@ -21,7 +21,7 @@ export const warningNoteFactory = Factory.define<WarningNote>(
 
 export const mockedWarningNote = [
   warningNoteFactory.build({
-    type: 'Risk to Adults',
+    noteType: 'Risk to Adults',
     reviewedDate: new Date(2020, 11, 13),
     reviewedBy: 'Bar',
     disclosedDate: new Date(2020, 11, 12),

--- a/pages/api/residents/[id]/warningnotes/index.ts
+++ b/pages/api/residents/[id]/warningnotes/index.ts
@@ -20,16 +20,14 @@ const endpoint: NextApiHandler = async (
     case 'GET':
       try {
         const data = await getWarningNotesByResident(
-          parseInt(req.query.id as string, 10)
+          Number(req.query.id as string)
         );
         res.status(StatusCodes.OK).json(data);
       } catch (error) {
         console.error('Warning Notes get error:', error?.response?.data);
-        error?.response?.status === StatusCodes.NOT_FOUND
-          ? res.status(StatusCodes.OK).json([]) // this should be fixed BE side
-          : res
-              .status(StatusCodes.INTERNAL_SERVER_ERROR)
-              .json({ message: 'Unable to get the Warning Notes' });
+        res
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .json({ message: 'Unable to get the Warning Notes' });
       }
       break;
 

--- a/types.ts
+++ b/types.ts
@@ -199,7 +199,7 @@ export interface Worker {
 
 interface BaseNote {
   id: number;
-  type: string;
+  noteType: string;
   createdBy: string;
   startDate: Date;
   reviewDate: Date;
@@ -208,7 +208,7 @@ interface BaseNote {
   reviewedDate?: Date;
   reviewedBy?: string;
   notes: string;
-  discussedWithManager: string;
+  managerName: string;
   discussedWithManagerDate: Date;
   status: 'closed' | 'open';
   reviews: Array<DisclosedReviewedNote | UndisclosedReviewedNote>;
@@ -230,7 +230,7 @@ interface ReviewedNote {
   reviewedDate: Date;
   reviewdBy: Date;
   notes: string;
-  discussedWithManager: string;
+  managerName: string;
   discussedWithManagerDate: Date;
 }
 


### PR DESCRIPTION
**What**  
- aligned warning notes `POST` object to BE
- fixed API `/residents/:id/warningnotes` (now the BE is returning `200` even if there aren't notes)
- added warningnote to the forms (only for admins)


**How to test it**
- go into a person page
- click add record
- search for **warning note**
- add a warning note
- check that it appears correctly in the person page