### PR TITLE
add a 404 page

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,24 @@
+import Head from 'next/head';
+
+const NotFound = (): React.ReactElement => (
+  <>
+    <Head>
+      <title>Page not found | Social care | Hackney Council</title>
+    </Head>
+
+    <h1 className="lbh-heading-h1">Page not found</h1>
+
+    <p className="lbh-body">
+      If you typed the web address, check it is correct.
+    </p>
+    <p className="lbh-body">
+      If you pasted the web address, check you copied the entire address.
+    </p>
+    <p className="lbh-body">
+      If the web address is correct or you selected a link or button, please
+      report an issue.
+    </p>
+  </>
+);
+
+export default NotFound;


### PR DESCRIPTION
it adds a [proper branded 404 page](https://www.netlify.com/blog/2020/12/08/making-a-custom-404-page-in-next.js/) that is consistent with [design system guidance](https://design-system.service.gov.uk/patterns/page-not-found-pages/)