### PR TITLE
activate the first version of conversation 3

### DIFF
--- a/components/AddForm/AddForm.tsx
+++ b/components/AddForm/AddForm.tsx
@@ -20,6 +20,10 @@ const AddForm = ({ person }: { person: Resident }): React.ReactElement => {
             text: 'Case Note Recording',
             value: `/people/${person.id}/records/case-notes-recording`,
           },
+          {
+            text: 'Conversation 3',
+            value: `/people/${person.id}/records/conversation-3`,
+          },
         ]
       : [];
   const betaForms = user.hasDevPermissions

--- a/components/Cases/CaseLink.tsx
+++ b/components/Cases/CaseLink.tsx
@@ -28,6 +28,8 @@ const getLink = (
       return `/people/${caseFormData.mosaic_id}/records/${recordId}?is_historical=${caseFormData.is_historical}`;
     case 'Historical_Visit':
       return `/people/${caseFormData.mosaic_id}/visits/${recordId}?is_historical=${caseFormData.is_historical}`;
+    case 'ASC_conv3':
+      return `/people/${caseFormData.mosaic_id}/visits/${recordId}`;
     default:
       return null;
   }

--- a/components/Cases/CaseLink.tsx
+++ b/components/Cases/CaseLink.tsx
@@ -22,14 +22,13 @@ const getLink = (
         (caseFormData as AllocationCaseFormData | DeallocationCaseFormData)
           .allocation_id
       }?recordId=${recordId}`;
+    case 'ASC_conv3':
     case fileName:
       return `/people/${caseFormData.mosaic_id}/records/${recordId}`;
     case 'Historical_Case_Note':
       return `/people/${caseFormData.mosaic_id}/records/${recordId}?is_historical=${caseFormData.is_historical}`;
     case 'Historical_Visit':
       return `/people/${caseFormData.mosaic_id}/visits/${recordId}?is_historical=${caseFormData.is_historical}`;
-    case 'ASC_conv3':
-      return `/people/${caseFormData.mosaic_id}/visits/${recordId}`;
     default:
       return null;
   }

--- a/components/Cases/CaseRecap/CaseNote.tsx
+++ b/components/Cases/CaseRecap/CaseNote.tsx
@@ -17,12 +17,15 @@ const CaseNote = ({ personId, recordId }: Props): React.ReactElement => {
   const fileData =
     recordData && (form as Record<string, FormStep[]>)[recordData];
 
+  console.log(recordError, recordData, fileData);
+
   if (recordError || (recordData && !fileData)) {
     return <ErrorMessage />;
   }
   if (!record || !fileData) {
     return <Spinner />;
   }
+
   return (
     <>
       <Summary

--- a/components/Cases/CaseRecap/CaseNote.tsx
+++ b/components/Cases/CaseRecap/CaseNote.tsx
@@ -17,8 +17,6 @@ const CaseNote = ({ personId, recordId }: Props): React.ReactElement => {
   const fileData =
     recordData && (form as Record<string, FormStep[]>)[recordData];
 
-  console.log(recordError, recordData, fileData);
-
   if (recordError || (recordData && !fileData)) {
     return <ErrorMessage />;
   }

--- a/data/forms/asc-conversation-3.tsx
+++ b/data/forms/asc-conversation-3.tsx
@@ -23,7 +23,7 @@ const steps: FormStep[] = [
         name: 'start_date_of_conversation_3',
         label: 'Start Date of Conversation 3',
         width: 10,
-        rules: { required: true },
+        rules: { required: 'Add a valid date.' },
       },
       <h3
         key="person details"
@@ -93,7 +93,7 @@ const steps: FormStep[] = [
         label:
           'Has this person been assessed by Hackney adult social care before?',
         options: ['Yes', 'No', 'Not known'],
-        rules: { required: true },
+        rules: { required: 'Please select one option.' },
       },
       <h3
         key="support reasons"
@@ -203,7 +203,7 @@ const steps: FormStep[] = [
           'Did the client choose to decline any further Social Services support?',
         hint:
           '(Has the client stated that they do not wish further assessment or services from Hackney Adults Social Care at this point)',
-        rules: { required: true },
+        rules: { required: 'Please select one option.' },
       },
       <p key="lifewellbeing">
         Areas of my life I enjoy most or value (including my main interests and
@@ -257,7 +257,7 @@ const steps: FormStep[] = [
         width: 30,
         label: 'Number of Visits',
         hint: '(including telephone calls to the person, etc)',
-        rules: { required: true },
+        rules: { required: 'Please enter the number of visits' },
       },
       {
         component: 'Checkbox',
@@ -284,21 +284,23 @@ const steps: FormStep[] = [
         name: 'medical_condition',
         label:
           'Do you have a condition as a result of either your physical, mental, sensory, learning or cognitive disabilities or illnesses, substance misuse or brain injury?',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
       {
         component: 'Radios',
         name: 'medical_eligible_outcome',
         label:
           'As a result of your needs are you unable to achieve two or more of the eligible outcomes below',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option..' },
       },
       {
         component: 'Radios',
         name: 'maintain_home_environment',
         label:
           'Can you "Maintain a habitable home environment" alone within a reasonable time and without significant pain, distress, anxiety, or risk to yourself or others?',
-        rules: { required: true },
+        rules: {
+          required: 'Please select relevant options.',
+        },
       },
       {
         component: 'TextArea',
@@ -310,7 +312,7 @@ const steps: FormStep[] = [
         name: 'maintain_nutrition_alone',
         label:
           'Can you "Manage and maintain nutrition" alone within within a reasonable time and without significant pain, distress, anxiety or risk to yourself or others?',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
       {
         component: 'TextArea',
@@ -322,7 +324,7 @@ const steps: FormStep[] = [
         name: 'manage_toilet_needs',
         label:
           'Can you "Manage toilet needs" alone within within a reasonable time and without significant pain, distress, anxiety or risk to yourself or others?',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
       {
         component: 'TextArea',
@@ -334,7 +336,7 @@ const steps: FormStep[] = [
         name: 'maintain_personal_hygiene',
         label:
           'Can you "Maintain personal hygiene" alone within within a reasonable time and without significant pain, distress, anxiety or risk to yourself or others?',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
       {
         component: 'TextArea',
@@ -346,7 +348,7 @@ const steps: FormStep[] = [
         name: 'can_be_apprpriately_clothed',
         label:
           'Can you "Be appropriately clothed" alone within within a reasonable time and without significant pain, distress, anxiety or risk to yourself or others?',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
       {
         component: 'TextArea',
@@ -358,7 +360,7 @@ const steps: FormStep[] = [
         name: 'maintain_relationships',
         label:
           'Can you "Develop and maintain family or other personal relationships" alone within within a reasonable time and without significant pain, distress, anxiety or risk to yourself or others?',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
       {
         component: 'TextArea',
@@ -371,7 +373,7 @@ const steps: FormStep[] = [
         name: 'use_necessary_facilities',
         label:
           'Can you "Make use of necessary facilities or services in the local community (including public transport and recreational facilities/services)" alone within within a reasonable time and without significant pain, distress, anxiety or risk to yourself or others?',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
       {
         component: 'TextArea',
@@ -384,7 +386,7 @@ const steps: FormStep[] = [
         name: 'access_work_alone',
         label:
           'Can you "Access and engage in work, training, education or volunteering" alone within within a reasonable time and without significant pain, distress, anxiety or risk to yourself or others?',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
       {
         component: 'TextArea',
@@ -397,7 +399,7 @@ const steps: FormStep[] = [
         name: 'caring_responsibilities',
         label:
           'Can you "Carry out any caring responsibilities for a child" alone within within a reasonable time and without significant pain, distress, anxiety or risk to yourself or others?',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
       {
         component: 'TextArea',
@@ -409,7 +411,7 @@ const steps: FormStep[] = [
         name: 'home_safety_alone',
         label:
           'Can you "Be able to make use of your home safely" alone within within a reasonable time and without significant pain, distress, anxiety or risk to yourself or others?',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
       {
         component: 'TextArea',
@@ -421,7 +423,7 @@ const steps: FormStep[] = [
         name: 'home_safety_wellbeing',
         label:
           'As a result of being unable to achieve these outcomes is there, or is there likely to be, a significant impact on your wellbeing?',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
     ],
   },
@@ -458,7 +460,7 @@ const steps: FormStep[] = [
         name: 'details_wellbeing_impact',
         label:
           'Details of the impact on your wellbeing (in the absence of any support you may already have in place)',
-        rules: { required: true },
+        rules: { required: 'Please provide details.' },
       },
     ],
   },
@@ -498,27 +500,27 @@ const steps: FormStep[] = [
         name: 'carer_first_name',
         width: 30,
         label: 'Carer First Name',
-        rules: { required: true },
+        rules: { required: 'Please add carer&apos:s name.' },
       },
       {
         component: 'TextInput',
         name: 'carer_last_name',
         width: 30,
         label: 'Carer Last Name',
-        rules: { required: true },
+        rules: { required: 'Please add last name' },
       },
       {
         component: 'TextInput',
         name: 'relation_to_subject',
         width: 30,
         label: 'Relationship to main subject of assessment',
-        rules: { required: true },
+        rules: { required: 'Please describe the relationship' },
       },
       {
         component: 'Radios',
         name: 'main_carer',
         label: 'Is this the main carer for the cared-for person?)',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
       {
         component: 'Radios',
@@ -536,7 +538,7 @@ const steps: FormStep[] = [
         name: 'carer_seperate_conversation_agree',
         label:
           'If conversation is completed with the Carer present, does the Carer agree this is a joint conversation?',
-        rules: { required: true },
+        rules: { required: 'Does the carer agree?' },
       },
     ],
   },
@@ -551,13 +553,13 @@ const steps: FormStep[] = [
         name: 'carer_assessed',
         label:
           'Has the carer been assessed as having one or more eligible need?',
-        rules: { required: true },
+        rules: { required: 'Please select a relevant option.' },
       },
       {
         component: 'TextArea',
         name: 'impact_carer_independence',
         label: "Impact of caring on your own Carer's independence",
-        rules: { required: true },
+        rules: { required: "Describe impact on carer's independence" },
       },
       <h3
         key="contingency_sub_heading"
@@ -831,7 +833,7 @@ const steps: FormStep[] = [
         width: 10,
         hint:
           "Today's date, being the submission date of this Google form  instead of authorised date",
-        rules: { required: true },
+        rules: { required: 'Please add a date' },
       },
       {
         component: 'NumberInput',
@@ -980,7 +982,7 @@ const steps: FormStep[] = [
         label: 'Date of Next Review',
         hint:
           'Please schedule a date in 3, 6 or 12 months time, as required, for the Long Term team to carry out a Review',
-        rules: { required: true },
+        rules: { required: 'Please add a date' },
       },
       <h3
         key="please_ensure"

--- a/data/forms/index.tsx
+++ b/data/forms/index.tsx
@@ -1,4 +1,5 @@
 import ASC_case_note from './asc-case-notes-recording';
 import CFS_case_note from './cfs-case-notes-recording';
+import ASC_conv3 from './asc-conversation-3';
 
-export { ASC_case_note, CFS_case_note };
+export { ASC_case_note, CFS_case_note, ASC_conv3 };

--- a/data/googleForms/adultForms.ts
+++ b/data/googleForms/adultForms.ts
@@ -53,12 +53,7 @@ export default [
       'https://docs.google.com/forms/d/e/1FAIpQLSdcITf67BouyUDCulb0oaSOyU1vSiqGC2qxmg_4GHBdV7we7A/viewform',
     category: 'Information Assessment',
   },
-  {
-    text: 'Conversation 3',
-    value:
-      'https://docs.google.com/forms/d/e/1FAIpQLSf5a71YAXg67cK3PmAo5u6vctHr62dAM7vIOcUsQ5qCT-7o1A/viewform',
-    category: 'Information Assessment',
-  },
+
   {
     text: 'Rapid D2A Assessment',
     value:

--- a/pages/people/[id]/records/conversation-3/[[...stepId]].tsx
+++ b/pages/people/[id]/records/conversation-3/[[...stepId]].tsx
@@ -20,7 +20,6 @@ const CaseNotesRecording = (): ReactElement => {
   const { user } = useAuth() as { user: User };
   const onFormSubmit = useCallback(
     (person) => async (formData: FormData) => {
-      console.log(formData);
       await addCase({
         personId: person.id,
         firstName: person.firstName,
@@ -30,19 +29,10 @@ const CaseNotesRecording = (): ReactElement => {
         dateOfEvent: new Date().toISOString(),
         workerEmail: user.email,
         formNameOverall: 'ASC_conv3',
-        formName: 'ASC_conv3',
+        formName: 'ASC Conversation 3',
         caseFormData: JSON.stringify(formData),
       });
     },
-    // (person) => (formData: FormData) =>
-    //   console.log({
-    //     mosaic_id: person.mosaicId,
-    //     first_name: person.firstName,
-    //     last_name: person.lastName,
-    //     worker_email: user.email,
-    //     form_name: 'ASC_conv3',
-    //     ...formData,
-    //   }),
     [user.email]
   );
   return (

--- a/pages/people/[id]/records/conversation-3/[[...stepId]].tsx
+++ b/pages/people/[id]/records/conversation-3/[[...stepId]].tsx
@@ -27,6 +27,7 @@ const CaseNotesRecording = (): ReactElement => {
         lastName: person.lastName,
         contextFlag: person.contextFlag,
         dateOfBirth: person.dateOfBirth,
+        dateOfEvent: new Date().toISOString(),
         workerEmail: user.email,
         formNameOverall: 'ASC_conv3',
         formName: 'ASC_conv3',

--- a/pages/people/[id]/records/conversation-3/[[...stepId]].tsx
+++ b/pages/people/[id]/records/conversation-3/[[...stepId]].tsx
@@ -7,7 +7,7 @@ import BackButton from 'components/Layout/BackButton/BackButton';
 import FormWizard from 'components/FormWizard/FormWizard';
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import Seo from 'components/Layout/Seo/Seo';
-// import { addCase } from 'utils/api/cases';
+import { addCase } from 'utils/api/cases';
 
 import formSteps from 'data/forms/asc-conversation-3';
 
@@ -19,24 +19,29 @@ const CaseNotesRecording = (): ReactElement => {
   const { query } = useRouter();
   const { user } = useAuth() as { user: User };
   const onFormSubmit = useCallback(
-    // (person) => async (formData: FormData) =>
-    //   await addCase({
+    (person) => async (formData: FormData) => {
+      console.log(formData);
+      await addCase({
+        personId: person.id,
+        firstName: person.firstName,
+        lastName: person.lastName,
+        contextFlag: person.contextFlag,
+        dateOfBirth: person.dateOfBirth,
+        workerEmail: user.email,
+        formNameOverall: 'ASC_conv3',
+        formName: 'ASC_conv3',
+        caseFormData: JSON.stringify(formData),
+      });
+    },
+    // (person) => (formData: FormData) =>
+    //   console.log({
     //     mosaic_id: person.mosaicId,
     //     first_name: person.firstName,
     //     last_name: person.lastName,
     //     worker_email: user.email,
-    //     form_name: 'ASC_conv1',
+    //     form_name: 'ASC_conv3',
     //     ...formData,
     //   }),
-    (person) => (formData: FormData) =>
-      console.log({
-        mosaic_id: person.mosaicId,
-        first_name: person.firstName,
-        last_name: person.lastName,
-        worker_email: user.email,
-        form_name: 'ASC_conv3',
-        ...formData,
-      }),
     [user.email]
   );
   return (


### PR DESCRIPTION
this pr activates our first iteration of the conversation 3 form, making it available and ready for use by practitioners.

it:

- launches our conversation 3 form rather than the google form when adding a new record
- updates `/pages/person/[id]/records/conversation-3` form to submit answers as a new record
- modifies the `CaseNote` component to support displaying answers from the conversation 3 form
- makes some lightweight usability improvements to the conversation 3 form, like adding missing error messages

we know that there are issues with the ux of this form and the wording of questions. we're intending to iterate on this quickly, but it's important to launch this as-is to solve a pressing need for practitioners.