### PR TITLE
update permissions - childrens can edit person not adults

### DIFF
--- a/pages/people/[id]/index.tsx
+++ b/pages/people/[id]/index.tsx
@@ -22,7 +22,7 @@ const PersonPage = (): React.ReactElement => {
       <PersonView
         personId={personId}
         showPersonDetails={false}
-        canEdit={user.hasAdminPermissions || user.hasAdultPermissions}
+        canEdit={user.hasAdminPermissions || user.hasChildrenPermissions}
       >
         {(person) => (
           <Stack space={7} className="govuk-!-margin-top-7">


### PR DESCRIPTION
**What**  

Editing permission for `edit person`, functionality is currently only being deployed for children's workers.

**Why**  

Based on what different organisations are requesting permission for.
