### PR TITLE
compy with hackney sign in patterns

### DIFF
--- a/components/Layout/Header/Header.spec.tsx
+++ b/components/Layout/Header/Header.spec.tsx
@@ -40,7 +40,7 @@ describe('Header component', () => {
     );
 
     expect(getByText('Search')).toBeInTheDocument();
-    expect(getByText('Logout')).toBeInTheDocument();
+    expect(getByText('Sign out')).toBeInTheDocument();
   });
 
   it('should render service name but no header links', () => {
@@ -55,7 +55,7 @@ describe('Header component', () => {
     );
     expect(getByText('Foo')).toBeInTheDocument();
     expect(queryByText('Search')).not.toBeInTheDocument();
-    expect(queryByText('Logout')).not.toBeInTheDocument();
+    expect(queryByText('Sign out')).not.toBeInTheDocument();
   });
 
   it('should set active the correct link', () => {

--- a/components/Layout/Header/Header.tsx
+++ b/components/Layout/Header/Header.tsx
@@ -28,7 +28,7 @@ const loggedNavLinks = [
     path: '/workers',
   },
   {
-    name: 'Logout',
+    name: 'Sign out',
     path: '/logout',
   },
 ];
@@ -62,7 +62,7 @@ const HeaderComponent = ({
               <Logo />
               <span className="lbh-header__logo-text"> Hackney </span>
               <span className="lbh-header__service-name">{serviceName}</span>
-              <span className="govuk-tag">{user && getUserType(user)}</span>
+              {user && <span className="govuk-tag">{getUserType(user)}</span>}
             </a>
           </div>
           <nav className="lbh-header__links" aria-label="Navigation menu">

--- a/components/Layout/Header/__snapshots__/Header.spec.tsx.snap
+++ b/components/Layout/Header/__snapshots__/Header.spec.tsx.snap
@@ -56,7 +56,7 @@ exports[`Header component should set active the correct link 1`] = `
             class="govuk-header__link"
             href="/logout"
           >
-            Logout
+            Sign out
           </a>
         </nav>
       </div>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -9,15 +9,29 @@ interface Props {
 const AdminLoginPage = ({ gssoUrl, returnUrl }: Props): React.ReactElement => (
   <>
     <Seo title="Log In" />
-    <h1>Login</h1>
-    <p className="govuk-body">Please log in with your Hackney email account.</p>
-    <div>
-      <a className="govuk-button" href={`${gssoUrl}${returnUrl}`}>
-        Login
-      </a>
-    </div>
-    <p className="govuk-body">
-      Please contact your administrator if you have issues logging in.
+    <h1>Sign in</h1>
+    <a
+      href={`${gssoUrl}${returnUrl}`}
+      className="govuk-button lbh-button  lbh-button--start govuk-button--start"
+    >
+      Sign in with Google
+      <svg
+        className="govuk-button__start-icon"
+        xmlns="http://www.w3.org/2000/svg"
+        width="17.5"
+        height="19"
+        viewBox="0 0 33 40"
+        role="presentation"
+        focusable="false"
+      >
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+      </svg>
+    </a>
+
+    <p className="lbh-body">Please sign in with your Hackney email account.</p>
+
+    <p className="lbh-body">
+      Please contact your manager if you have issues signing in.
     </p>
   </>
 );


### PR DESCRIPTION
our language and design patterns for signing in and out are now [consistent with the hackney design system](https://design-system.hackney.gov.uk/patterns/sign-in).

specifically, we use "sign in/out" language rather than "log in/out", and have improved the microcopy on the sign in page.

we've left the paths of these pages unmodified to avoid accidentally creating bugs.