### PR TITLE
fixed cases sanitisation regex

### DIFF
--- a/lib/cases.spec.ts
+++ b/lib/cases.spec.ts
@@ -8,6 +8,16 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const { ENDPOINT_API, AWS_KEY } = process.env;
 
+describe('sanitiseCaseFormData', () => {
+  it('should work properly', () => {
+    expect(
+      casesAPI.sanitiseCaseFormData(
+        '{ "_id" : ObjectId("608bbaf33231b56b163e4d99"), "text" : "(foo), bar"}'
+      )
+    ).toEqual({ text: '(foo), bar' });
+  });
+});
+
 describe('cases APIs', () => {
   describe('getCases', () => {
     it('should work properly', async () => {

--- a/lib/cases.ts
+++ b/lib/cases.ts
@@ -8,9 +8,9 @@ const headersWithKey = {
   'x-api-key': AWS_KEY,
 };
 
-const regex = /"_id.*ObjectId\(.*\),./;
+const regex = /"_id.*ObjectId\(\S*\),./;
 
-const sanitiseCaseFormData = (caseFormData: string): string =>
+export const sanitiseCaseFormData = (caseFormData: string): string =>
   caseFormData && JSON.parse(caseFormData.replace(regex, ''));
 
 export const getCases = async (


### PR DESCRIPTION
**What**  
The current regex was breaking in case JSON was containing `(${text}), `.
Now the RegEx has been fixed.

Ideally the BE should filter out this property but it's a quick fix in the meantime.