### PR TITLE
fixed focus on error in date input

### DIFF
--- a/components/Form/DateInput/DateInput.tsx
+++ b/components/Form/DateInput/DateInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, forwardRef } from 'react';
+import { useCallback, useRef, forwardRef } from 'react';
 import cx from 'classnames';
 import { Controller, Control } from 'react-hook-form';
 
@@ -169,33 +169,38 @@ const ControlledDateInput = ({
   rules,
   format = 'ISO',
   ...otherProps
-}: Props): React.ReactElement => (
-  <Controller
-    render={({ onChange, value }) => (
-      <DateInput
-        name={name}
-        value={value}
-        onChange={onChange}
-        format={format}
-        {...otherProps}
-      />
-    )}
-    name={name}
-    rules={{
-      ...rules,
-      validate: {
-        valid: (value) =>
-          value &&
-          (isDateValid(format === 'ISO' ? value : convertFormat(value)) ||
-            'Must be a valid Date'),
-        ...(typeof rules?.validate === 'function'
-          ? { validation: rules.validate }
-          : rules?.validate),
-      },
-    }}
-    control={control}
-    defaultValue={null}
-  />
-);
+}: Props): React.ReactElement => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <Controller
+      render={({ onChange, value }) => (
+        <DateInput
+          name={name}
+          value={value}
+          onChange={onChange}
+          format={format}
+          ref={inputRef}
+          {...otherProps}
+        />
+      )}
+      name={name}
+      onFocus={() => inputRef.current?.focus()}
+      rules={{
+        ...rules,
+        validate: {
+          valid: (value) =>
+            value &&
+            (isDateValid(format === 'ISO' ? value : convertFormat(value)) ||
+              'Must be a valid Date'),
+          ...(typeof rules?.validate === 'function'
+            ? { validation: rules.validate }
+            : rules?.validate),
+        },
+      }}
+      control={control}
+      defaultValue={null}
+    />
+  );
+};
 
 export default ControlledDateInput;


### PR DESCRIPTION
**What**  
Fixed missing input `ref` in `DateInput`, that was preventing the focus on the input in case of error.

**How to test it**
- try to add a new warning `/people/7/warning-notes/add` omitting a date
- on submit the browser should set the focus on the input itself

