### PR TITLE
feature(SCT-248): Todays date by default for case notes

### DIFF
--- a/components/Form/DatePicker/DatePicker.spec.tsx
+++ b/components/Form/DatePicker/DatePicker.spec.tsx
@@ -1,0 +1,22 @@
+import { screen, render } from '@testing-library/react';
+import DatePicker from './DatePicker';
+
+jest.useFakeTimers('modern').setSystemTime(new Date('2020-01-01').getTime());
+
+describe('DatePicker', () => {
+  it("can render today's date", () => {
+    render(<DatePicker label="Date" name="whatever" defaultToday />);
+
+    expect((screen.getByLabelText('Date') as HTMLInputElement).value).toBe(
+      '2020-01-01'
+    );
+  });
+
+  it('renders a blank value by default', () => {
+    render(<DatePicker label="Date" name="whatever" />);
+
+    expect(
+      (screen.getByLabelText('Date') as HTMLInputElement).value
+    ).toBeFalsy();
+  });
+});

--- a/components/Form/DatePicker/DatePicker.tsx
+++ b/components/Form/DatePicker/DatePicker.tsx
@@ -1,9 +1,27 @@
 import { TextInput } from '..';
+import { TextInputNoType } from 'components/Form/types';
 
-import type { TextInputNoType as Props } from 'components/Form/types';
+import { format } from 'date-fns';
 
-const DateInput = (props: Props): React.ReactElement => (
-  <TextInput width={10} {...props} type="date" />
-);
+format(new Date(2014, 1, 11), 'MM/dd/yyyy');
+
+interface Props extends TextInputNoType {
+  defaultToday?: boolean;
+}
+
+const DateInput = ({ defaultToday, ...props }: Props): React.ReactElement => {
+  return (
+    <>
+      <TextInput
+        width={10}
+        {...props}
+        type="date"
+        defaultValue={
+          defaultToday ? format(new Date(), 'yyyy-MM-dd') : undefined
+        }
+      />
+    </>
+  );
+};
 
 export default DateInput;

--- a/components/Form/DatePicker/DatePicker.tsx
+++ b/components/Form/DatePicker/DatePicker.tsx
@@ -1,27 +1,18 @@
 import { TextInput } from '..';
 import { TextInputNoType } from 'components/Form/types';
-
 import { format } from 'date-fns';
-
-format(new Date(2014, 1, 11), 'MM/dd/yyyy');
 
 interface Props extends TextInputNoType {
   defaultToday?: boolean;
 }
 
-const DateInput = ({ defaultToday, ...props }: Props): React.ReactElement => {
-  return (
-    <>
-      <TextInput
-        width={10}
-        {...props}
-        type="date"
-        defaultValue={
-          defaultToday ? format(new Date(), 'yyyy-MM-dd') : undefined
-        }
-      />
-    </>
-  );
-};
+const DateInput = ({ defaultToday, ...props }: Props): React.ReactElement => (
+  <TextInput
+    width={10}
+    {...props}
+    type="date"
+    defaultValue={defaultToday ? format(new Date(), 'yyyy-MM-dd') : undefined}
+  />
+);
 
 export default DateInput;

--- a/components/Form/types.ts
+++ b/components/Form/types.ts
@@ -76,6 +76,7 @@ export type TextInputNoType = Omit<TextInput, 'type'>;
 
 interface StepTextInputNoType extends TextInputNoType {
   component: 'NumberInput' | 'DatePicker' | 'PhoneInput' | 'EmailInput';
+  defaultToday?: boolean;
 }
 
 type TextAreaType = GenericField & InputHTMLAttributes<HTMLTextAreaElement>;

--- a/data/forms/asc-case-notes-recording.tsx
+++ b/data/forms/asc-case-notes-recording.tsx
@@ -22,7 +22,7 @@ const formSteps: FormStep[] = [
         rules: { required: 'Please provide a case note type' },
       },
       {
-        component: 'DateInput',
+        component: 'DatePicker',
         name: 'date_of_event',
         label: 'Date of Event',
         hint: 'For example, 31 03 1980',

--- a/data/forms/asc-case-notes-recording.tsx
+++ b/data/forms/asc-case-notes-recording.tsx
@@ -27,6 +27,7 @@ const formSteps: FormStep[] = [
         label: 'Date of Event',
         hint: 'For example, 31 03 1980',
         rules: { required: 'Please provide a valid date.' },
+        defaultToday: true,
       },
       {
         component: 'TextInput',

--- a/data/forms/cfs-case-notes-recording.tsx
+++ b/data/forms/cfs-case-notes-recording.tsx
@@ -44,7 +44,7 @@ const formSteps: FormStep[] = [
         rules: { required: true },
       },
       {
-        component: 'DateInput',
+        component: 'DatePicker',
         name: 'dateOfEvent',
         label: 'Date of Event',
         hint: 'For example, 31 03 1980',

--- a/data/forms/cfs-case-notes-recording.tsx
+++ b/data/forms/cfs-case-notes-recording.tsx
@@ -49,6 +49,7 @@ const formSteps: FormStep[] = [
         label: 'Date of Event',
         hint: 'For example, 31 03 1980',
         rules: { required: true },
+        defaultToday: true,
       },
       {
         component: 'TextInput',


### PR DESCRIPTION
this makes it easier/faster to add a case note to a person by:

- using `<input type="date"/>` rather than the more complicated "three text inputs" style
- enhances the `<DatePicker/>` element with a prop that causes it to render with today's date as an intial value
- reconfigure the form configuration data to use that prop for the case note form