### PR TITLE
fix(SCT-261): Allow edit worker page to load if teams is an empty array

### DIFF
--- a/pages/workers/[id]/edit/[[...stepId]].tsx
+++ b/pages/workers/[id]/edit/[[...stepId]].tsx
@@ -43,6 +43,7 @@ const UpdateWorker = (): React.ReactElement => {
       createdBy: user.email,
     });
   };
+
   return (
     <FormWizard
       formPath={`/workers/${workerId}/edit/`}
@@ -52,7 +53,7 @@ const UpdateWorker = (): React.ReactElement => {
       defaultValues={{
         ...data,
         user,
-        team: data.teams?.[0].name,
+        team: data.teams?.[0]?.name,
         teams: {
           A: ATeams.map(({ name }) => name),
           C: CTeams.map(({ name }) => name),


### PR DESCRIPTION
**What**  

Added a null condition accessor for getting the name property of teams[0] as teams can be an empty array.

**Why**  

When loading the edit worker page you get logged out.

**Anything else?**

- Have you added any new third-party libraries? no
- Are any new environment variables or configuration values needed? no
- Anything else in this PR that isn't covered by the what/why? no
