### PR TITLE
fixed restricted on resident

### DIFF
--- a/components/Cases/Cases.spec.tsx
+++ b/components/Cases/Cases.spec.tsx
@@ -5,14 +5,14 @@ import { UserContext } from 'components/UserContext/UserContext';
 import { userFactory } from 'factories/users';
 
 import { mockedNote, mockedAllocationNote } from 'factories/cases';
-import { mockedResident } from 'factories/residents';
+import { residentFactory } from 'factories/residents';
 
 import Cases from './Cases';
 
 describe('Cases component', () => {
   const props = {
     id: 44000000,
-    person: mockedResident,
+    person: residentFactory.build(),
   };
 
   it('should render records properly', async () => {
@@ -83,10 +83,9 @@ describe('Cases component', () => {
   it('should render a error message when a person is restricted', async () => {
     const props = {
       id: 44000000,
-      person: {
-        ...mockedResident,
-        restricted: true,
-      },
+      person: residentFactory.build({
+        restricted: 'Y',
+      }),
     };
     const { asFragment, queryByText } = render(
       <UserContext.Provider
@@ -105,10 +104,9 @@ describe('Cases component', () => {
   it('should work properly if person is restricted but user.hasUnrestrictedPermissions', async () => {
     const props = {
       id: 44000000,
-      person: {
-        ...mockedResident,
-        restricted: true,
-      },
+      person: residentFactory.build({
+        restricted: 'Y',
+      }),
     };
     const { asFragment, queryByText } = render(
       <UserContext.Provider

--- a/components/Cases/Cases.tsx
+++ b/components/Cases/Cases.tsx
@@ -76,7 +76,9 @@ const CasesWrapper = ({ id, person }: WrapperProps): React.ReactElement => {
         <Button label="Add a new record" route={`${id}/records`} />
       </div>
       <hr className="govuk-divider" />
-      {user.hasUnrestrictedPermissions || !person.restricted ? (
+      {user.hasUnrestrictedPermissions ||
+      !person.restricted ||
+      person.restricted === 'N' ? (
         <Cases id={id} />
       ) : (
         <ErrorSummary

--- a/lib/residents.spec.ts
+++ b/lib/residents.spec.ts
@@ -62,7 +62,6 @@ describe('residents APIs', () => {
         residents: [
           {
             name: 'foo',
-            restricted: false,
             address: { address: 'valid line', postcode: 'SE9 4RZ' },
           },
         ],
@@ -91,7 +90,7 @@ describe('residents APIs', () => {
       });
       expect(data).toEqual({
         name: 'foobar',
-        restricted: true,
+        restricted: 'Y',
         address: undefined,
       });
     });

--- a/lib/residents.ts
+++ b/lib/residents.ts
@@ -6,8 +6,7 @@ const { ENDPOINT_API, AWS_KEY } = process.env;
 
 const headers = { 'x-api-key': AWS_KEY };
 
-interface ResidentBE extends Omit<LegacyResident, 'restricted'> {
-  restricted: 'Y' | 'N';
+interface ResidentBE extends LegacyResident {
   addressList: Array<{
     displayAddressFlag: 'Y' | 'N';
     addressLine1: string;
@@ -24,7 +23,6 @@ const sanitiseResidentData = (residents: ResidentBE[]): LegacyResident[] =>
       );
       return {
         ...resident,
-        restricted: resident.restricted === 'Y',
         address: address && {
           address: address.addressLine1,
           postcode: address.postCode,
@@ -52,10 +50,7 @@ export const getResident = async (
     headers,
     params,
   });
-  return {
-    ...data,
-    restricted: data.restricted === 'Y',
-  };
+  return data;
 };
 
 export const normalisePhoneInput = (

--- a/pages/people/[id]/edit/[[...stepId]].tsx
+++ b/pages/people/[id]/edit/[[...stepId]].tsx
@@ -37,7 +37,6 @@ const UpdatePerson = (): ReactElement => {
     const ref = await updateResident(personId, {
       ...formData,
       contextFlag: formData.contextFlag || user.permissionFlag,
-      restricted: formData.restricted ? 'Y' : 'N',
       nhsNumber: Number(formData.nhsNumber),
       createdBy: user.email,
     });

--- a/types.ts
+++ b/types.ts
@@ -116,7 +116,7 @@ export interface LegacyResident {
   gender: string;
   nationality?: string;
   nhsNumber: string;
-  restricted?: boolean;
+  restricted?: 'Y' | 'N';
   address?: {
     address: string;
     postcode: string;
@@ -161,7 +161,7 @@ export interface Resident {
   nhsNumber?: number;
   emailAddress?: string;
   preferredMethodOfContact?: string;
-  restricted?: boolean;
+  restricted?: 'Y' | 'N';
   dateOfDeath?: string;
   address?: {
     address: string;


### PR DESCRIPTION
**What**  
- Fixed `restricted` on resident object, aligned it to the BE API
- Fixed re-population of the "restricted" input on resident edit

**How to test it**
- Check an edit resident page
- The "restricted" input is re-populated as expected
