### PR TITLE
Wire up PATCH warning note endpoint to front end

### DIFF
--- a/data/forms/warning-note-review.tsx
+++ b/data/forms/warning-note-review.tsx
@@ -21,7 +21,7 @@ const formSteps: FormStep[] = [
       },
       {
         component: 'TextArea',
-        name: 'reviewDetails',
+        name: 'reviewNotes',
         label: 'Details of review',
         hint:
           'include details of disclosure to individual, any updates and why renewing or ending',
@@ -34,7 +34,7 @@ const formSteps: FormStep[] = [
       </span>,
       {
         component: 'TextInput',
-        name: 'discussedWithManager',
+        name: 'managerName',
         label: 'Manager’s name',
         rules: { required: true },
       },

--- a/lib/warningNotes.spec.ts
+++ b/lib/warningNotes.spec.ts
@@ -79,7 +79,8 @@ describe('warningNotesAPI', () => {
       mockedAxios.patch.mockResolvedValue({ data: {} });
       await warningNotesAPI.updateWarningNote({
         status: 'Closed',
-        closedBy: 'foo@bar.com',
+        endedBy: 'foo@bar.com',
+        endedDate: '2021-04-29',
       });
       expect(mockedAxios.patch).toHaveBeenCalled();
       expect(mockedAxios.patch.mock.calls[0][0]).toEqual(
@@ -87,7 +88,8 @@ describe('warningNotesAPI', () => {
       );
       expect(mockedAxios.patch.mock.calls[0][1]).toEqual({
         status: 'Closed',
-        closedBy: 'foo@bar.com',
+        endedBy: 'foo@bar.com',
+        endedDate: '2021-04-29',
       });
       expect(mockedAxios.patch.mock.calls[0][2]?.headers).toEqual({
         'Content-Type': 'application/json',

--- a/lib/warningNotes.spec.ts
+++ b/lib/warningNotes.spec.ts
@@ -53,4 +53,55 @@ describe('warningNotesAPI', () => {
       expect(data).toEqual(['foo']);
     });
   });
+
+  describe('updateWarningNote', () => {
+    it('should work properly if the status is open', async () => {
+      mockedAxios.patch.mockResolvedValue({ data: {} });
+      await warningNotesAPI.updateWarningNote({
+        status: 'Open',
+        reviwedBy: 'foo@bar.com',
+      });
+      expect(mockedAxios.patch).toHaveBeenCalled();
+      expect(mockedAxios.patch.mock.calls[0][0]).toEqual(
+        `${ENDPOINT_API}/warningnotes`
+      );
+      expect(mockedAxios.patch.mock.calls[0][1]).toEqual({
+        status: 'Open',
+        reviwedBy: 'foo@bar.com',
+      });
+      expect(mockedAxios.patch.mock.calls[0][2]?.headers).toEqual({
+        'Content-Type': 'application/json',
+        'x-api-key': AWS_KEY,
+      });
+    });
+
+    it('should work properly if the status is closed', async () => {
+      mockedAxios.patch.mockResolvedValue({ data: {} });
+      await warningNotesAPI.updateWarningNote({
+        status: 'Closed',
+        closedBy: 'foo@bar.com',
+      });
+      expect(mockedAxios.patch).toHaveBeenCalled();
+      expect(mockedAxios.patch.mock.calls[0][0]).toEqual(
+        `${ENDPOINT_API}/warningnotes`
+      );
+      expect(mockedAxios.patch.mock.calls[0][1]).toEqual({
+        status: 'Closed',
+        closedBy: 'foo@bar.com',
+      });
+      expect(mockedAxios.patch.mock.calls[0][2]?.headers).toEqual({
+        'Content-Type': 'application/json',
+        'x-api-key': AWS_KEY,
+      });
+    });
+
+    it('should throw an error with the wrong body', async () => {
+      try {
+        // @ts-expect-error check validation
+        await warningNotesAPI.updateWarningNote(123);
+      } catch (e) {
+        expect(e.name).toEqual('ValidationError');
+      }
+    });
+  });
 });

--- a/lib/warningNotes.ts
+++ b/lib/warningNotes.ts
@@ -38,11 +38,10 @@ export const addWarningNote = async (
   });
 };
 
-export const patchWarningNote = async (
-  personId: number,
+export const updateWarningNote = async (
   params: Record<string, unknown>
 ): Promise<void> => {
-  await axios.patch(`${ENDPOINT_API}/warningnotes/${personId}`, params, {
+  await axios.patch(`${ENDPOINT_API}/warningnotes`, params, {
     headers: { ...headers, 'Content-Type': 'application/json' },
   });
 };

--- a/pages/api/warningnotes/[warningNoteId].ts
+++ b/pages/api/warningnotes/[warningNoteId].ts
@@ -44,8 +44,8 @@ const endpoint: NextApiHandler = async (
         const data = await updateWarningNote(req.body);
         res.status(StatusCodes.OK).json(data);
       } catch (error) {
-        console.error('Warning note patch error:', error?.response?.data);
-        console.error('Warning note patch request:', req);
+        console.error('Warning Note patch error:', error?.response?.data);
+        console.error('Warning Note patch request:', req);
         res
           .status(StatusCodes.INTERNAL_SERVER_ERROR)
           .json({ message: 'Unable to update warning note' });

--- a/pages/api/warningnotes/[warningNoteId].ts
+++ b/pages/api/warningnotes/[warningNoteId].ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { getWarningNote } from 'lib/warningNotes';
+import { getWarningNote, updateWarningNote } from 'lib/warningNotes';
 import { isAuthorised } from 'utils/auth';
 
 import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
@@ -36,6 +36,19 @@ const endpoint: NextApiHandler = async (
           : res
               .status(StatusCodes.INTERNAL_SERVER_ERROR)
               .json({ message: 'Unable to get the Warning Note' });
+      }
+      break;
+
+    case 'PATCH':
+      try {
+        const data = await updateWarningNote(req.body);
+        res.status(StatusCodes.OK).json(data);
+      } catch (error) {
+        console.error('Warning note patch error:', error?.response?.data);
+        console.error('Warning note patch request:', req);
+        res
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .json({ message: 'Unable to update warning note' });
       }
       break;
 

--- a/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
+++ b/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
@@ -19,14 +19,14 @@ const ReviewWarningNote = (): React.ReactElement => {
   const confirmation = asPath.includes('confirmation');
   const { user } = useAuth() as { user: User };
   const onFormSubmit = useCallback(
-    (person: Resident) => async ({ ...formData }: Record<string, unknown>) => {
-      updateWarningNote(warningNoteId, {
+    async ({ ...formData }: Record<string, unknown>) => {
+      await updateWarningNote(warningNoteId, {
         warningNoteId,
         reviewedBy: user.email,
         endedBy: formData.reviewDecision === 'No' ? user.email : undefined,
         endedDate:
           formData.reviewDecision === 'No'
-            ? new Date().toISOString().substr(0, 10)
+            ? new Date().toISOString()
             : undefined,
         status: formData.reviewDecision === 'No' ? 'closed' : 'open',
         ...formData,
@@ -70,7 +70,7 @@ const ReviewWarningNote = (): React.ReactElement => {
               formPath={`/people/${personId}/warning-notes/${warningNoteId}/`}
               formSteps={formSteps}
               title="Review Warning Note"
-              onFormSubmit={onFormSubmit(person)}
+              onFormSubmit={onFormSubmit}
               personDetails={{ ...person }}
               defaultValues={{ person }}
               customConfirmation={CustomConfirmation}

--- a/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
+++ b/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
@@ -23,8 +23,12 @@ const ReviewWarningNote = (): React.ReactElement => {
       updateWarningNote(warningNoteId, {
         warningNoteId,
         reviewedBy: user.email,
-        endedBy: formData.reviewDecision === 'No' && user.email,
-        status: formData.reviewDecision === 'No' ? 'Closed' : 'Open',
+        endedBy: formData.reviewDecision === 'No' ? user.email : undefined,
+        endedDate:
+          formData.reviewDecision === 'No'
+            ? new Date().toISOString().substr(0, 10)
+            : undefined,
+        status: formData.reviewDecision === 'No' ? 'closed' : 'open',
         ...formData,
       });
     },

--- a/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
+++ b/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
@@ -9,6 +9,7 @@ import FormWizard from 'components/FormWizard/FormWizard';
 import formSteps from 'data/forms/warning-note-review';
 import { useAuth } from 'components/UserContext/UserContext';
 import CustomConfirmation from 'components/Steps/ReviewWarningNoteConfirmation';
+import { updateWarningNote } from 'utils/api/warningNotes';
 
 const ReviewWarningNote = (): React.ReactElement => {
   const { query, asPath } = useRouter();
@@ -18,21 +19,13 @@ const ReviewWarningNote = (): React.ReactElement => {
   const confirmation = asPath.includes('confirmation');
   const { user } = useAuth() as { user: User };
   const onFormSubmit = useCallback(
-    (person: Resident) => async ({
-      form_name,
-      ...formData
-    }: Record<string, unknown>) => {
-      console.log({
-        personId: person.id,
-        firstName: person.firstName,
-        lastName: person.lastName,
-        contextFlag: person.contextFlag,
-        dateOfBirth: person.dateOfBirth,
-        workerEmail: user.email,
-        formNameOverall:
-          person.contextFlag === 'A' ? 'ASC_case_note' : 'CFS_case_note',
-        formName: form_name,
-        caseFormData: JSON.stringify(formData),
+    (person: Resident) => async ({ ...formData }: Record<string, unknown>) => {
+      updateWarningNote(warningNoteId, {
+        warningNoteId,
+        reviewedBy: user.email,
+        endedBy: formData.reviewDecision === 'No' && user.email,
+        status: formData.reviewDecision === 'No' ? 'Closed' : 'Open',
+        ...formData,
       });
     },
     [user.email]

--- a/utils/api/warningNotes.ts
+++ b/utils/api/warningNotes.ts
@@ -21,9 +21,12 @@ export const addWarningNote = async (
 };
 
 export const updateWarningNote = async (
-  noteId: number,
+  warningNoteId: number,
   formData: Record<string, unknown>
 ): Promise<Record<string, unknown>> => {
-  const { data } = await axios.patch(`/api/warningnotes/${noteId}`, formData);
+  const { data } = await axios.patch(
+    `/api/warningnotes/${warningNoteId}`,
+    formData
+  );
   return data;
 };


### PR DESCRIPTION
**What**  
This PR adds the PATCH endpoint call to the front end with all the required data.

**Why**  
To allow users to add a review to a warning note and either end it or renew it.

**Anything else?**
Would like some feedback on some of my decisions here specially on the tests for the API call and how I get the `endedDate` property.

The table with information won't render as of yet as the GET endpoint for an individual note doesn't seem to be ready, furthermore in a future PR the note must not be allowed to be re-reviewed if it is ended.
