### PR TITLE
chore: add storybook-static dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ cypress/fixtures
 cypress/screenshots
 cypress/support
 cypress/videos
+
+# Storybook
+storybook-static


### PR DESCRIPTION
**What**  
If you run `yarn storybook-build` it generates a `./storybook-static` dir that we wouldn't want to commit to git. This adds that dir to our `.gitignore`