### PR TITLE
SCT-193 - Phone number validation blocking users from creating people

### DIFF
--- a/components/Form/PhoneInput/PhoneInput.tsx
+++ b/components/Form/PhoneInput/PhoneInput.tsx
@@ -13,8 +13,8 @@ const PhoneInput = ({ rules, ...props }: Props): React.ReactElement => (
       // this should be removed when the BE
       // fix the inconsistencies in phone numbers
       pattern: {
-        value: /^[\d\s+]+$/,
-        message: 'Move text to phone type box',
+        value: /^[\d]+$/,
+        message: 'Only numbers are supported here',
       },
       ...rules,
     }}


### PR DESCRIPTION
Phone number input field validation error is now triggered when it contains white spaces. The backend should now accept all phone numbers coming from the frontend.