### PR TITLE
SCT-28  Decide when to update frontend to use the service API in new …

### DIFF
--- a/components/Layout/Header/Header.tsx
+++ b/components/Layout/Header/Header.tsx
@@ -57,9 +57,6 @@ const HeaderComponent = ({
     }
   }, [user, pathname]);
 
-  if (NEXT_PUBLIC_MAINTENANCE_MODE && NEXT_PUBLIC_MAINTENANCE_MODE === '1')
-    return <></>;
-
   return (
     <header className="lbh-header ">
       <div className="lbh-header__main">
@@ -76,17 +73,23 @@ const HeaderComponent = ({
               )}
             </a>
           </div>
-          <nav className="lbh-header__links" aria-label="Navigation menu">
-            {navLinks && (
-              <>
-                {navLinks.map(({ name, path }) => (
-                  <Link href={path} key={path}>
-                    <a className="govuk-header__link">{name}</a>
-                  </Link>
-                ))}
-              </>
-            )}
-          </nav>
+
+          {NEXT_PUBLIC_MAINTENANCE_MODE &&
+          NEXT_PUBLIC_MAINTENANCE_MODE === '1' ? (
+            ''
+          ) : (
+            <nav className="lbh-header__links" aria-label="Navigation menu">
+              {navLinks && (
+                <>
+                  {navLinks.map(({ name, path }) => (
+                    <Link href={path} key={path}>
+                      <a className="govuk-header__link">{name}</a>
+                    </Link>
+                  ))}
+                </>
+              )}
+            </nav>
+          )}
         </div>
       </div>
     </header>

--- a/components/Layout/Header/Header.tsx
+++ b/components/Layout/Header/Header.tsx
@@ -8,6 +8,8 @@ import { getData } from 'utils/saveData';
 import { getUserType } from 'utils/user';
 import Logo from './Logo';
 
+const { NEXT_PUBLIC_MAINTENANCE_MODE } = process.env;
+
 const loggedNavLinks = [
   {
     name: 'Search',
@@ -54,6 +56,10 @@ const HeaderComponent = ({
       );
     }
   }, [user, pathname]);
+
+  if (NEXT_PUBLIC_MAINTENANCE_MODE && NEXT_PUBLIC_MAINTENANCE_MODE === '1')
+    return <></>;
+
   return (
     <header className="lbh-header ">
       <div className="lbh-header__main">

--- a/next.config.js
+++ b/next.config.js
@@ -4,4 +4,56 @@ module.exports = {
   future: {
     webpack5: true,
   },
+  async redirects() {
+    let redirects = maintenanceMode();
+    return redirects.filter(Boolean);
+  },
 };
+
+function maintenanceMode() {
+  let maintenance_array = [];
+
+  if (
+    process.env.NEXT_PUBLIC_MAINTENANCE_MODE &&
+    process.env.NEXT_PUBLIC_MAINTENANCE_MODE === '1'
+  ) {
+    let pages = [
+      '/access-denied',
+      '/forms-in-progress',
+      '/login',
+      '/logout',
+      '/index',
+      '/search',
+      '/my-records',
+      '/workers',
+      '/workers/:slug*',
+      '/api/:slug*',
+      '/people',
+      '/people/:slug*',
+      '/submissions:slug*',
+    ];
+
+    pages.forEach((elm) => {
+      maintenance_array = [
+        ...maintenance_array,
+        {
+          source: elm,
+          basePath: false,
+          destination: '/maintenance',
+          permanent: false,
+        },
+      ];
+    });
+  } else {
+    maintenance_array = [
+      ...maintenance_array,
+      {
+        source: '/maintenance',
+        destination: '/',
+        basePath: false,
+        permanent: false,
+      },
+    ];
+  }
+  return maintenance_array;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -30,7 +30,7 @@ function maintenanceMode() {
       '/api/:slug*',
       '/people',
       '/people/:slug*',
-      '/submissions:slug*',
+      '/submissions/:slug*',
     ];
 
     pages.forEach((elm) => {

--- a/pages/maintenance.tsx
+++ b/pages/maintenance.tsx
@@ -3,11 +3,8 @@ import Seo from 'components/Layout/Seo/Seo';
 const Maintenance = (): React.ReactElement => (
   <>
     <Seo title="Maintenance mode" />
-    <h1>Maintenance mode</h1>
-    <p className="govuk-body">
-      The service is currently being updated. Have a cup of tea and come back
-      later.
-    </p>
+    <h1>Sorry, the service is unavailable</h1>
+    <p className="govuk-body"></p>
   </>
 );
 

--- a/pages/maintenance.tsx
+++ b/pages/maintenance.tsx
@@ -1,0 +1,14 @@
+import Seo from 'components/Layout/Seo/Seo';
+
+const Maintenance = (): React.ReactElement => (
+  <>
+    <Seo title="Maintenance mode" />
+    <h1>Maintenance mode</h1>
+    <p className="govuk-body">
+      The service is currently being updated. Have a cup of tea and come back
+      later.
+    </p>
+  </>
+);
+
+export default Maintenance;

--- a/pages/maintenance.tsx
+++ b/pages/maintenance.tsx
@@ -4,7 +4,7 @@ const Maintenance = (): React.ReactElement => (
   <>
     <Seo title="Maintenance mode" />
     <h1>Sorry, the service is unavailable</h1>
-    <p className="govuk-body"></p>
+    <p className="govuk-body">You will be able to use the service from 8pm on Tuesday 24 May 2021.</p>
   </>
 );
 

--- a/pages/maintenance.tsx
+++ b/pages/maintenance.tsx
@@ -4,7 +4,9 @@ const Maintenance = (): React.ReactElement => (
   <>
     <Seo title="Maintenance mode" />
     <h1>Sorry, the service is unavailable</h1>
-    <p className="govuk-body">You will be able to use the service from 8pm on Tuesday 24 May 2021.</p>
+    <p className="govuk-body">
+      You will be able to use the service from 8pm on Tuesday 24 May 2021.
+    </p>
   </>
 );
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -52,6 +52,7 @@ functions:
       NEXT_PUBLIC_FEEDBACK_LINK: ${ssm:/lbh-social-care/${self:provider.stage}/next-public-feedback-link}
       REDIRECT_URL: ${ssm:/lbh-social-care/${self:provider.stage}/redirect_url}
       NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: ${ssm:/lbh-social-care/${self:provider.stage}/next_public_google_analytics_id}
+      NEXT_PUBLIC_MAINTENANCE_MODE: 0
 resources:
   Resources:
     CloudFrontDistribution:


### PR DESCRIPTION
Frontend bits for maintenance mode.

This needs a NEXT_PUBLIC_MAINTENANCE_MODE=1 variable in the .env file

For now the "blocked" pages are listed manually.
I tried adding a wildcard   - source: '/((?!maintenance).*)', -  but this prevents the maintenance page into loading the various resources it needs as they would be redirect as well.

The change in the header makes it not appear if it's in maintenance mode.
Everything else is routing.

Wording will probably need to be changed.