### PR TITLE
feat(SCT-400): expose dashboard at a hidden URL for testing

### DIFF
--- a/components/Dashboard/DashboardWrapper.tsx
+++ b/components/Dashboard/DashboardWrapper.tsx
@@ -14,7 +14,7 @@ const DashboardWrapper = ({ children }: Props): React.ReactElement => (
       title="Dashboard"
       tabs={[
         {
-          url: '/',
+          url: '/__dashboard',
           text: 'Clients allocated',
         },
         {

--- a/components/Dashboard/__snapshots__/DashboardWrapper.spec.tsx.snap
+++ b/components/Dashboard/__snapshots__/DashboardWrapper.spec.tsx.snap
@@ -45,7 +45,7 @@ exports[`DashboardWrapper should render properly 1`] = `
           >
             <a
               class="lbh-tabs govuk-tabs__tab"
-              href="/"
+              href="/__dashboard"
             >
               Clients allocated
             </a>

--- a/pages/__dashboard.tsx
+++ b/pages/__dashboard.tsx
@@ -1,7 +1,17 @@
 import Seo from 'components/Layout/Seo/Seo';
 import MyAllocatedCases from 'components/AllocatedCases/MyAllocatedCases';
 import DashboardWrapper from 'components/Dashboard/DashboardWrapper';
-import { GetServerSideProps } from 'next';
+
+/**
+ * This page, the Dashboard, is being exposed for internal testing at `{domain}/__dashboard`.
+ *
+ * Once the Dashboard is ready to launch, this file should be removed, and the redirect
+ *  (see `getServerSideProps()` in `/pages/index.tsx`) should be removed, so the
+ *  dashboard is available at the `{domain}/` route.
+ *
+ * `/components/Dashboard/DashboardWrapper.tsx` will also need to change to modify the base path of
+ *  the dashboard from `/__dashboard` to `/`.
+ */
 
 const MyCasesPage = (): React.ReactElement => (
   <div>
@@ -14,14 +24,5 @@ const MyCasesPage = (): React.ReactElement => (
     </DashboardWrapper>
   </div>
 );
-
-export const getServerSideProps: GetServerSideProps = async () => {
-  return {
-    props: {},
-    redirect: {
-      destination: '/search',
-    },
-  };
-};
 
 export default MyCasesPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,14 +14,4 @@ const MyCasesPage = (): React.ReactElement => (
   </div>
 );
 
-// TODO: remove this redirect when dashboard is ready to launch
-export const getServerSideProps = async () => {
-  return {
-    props: {},
-    redirect: {
-      destination: '/search',
-    },
-  };
-};
-
 export default MyCasesPage;


### PR DESCRIPTION
**What**  
We want to test the dashboard with some stakeholders before launching it for all customers. This PR makes an obfuscated URL `{domain}/__dashboard` which allows us to navigate to it, and demo the behaviour, without exposing it in navigational elements, or showing it to all users on the home page.

The ticket to undo this change / launch the dashboard is [SCT-401](https://hackney.atlassian.net/browse/SCT-401).

**Why**  
[SCT-400](https://hackney.atlassian.net/browse/SCT-400)

**Anything else?**

- ~Have you added any new third-party libraries?~
- ~Are any new environment variables or configuration values needed?~
- ~Anything else in this PR that isn't covered by the what/why?~
