### PR TITLE
feat(SCT-229): Create warning note end details page

### DIFF
--- a/components/WarningNote/WarningNoteRecap/WarningNoteRecap.tsx
+++ b/components/WarningNote/WarningNoteRecap/WarningNoteRecap.tsx
@@ -66,34 +66,41 @@ const WarningNoteRecap = ({
     warningNote.warningNoteReviews.length > 0 &&
     formName != 'Warning Note Created';
 
+  const reverseDisplayOrderOfReviews = warningNote.warningNoteReviews
+    .slice(0)
+    .reverse();
+
   return (
     <>
       {displayReviews &&
-        warningNote.warningNoteReviews
-          .slice(0)
-          .reverse()
-          .map((review) => {
-            return (
-              <Summary
-                key={review.id}
-                formData={{
-                  ...review,
-                  endDate: warningNote.endDate,
-                  nextReviewDate: warningNote.nextReviewDate,
-                  person,
-                }}
-                formSteps={reviewedNoteSummary.map((step) => {
-                  return {
-                    ...step,
-                    title: `Warning Review Details ${new Date(
-                      review.reviewDate
-                    ).toLocaleDateString('en-GB')}`,
-                  };
-                })}
-                formPath={`/people/:peopleId/warning-notes/:warningNoteId`}
-              />
-            );
-          })}
+        reverseDisplayOrderOfReviews.map((review) => {
+          return (
+            <Summary
+              key={review.id}
+              formData={{
+                ...review,
+                endDate:
+                  reverseDisplayOrderOfReviews.indexOf(review) == 0
+                    ? warningNote.endDate
+                    : null,
+                nextReviewDate:
+                  reverseDisplayOrderOfReviews.indexOf(review) == 0
+                    ? warningNote.nextReviewDate
+                    : null,
+                person,
+              }}
+              formSteps={reviewedNoteSummary.map((step) => {
+                return {
+                  ...step,
+                  title: `Warning Review Details ${new Date(
+                    review.reviewDate
+                  ).toLocaleDateString('en-GB')}`,
+                };
+              })}
+              formPath={`/people/:peopleId/warning-notes/:warningNoteId`}
+            />
+          );
+        })}
       <Summary
         formData={{
           ...warningNote,

--- a/components/WarningNote/WarningNoteRecap/WarningNoteRecap.tsx
+++ b/components/WarningNote/WarningNoteRecap/WarningNoteRecap.tsx
@@ -97,7 +97,7 @@ const WarningNoteRecap = ({
                   ).toLocaleDateString('en-GB')}`,
                 };
               })}
-              formPath={`/people/:peopleId/warning-notes/:warningNoteId`}
+              formPath="/people/:peopleId/warning-notes/:warningNoteId"
             />
           );
         })}

--- a/components/WarningNote/WarningNoteRecap/WarningNoteRecap.tsx
+++ b/components/WarningNote/WarningNoteRecap/WarningNoteRecap.tsx
@@ -5,12 +5,46 @@ import { useWarningNote } from 'utils/api/warningNotes';
 import { formStepsAdult, formStepsChild } from 'data/forms/warning-note';
 import { Resident } from 'types';
 import reviewFormSteps from 'data/forms/warning-note-review';
+import { FormComponentStep, FormStep } from 'components/Form/types';
 
 export interface Props {
   person: Resident;
   warningNoteId: number;
   formName?: string;
 }
+
+export const modifyReviewSummary = (): FormStep[] => {
+  const reviewedBy: FormComponentStep = {
+    component: 'TextInput',
+    name: 'lastModifiedBy',
+    label: 'Review done by',
+  };
+
+  const endDate: FormComponentStep = {
+    component: 'DateInput',
+    name: 'endDate',
+    label: 'End Date',
+  };
+
+  const nextReviewDateWithoutReviewDecision: FormComponentStep = {
+    component: 'DateInput',
+    name: 'nextReviewDate',
+    label: 'Next Review Date',
+  };
+
+  const updatedReviewFormSteps = reviewFormSteps;
+
+  updatedReviewFormSteps[0].components.pop();
+  updatedReviewFormSteps[0].components.splice(1, 0, reviewedBy);
+  updatedReviewFormSteps[0].components.push(
+    endDate,
+    nextReviewDateWithoutReviewDecision
+  );
+
+  return updatedReviewFormSteps;
+};
+
+const reviewedNoteSummary = modifyReviewSummary();
 
 const WarningNoteRecap = ({
   person,
@@ -42,8 +76,13 @@ const WarningNoteRecap = ({
             return (
               <Summary
                 key={review.id}
-                formData={{ ...review, person }}
-                formSteps={reviewFormSteps.map((step) => {
+                formData={{
+                  ...review,
+                  endDate: warningNote.endDate,
+                  nextReviewDate: warningNote.nextReviewDate,
+                  person,
+                }}
+                formSteps={reviewedNoteSummary.map((step) => {
                   return {
                     ...step,
                     title: `Warning Review Details ${new Date(

--- a/cypress/integration/view_warning_note_details.ts
+++ b/cypress/integration/view_warning_note_details.ts
@@ -48,6 +48,27 @@ describe('Viewing a created warning note', () => {
       cy.contains('WARNING REVIEW DETAILS').should('be.visible');
       cy.contains('WARNING DETAILS').should('be.visible');
     });
+
+    it('should show the details of all submitted reviews and the initial note when a warning note has been ended', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('ADULT_RECORD_PERSON_ID')}`,
+        AuthRoles.AdultsGroup
+      );
+
+      cy.contains('td', 'Warning Note Ended')
+        .siblings()
+        .contains('a', 'View')
+        .click();
+
+      cy.contains('RECORDS HISTORY').should('not.exist');
+
+      cy.contains(Cypress.env('ADULT_RECORD_FULL_NAME')).should('be.visible');
+      cy.contains('Show details').click();
+      cy.contains('Hide details').should('be.visible');
+      cy.contains('Warning Note End Details').should('be.visible');
+      cy.contains('WARNING REVIEW DETAILS').should('be.visible');
+      cy.contains('WARNING DETAILS').should('be.visible');
+    });
   });
 
   describe('As a user in the Children group and records are not restricted', () => {
@@ -98,6 +119,29 @@ describe('Viewing a created warning note', () => {
       cy.contains('Show details').click();
       cy.contains('Hide details').should('be.visible');
       cy.contains('Warning Note Review Details').should('be.visible');
+      cy.contains('WARNING REVIEW DETAILS').should('be.visible');
+      cy.contains('WARNING DETAILS').should('be.visible');
+    });
+
+    it('should show the details of all submitted reviews and the initial note when a warning note has been ended', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}`,
+        AuthRoles.ChildrensGroup
+      );
+
+      cy.contains('td', 'Warning Note Ended')
+        .siblings()
+        .contains('a', 'View')
+        .click();
+
+      cy.contains('RECORDS HISTORY').should('not.exist');
+
+      cy.contains(Cypress.env('CHILDREN_RECORD_FULL_NAME')).should(
+        'be.visible'
+      );
+      cy.contains('Show details').click();
+      cy.contains('Hide details').should('be.visible');
+      cy.contains('Warning Note End Details').should('be.visible');
       cy.contains('WARNING REVIEW DETAILS').should('be.visible');
       cy.contains('WARNING DETAILS').should('be.visible');
     });

--- a/pages/people/[id]/warning-notes/[warningNoteId]/view/[[...stepId]].tsx
+++ b/pages/people/[id]/warning-notes/[warningNoteId]/view/[[...stepId]].tsx
@@ -14,7 +14,9 @@ const ViewWarningNote = (): React.ReactElement => {
       <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
         {formName == 'Warning Note Created'
           ? 'Warning Note Details'
-          : 'Warning Note Review Details'}
+          : formName == 'Warning Note Reviewed'
+          ? 'Warning Note Review Details'
+          : 'Warning Note End Details'}
       </h1>
       <PersonView personId={personId} expandView>
         {(person) => (

--- a/types.ts
+++ b/types.ts
@@ -210,7 +210,7 @@ interface BaseNote {
   createdBy: string;
   startDate: string;
   reviewDate: string;
-  endedDate?: string;
+  endDate?: string;
   endedBy?: string;
   reviewedDate?: string;
   reviewedBy?: string;


### PR DESCRIPTION
**N.B:** See this [user story](https://hackney.atlassian.net/browse/SCS-510) for a more detailed user journey for ending a warning note.

**What**  
This adds a page to view warning note reviews from the records history section. i.e when the user clicks `view` next to a **Warning Note Ended** record:
<img width="996" alt="Screenshot 2021-05-26 at 2 51 27 pm" src="https://user-images.githubusercontent.com/32823756/119671873-0a934d00-be32-11eb-8d4b-9ec4d6cfe870.png">

**Before:**
Clicking the view link would take the user to a page that only showed the details of the initial warning note and did not display any review information:
<img width="1012" alt="Screenshot 2021-05-26 at 2 52 38 pm" src="https://user-images.githubusercontent.com/32823756/119671940-1717a580-be32-11eb-9067-531e6f26f424.png">

**After:**
Now, clicking the view link would take the user to a page displaying all the reviews submitted up until the warning note was closed as well as the original warning note itself:
<img width="674" alt="Screenshot 2021-05-27 at 10 26 36 am" src="https://user-images.githubusercontent.com/32823756/119801962-0caee780-bed6-11eb-9dd0-4b4dbdcd43da.png">

**Why**  
When a warning note is ended, a log of this action is made in the records' history section. The view link takes the user to a warning note end details page to allow the user to see all the reviews done until the warning note was closed.