### PR TITLE
Fixed add warning note confirmation

### DIFF
--- a/components/Steps/PersonLinkConfirmation.spec.tsx
+++ b/components/Steps/PersonLinkConfirmation.spec.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react';
 
-import DetailConfirmation from './DetailConfirmation';
-import { FormStep } from 'components/Form/types';
+import DetailConfirmation from './PersonLinkConfirmation';
 
 jest.mock('next/router', () => ({
   useRouter: () => ({
@@ -11,25 +10,7 @@ jest.mock('next/router', () => ({
 
 describe('Detail Confirmation component', () => {
   const props = {
-    formData: {
-      bar_input: 'foo',
-    },
-    formSteps: [
-      {
-        components: [
-          {
-            component: 'TextInput',
-            name: 'bar_input',
-            width: 30,
-            label: 'Foo',
-          },
-        ],
-        id: 'foo-bar',
-        title: 'Foo Bar',
-      },
-    ] as FormStep[],
     successMessage: 'Done!',
-    formPath: 'foo/bar-foo',
   };
 
   it('should render properly', () => {

--- a/components/Steps/PersonLinkConfirmation.tsx
+++ b/components/Steps/PersonLinkConfirmation.tsx
@@ -1,27 +1,19 @@
 import { useRouter } from 'next/router';
 
 import Button from 'components/Button/Button';
-import { FormStep } from 'components/Form/types';
 
 interface Props {
-  formSteps: FormStep[];
-  successMessage?: string;
+  successMessage: string;
 }
 
-const DetailConfirmation = ({
-  formSteps,
-  successMessage,
-}: Props): React.ReactElement => {
+const DetailConfirmation = ({ successMessage }: Props): React.ReactElement => {
   const router = useRouter();
   const { id } = router.query;
   return (
     <>
-      <h1 className="govuk-fieldset__legend--l gov-weight-lighter govuk-!-margin-bottom-7">
-        {successMessage || 'Submission complete'}
-      </h1>
       <div className="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-9">
         <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
-          {formSteps[0].title} details have been added
+          {successMessage}
         </h1>
       </div>
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>

--- a/components/Steps/__snapshots__/PersonLinkConfirmation.spec.tsx.snap
+++ b/components/Steps/__snapshots__/PersonLinkConfirmation.spec.tsx.snap
@@ -2,18 +2,13 @@
 
 exports[`Detail Confirmation component should render properly 1`] = `
 <DocumentFragment>
-  <h1
-    class="govuk-fieldset__legend--l gov-weight-lighter govuk-!-margin-bottom-7"
-  >
-    Done!
-  </h1>
   <div
     class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-9"
   >
     <h1
       class="govuk-fieldset__legend--l gov-weight-lighter"
     >
-      Foo Bar details have been added
+      Done!
     </h1>
   </div>
   <div

--- a/pages/people/[id]/records/case-notes-recording/[[...stepId]].tsx
+++ b/pages/people/[id]/records/case-notes-recording/[[...stepId]].tsx
@@ -7,7 +7,7 @@ import { useAuth } from 'components/UserContext/UserContext';
 import BackButton from 'components/Layout/BackButton/BackButton';
 import FormWizard from 'components/FormWizard/FormWizard';
 import { addCase } from 'utils/api/cases';
-import CustomConfirmation from 'components/Steps/DetailConfirmation';
+import PersonLinkConfirmation from 'components/Steps/PersonLinkConfirmation';
 
 import formStepsAdult from 'data/forms/asc-case-notes-recording';
 import formStepsChild from 'data/forms/cfs-case-notes-recording';
@@ -59,7 +59,8 @@ const CaseNotesRecording = (): React.ReactElement => {
                 personDetails={{ ...person }}
                 includesDetails
                 hideBackButton
-                customConfirmation={CustomConfirmation}
+                successMessage="Case Notes Recording details have been added"
+                customConfirmation={PersonLinkConfirmation}
               />
             </div>
           )}

--- a/pages/people/[id]/warning-notes/add/[[...stepId]].tsx
+++ b/pages/people/[id]/warning-notes/add/[[...stepId]].tsx
@@ -7,6 +7,7 @@ import { useAuth } from 'components/UserContext/UserContext';
 import BackButton from 'components/Layout/BackButton/BackButton';
 import FormWizard from 'components/FormWizard/FormWizard';
 import { addWarningNote } from 'utils/api/warningNotes';
+import PersonLinkConfirmation from 'components/Steps/PersonLinkConfirmation';
 
 import { formStepsAdult, formStepsChild } from 'data/forms/warning-note';
 
@@ -53,6 +54,8 @@ const CaseNotesRecording = (): React.ReactElement => {
               personDetails={{ ...person }}
               includesDetails
               hideBackButton
+              successMessage="Warning note has been added"
+              customConfirmation={PersonLinkConfirmation}
             />
           )}
         </PersonView>


### PR DESCRIPTION
**What**  
- refactored `DetailsConfirmation` into `PersonLinkConfirmation`
- used `PersonLinkConfirmation` to the add warning note
- added `back to search` and `view person` buttons to _add warning notes_ and _case notes recording_

<img width="1002" alt="Screenshot 2021-05-08 at 14 05 31" src="https://user-images.githubusercontent.com/435399/117540387-7478bd80-b00f-11eb-9494-7e06635ebae4.png">


