### PR TITLE
Add view link to a created warning note in the records history

### DIFF
--- a/components/Cases/CaseLink.tsx
+++ b/components/Cases/CaseLink.tsx
@@ -5,6 +5,7 @@ import {
   AllocationCaseFormData,
   CaseFormData,
   DeallocationCaseFormData,
+  WarningNoteCaseFormData,
 } from 'types';
 
 const getLink = (
@@ -30,7 +31,9 @@ const getLink = (
     case 'Historical_Visit':
       return `/people/${caseFormData.mosaic_id}/visits/${recordId}?is_historical=${caseFormData.is_historical}`;
     case 'API_WarningNote':
-      return `/people/${caseFormData.mosaic_id}/warning-notes/${caseFormData.warning_note_id}`;
+      return `/people/${caseFormData.mosaic_id}/warning-notes/${
+        (caseFormData as WarningNoteCaseFormData).warning_note_id
+      }`;
     default:
       return null;
   }

--- a/components/Cases/CaseLink.tsx
+++ b/components/Cases/CaseLink.tsx
@@ -29,8 +29,8 @@ const getLink = (
       return `/people/${caseFormData.mosaic_id}/records/${recordId}?is_historical=${caseFormData.is_historical}`;
     case 'Historical_Visit':
       return `/people/${caseFormData.mosaic_id}/visits/${recordId}?is_historical=${caseFormData.is_historical}`;
-    case 'Warning_Note':
-      return `/people/${caseFormData.mosaic_id}/warning-notes/${recordId}`;
+    case 'API_WarningNote':
+      return `/people/${caseFormData.mosaic_id}/warning-notes/${caseFormData.warning_note_id}`;
     default:
       return null;
   }

--- a/types.ts
+++ b/types.ts
@@ -44,7 +44,6 @@ interface CaseFormDataBase {
   form_url?: string;
   case_note_title?: string;
   case_note_description?: string;
-  warning_note_id?: number;
 }
 
 export interface AllocationCaseFormData extends CaseFormDataBase {
@@ -58,6 +57,11 @@ export interface DeallocationCaseFormData extends CaseFormDataBase {
   allocation_id: number;
   deallocation_reason: string;
   created_by: string;
+}
+
+export interface WarningNoteCaseFormData extends CaseFormDataBase {
+  form_name_overall: 'API_WarningNote';
+  warning_note_id: number;
 }
 
 export interface HistoricCaseData {
@@ -86,7 +90,8 @@ export interface HistoricVisitData {
 export type CaseFormData =
   | CaseFormDataBase
   | AllocationCaseFormData
-  | DeallocationCaseFormData;
+  | DeallocationCaseFormData
+  | WarningNoteCaseFormData;
 
 export interface Case {
   recordId: string;

--- a/types.ts
+++ b/types.ts
@@ -44,6 +44,7 @@ interface CaseFormDataBase {
   form_url?: string;
   case_note_title?: string;
   case_note_description?: string;
+  warning_note_id?: number;
 }
 
 export interface AllocationCaseFormData extends CaseFormDataBase {


### PR DESCRIPTION

**What**  
The creation of a warning note is visible in record history, but the ‘view’ link is missing.
This adds a condition to the case link component to render a `view` link to the warning note
within the records history.

It also adds a warning note id attribute to the case form data type so that it can be used to create the relevant path.

### Before:
<img width="980" alt="Screenshot 2021-05-13 at 12 30 48 pm" src="https://user-images.githubusercontent.com/32823756/118120141-52a08180-b3e7-11eb-815f-a58330996e09.png">

### After:
<img width="997" alt="Screenshot 2021-05-13 at 12 31 01 pm" src="https://user-images.githubusercontent.com/32823756/118120253-7c59a880-b3e7-11eb-8448-6c773f50057c.png">