### PR TITLE
(SCT-213) increase Lambde timeout to 30s

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -16,7 +16,7 @@ functions:
   lbh-social-care:
     name: ${self:service}-${self:provider.stage}
     handler: lambda.handler
-    timeout: 10
+    timeout: 30
     package:
       include:
         - lambda.js


### PR DESCRIPTION
**What**  
Increase Lambda timeout to 30s

**Why**  
This will improve the situation where the Lambda times out due to backend performance issues

**Anything else?**

This is a temporary change to help us further diagnose the performance issues. Once we have improved the situation at the backend this need to be reverted back to 10s.
