### PR TITLE
Quick Fix: Add view link for a warning note

### DIFF
--- a/components/Cases/CaseLink.tsx
+++ b/components/Cases/CaseLink.tsx
@@ -28,6 +28,8 @@ const getLink = (
       return `/people/${caseFormData.mosaic_id}/records/${recordId}?is_historical=${caseFormData.is_historical}`;
     case 'Historical_Visit':
       return `/people/${caseFormData.mosaic_id}/visits/${recordId}?is_historical=${caseFormData.is_historical}`;
+    case 'Warning_Note':
+      return `/people/${caseFormData.mosaic_id}/warning-notes/${recordId}`;
     default:
       return null;
   }


### PR DESCRIPTION
The creation of a warning note is visible in record history, but the ‘view’ link is missing. 
This is live in production, so this is a quick PR to try and fix this. 🤞🏾 