### PR TITLE
use fieldset only if there options

### DIFF
--- a/components/Form/Checkbox/Checkbox.tsx
+++ b/components/Form/Checkbox/Checkbox.tsx
@@ -34,6 +34,23 @@ const Tickbox = ({
   </div>
 );
 
+const CheckBoxWrapper = ({
+  children,
+  isFieldset,
+  ariaDescribedby,
+}: {
+  children: React.ReactElement;
+  isFieldset: boolean;
+  ariaDescribedby?: string;
+}): React.ReactElement =>
+  isFieldset ? (
+    <fieldset className="govuk-fieldset" aria-describedby={ariaDescribedby}>
+      {children}
+    </fieldset>
+  ) : (
+    children
+  );
+
 const Checkbox = ({
   label,
   options,
@@ -43,59 +60,66 @@ const Checkbox = ({
   required,
   labelSize = 'm',
   ...otherProps
-}: Props): React.ReactElement => (
-  <div
-    className={cx('govuk-form-group', {
-      'govuk-form-group--error': error,
-    })}
-  >
-    <fieldset
-      className="govuk-fieldset"
-      aria-describedby={hint && `${name}-hint`}
+}: Props): React.ReactElement => {
+  return (
+    <div
+      className={cx('govuk-form-group', {
+        'govuk-form-group--error': error,
+      })}
     >
-      {options && (
-        <legend
-          className={`govuk-fieldset__legend govuk-fieldset__legend--${labelSize}`}
-        >
-          {label} {required && <span className="govuk-required">*</span>}
-        </legend>
-      )}
-      {hint && (
-        <div id={`${name}-hint`} className="govuk-hint">
-          {hint}
-        </div>
-      )}
-      <div className="govuk-checkboxes">
-        {options ? (
-          options.map((option: Option) => {
-            const { value, text } =
-              typeof option === 'string'
-                ? { value: option, text: option }
-                : option;
-            return (
+      <CheckBoxWrapper
+        isFieldset={Boolean(options)}
+        ariaDescribedby={hint && `${name}-hint`}
+      >
+        <>
+          {options && (
+            <legend
+              className={`govuk-fieldset__legend govuk-fieldset__legend--${labelSize}`}
+            >
+              {label} {required && <span className="govuk-required">*</span>}
+            </legend>
+          )}
+          {hint && (
+            <div id={`${name}-hint`} className="govuk-hint">
+              {hint}
+            </div>
+          )}
+          <div className="govuk-checkboxes">
+            {options ? (
+              options.map((option: Option) => {
+                const { value, text } =
+                  typeof option === 'string'
+                    ? { value: option, text: option }
+                    : option;
+                return (
+                  <Tickbox
+                    key={value}
+                    {...otherProps}
+                    name={name}
+                    value={value}
+                    label={text}
+                  />
+                );
+              })
+            ) : (
               <Tickbox
-                key={value}
                 {...otherProps}
                 name={name}
-                value={value}
-                label={text}
+                label={label}
+                required={required}
               />
-            );
-          })
-        ) : (
-          <Tickbox
-            {...otherProps}
-            name={name}
-            label={label}
-            required={required}
-          />
-        )}
-      </div>
-      {error && (
-        <ErrorMessage label={error.message} className="govuk-!-margin-top-3" />
-      )}
-    </fieldset>
-  </div>
-);
+            )}
+          </div>
+          {error && (
+            <ErrorMessage
+              label={error.message}
+              className="govuk-!-margin-top-3"
+            />
+          )}
+        </>
+      </CheckBoxWrapper>
+    </div>
+  );
+};
 
 export default Checkbox;

--- a/components/Form/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/components/Form/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -61,31 +61,27 @@ exports[`Checkbox should render properly - as Tickbox 1`] = `
   <div
     class="govuk-form-group"
   >
-    <fieldset
-      class="govuk-fieldset"
+    <div
+      class="govuk-checkboxes"
     >
       <div
-        class="govuk-checkboxes"
+        class="govuk-checkboxes__item"
       >
-        <div
-          class="govuk-checkboxes__item"
+        <input
+          class="govuk-checkboxes__input"
+          id="my-checkbox"
+          name="my-checkbox"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="govuk-label govuk-checkboxes__label"
+          for="my-checkbox"
         >
-          <input
-            class="govuk-checkboxes__input"
-            id="my-checkbox"
-            name="my-checkbox"
-            type="checkbox"
-            value=""
-          />
-          <label
-            class="govuk-label govuk-checkboxes__label"
-            for="my-checkbox"
-          >
-            My Checkbox 
-          </label>
-        </div>
+          My Checkbox 
+        </label>
       </div>
-    </fieldset>
+    </div>
   </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
**What**  
Only if `options` is present it wraps the `checkbox` with a `fieldset`.

**Why**  
It solves an accessibility proble.
