### PR TITLE
feat: Activate edit person functionality for ASC residents

### DIFF
--- a/components/PersonView/PersonView.spec.tsx
+++ b/components/PersonView/PersonView.spec.tsx
@@ -80,7 +80,7 @@ describe('PersonView component', () => {
     expect(children).toBeDefined();
   });
 
-  it('should render the "Edit" button if the current user is of the same type as the resident – childrens group only', async () => {
+  it('should render the "Edit" button if the resident is a Child and the user is in CFS', async () => {
     jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
       data: residentFactory.build({
         contextFlag: 'C',
@@ -107,7 +107,7 @@ describe('PersonView component', () => {
     getByText('Update person');
   });
 
-  it('should not render the "Edit" button if the resident is an Adult – awaiting sign off from ASC', async () => {
+  it('should render the "Edit" button if the resident is an Adult and the user is in ASC', async () => {
     jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
       data: residentFactory.build({
         contextFlag: 'A',
@@ -117,7 +117,7 @@ describe('PersonView component', () => {
       revalidate: jest.fn(),
     }));
 
-    const { queryByText } = render(
+    const { getByText } = render(
       <UserContext.Provider
         value={{
           user: userFactory.build({
@@ -131,7 +131,7 @@ describe('PersonView component', () => {
       </UserContext.Provider>
     );
 
-    expect(queryByText('Update person')).toBeNull();
+    getByText('Update person');
   });
 
   it('should not render the "Edit" button if the current user is of a different type to the resident', async () => {
@@ -179,6 +179,62 @@ describe('PersonView component', () => {
             hasAdminPermissions: false,
             hasAdultPermissions: false,
             hasChildrenPermissions: true,
+            hasUnrestrictedPermissions: false,
+          }),
+        }}
+      >
+        <PersonView {...props} />
+      </UserContext.Provider>
+    );
+
+    expect(queryByText('Update person')).toBeNull();
+  });
+
+  it('should not render the "Edit" button if the current user is of a different type to the resident (adult resident)', async () => {
+    jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+      data: residentFactory.build({
+        contextFlag: 'A',
+      }),
+      isValidating: false,
+      mutate: jest.fn(),
+      revalidate: jest.fn(),
+    }));
+
+    const { queryByText } = render(
+      <UserContext.Provider
+        value={{
+          user: userFactory.build({
+            hasAdminPermissions: false,
+            hasAdultPermissions: false,
+            hasChildrenPermissions: true,
+          }),
+        }}
+      >
+        <PersonView {...props} />
+      </UserContext.Provider>
+    );
+
+    expect(queryByText('Update person')).toBeNull();
+  });
+
+  it('should not render the "Edit" button if the current user is of the same context type as the resident, but the resident is restricted and the user does not have unrestricted access (adult resident)', async () => {
+    jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+      data: residentFactory.build({
+        contextFlag: 'A',
+        restricted: 'Y',
+      }),
+      isValidating: false,
+      mutate: jest.fn(),
+      revalidate: jest.fn(),
+    }));
+
+    const { queryByText } = render(
+      <UserContext.Provider
+        value={{
+          user: userFactory.build({
+            hasAdminPermissions: false,
+            hasAdultPermissions: true,
+            hasChildrenPermissions: false,
             hasUnrestrictedPermissions: false,
           }),
         }}

--- a/lib/permissions.spec.ts
+++ b/lib/permissions.spec.ts
@@ -24,25 +24,6 @@ describe('permissions', () => {
       ).toEqual(false);
     });
 
-    it('should return false when the resident is an adult', () => {
-      expect(
-        canUserEditPerson(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: true,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
-          residentFactory.build({
-            restricted: 'N',
-            contextFlag: 'A',
-          })
-        )
-      ).toEqual(false);
-    });
-
     it('should return true when the user is in CFS and the resident is a child', () => {
       expect(
         canUserEditPerson(
@@ -95,6 +76,63 @@ describe('permissions', () => {
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'C',
+          })
+        )
+      ).toEqual(false);
+    });
+
+    it('should return true when the user is in ASC and the resident is an adult', () => {
+      expect(
+        canUserEditPerson(
+          userFactory.build({
+            hasAdminPermissions: false,
+            hasAdultPermissions: true,
+            hasChildrenPermissions: false,
+            hasUnrestrictedPermissions: false,
+            hasDevPermissions: false,
+            hasAllocationsPermissions: false,
+          }),
+          residentFactory.build({
+            restricted: 'N',
+            contextFlag: 'A',
+          })
+        )
+      ).toEqual(true);
+    });
+
+    it('should return true when the user is in ASC, has unrestricted permissions, and the resident is a restricted adult', () => {
+      expect(
+        canUserEditPerson(
+          userFactory.build({
+            hasAdminPermissions: false,
+            hasAdultPermissions: true,
+            hasChildrenPermissions: false,
+            hasUnrestrictedPermissions: true,
+            hasDevPermissions: false,
+            hasAllocationsPermissions: false,
+          }),
+          residentFactory.build({
+            restricted: 'Y',
+            contextFlag: 'A',
+          })
+        )
+      ).toEqual(true);
+    });
+
+    it('should return false when the user is in ASC, does not have unrestricted permissions, and the resident is a restricted adult', () => {
+      expect(
+        canUserEditPerson(
+          userFactory.build({
+            hasAdminPermissions: false,
+            hasAdultPermissions: true,
+            hasChildrenPermissions: false,
+            hasUnrestrictedPermissions: false,
+            hasDevPermissions: false,
+            hasAllocationsPermissions: false,
+          }),
+          residentFactory.build({
+            restricted: 'Y',
+            contextFlag: 'A',
           })
         )
       ).toEqual(false);

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -21,8 +21,12 @@ export const canUserEditPerson = (
     return true;
   }
 
-  if (person.contextFlag === 'A') {
-    return false;
+  if (user.hasAdultPermissions && person.contextFlag === 'A') {
+    if (isPersonRestricted) {
+      return user.hasUnrestrictedPermissions || false;
+    }
+
+    return true;
   }
 
   return false;


### PR DESCRIPTION
**What**  
ASC have signed off the "Edit person" functionality, so this activates it for those residents.

~Note: currently in draft while we assess when this will go live – it'll also need some tweaks once https://github.com/LBHackney-IT/lbh-social-care-frontend/pull/362 goes in~ Done in https://github.com/LBHackney-IT/lbh-social-care-frontend/pull/365/commits/1c3c162d3bfd705179a8c00e00e2cbf83b9cd85d

**Anything else?**

- ~Have you added any new third-party libraries?~
- ~Are any new environment variables or configuration values needed?~
- ~Anything else in this PR that isn't covered by the what/why?~
