### PR TITLE
feat(SCT-355, SCT-366): add required validation error message to Warning Notes form fields

### DIFF
--- a/components/Form/DateInput/DateInput.tsx
+++ b/components/Form/DateInput/DateInput.tsx
@@ -11,6 +11,7 @@ import {
 } from 'utils/date';
 
 import { DateInput as IDateInput } from 'components/Form/types';
+import { FieldErrorMessage } from '../FieldErrorMessage/FieldErrorMessage';
 
 interface InputProps extends Omit<IDateInput, 'control'> {
   value?: string;
@@ -57,7 +58,9 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
         <span id={`${name}-hint`} className="lbh-hint">
           {hint}
         </span>
-        {error && <ErrorMessage label={error.message} />}
+
+        <FieldErrorMessage error={error} label={label} />
+
         <div className="lbh-date-input govuk-date-input" id={name}>
           <div className="lbh-date-input govuk-date-input__item">
             <div className="lbh-form-group govuk-form-group">

--- a/components/Form/FieldErrorMessage/FieldErrorMessage.spec.tsx
+++ b/components/Form/FieldErrorMessage/FieldErrorMessage.spec.tsx
@@ -1,0 +1,93 @@
+import { render } from '@testing-library/react';
+import { FieldErrorMessage } from './FieldErrorMessage';
+
+describe('<FieldErrorMessage />', () => {
+  it('should render nothing if no error is provided', () => {
+    const { asFragment } = render(<FieldErrorMessage error={undefined} />);
+
+    expect(asFragment()).toMatchInlineSnapshot('<DocumentFragment />');
+  });
+
+  it('should render an unknown error if no message or type is provided on the error object', () => {
+    const { getByText } = render(<FieldErrorMessage error={{}} />);
+
+    getByText('Oops an error occurred');
+  });
+
+  it('should render the provided error message if one is given', () => {
+    const { getByText } = render(
+      <FieldErrorMessage
+        error={{
+          message: 'This is my error message',
+        }}
+      />
+    );
+
+    getByText('This is my error message');
+  });
+
+  it('should render a general message if the error is of type "required" and no message is provided', () => {
+    const { getByText } = render(
+      <FieldErrorMessage
+        error={{
+          type: 'required',
+        }}
+      />
+    );
+
+    getByText('Enter a value');
+  });
+
+  it('should render a general message with the custom action if the error is of type "required" and no message is provided', () => {
+    const { getByText } = render(
+      <FieldErrorMessage
+        error={{
+          type: 'required',
+        }}
+        action="Select"
+      />
+    );
+
+    getByText('Select a value');
+  });
+
+  it('should render a field-specific message if the error is of type "required" and no message is provided', () => {
+    const { getByText } = render(
+      <FieldErrorMessage
+        error={{
+          type: 'required',
+        }}
+        label="First name"
+      />
+    );
+
+    getByText('Enter a first name');
+  });
+
+  it('should render a field-specific message with "an" if the label starts with a vowel, if the error is of type "required" and no message is provided', () => {
+    const { getByText } = render(
+      <FieldErrorMessage
+        error={{
+          type: 'required',
+        }}
+        label="Age"
+      />
+    );
+
+    getByText('Enter an age');
+  });
+
+  it('should not render "a" if the error is not singular', () => {
+    const { getByText } = render(
+      <FieldErrorMessage
+        error={{
+          type: 'required',
+        }}
+        label="Further details on this issue"
+        isSingular={false}
+      />
+    );
+
+    getByText('Enter further details on this issue');
+  });
+});

--- a/components/Form/FieldErrorMessage/FieldErrorMessage.tsx
+++ b/components/Form/FieldErrorMessage/FieldErrorMessage.tsx
@@ -1,0 +1,51 @@
+import ErrorMessage from '../../ErrorMessage/ErrorMessage';
+import { GenericField } from '../types';
+
+const generateErrorMessage = (
+  action = 'Enter',
+  isSingular: boolean,
+  error: Required<GenericField>['error'],
+  label?: string
+) => {
+  if (error.message) {
+    return error.message;
+  }
+
+  if (error.type === 'required') {
+    if (!label) {
+      return `${action} a value`;
+    }
+
+    const startsWithVowel = ['a', 'e', 'i', 'o', 'u'].includes(
+      label.toLowerCase()[0]
+    );
+
+    return `${action} ${
+      isSingular ? (startsWithVowel ? 'an' : 'a') : ''
+    } ${label.toLowerCase()}`;
+  }
+
+  return undefined;
+};
+
+type Props = {
+  action?: string;
+  error?: Required<GenericField>['error'];
+  label?: string;
+  isSingular?: boolean;
+};
+
+export const FieldErrorMessage: React.FC<Props> = ({
+  action,
+  error,
+  label,
+  isSingular = true,
+}: Props) => {
+  if (!error) {
+    return null;
+  }
+
+  const message = generateErrorMessage(action, isSingular, error, label);
+
+  return <ErrorMessage label={message} />;
+};

--- a/components/Form/Radios/Radios.tsx
+++ b/components/Form/Radios/Radios.tsx
@@ -2,7 +2,8 @@ import cx from 'classnames';
 
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 
-import type { Radios as Props } from 'components/Form/types';
+import type { GenericField, Radios as Props } from 'components/Form/types';
+import { FieldErrorMessage } from '../FieldErrorMessage/FieldErrorMessage';
 
 const defaultOptions = ['Yes', 'No'];
 
@@ -19,55 +20,61 @@ const Radios = ({
   rules,
   isRadiosInline = false,
   ...otherProps
-}: Props): React.ReactElement => (
-  <div
-    className={cx('govuk-form-group lbh-form-group', {
-      'govuk-form-group--error': error,
-    })}
-  >
-    <label className={`lbh-label govuk-label`} htmlFor={name}>
-      {label} {required && <span className="govuk-required">*</span>}
-    </label>
-    {hint && (
-      <span id={`${name}-hint`} className="lbh-hint">
-        {hint}
-      </span>
-    )}
-    {children}
-    {error && <ErrorMessage label={error.message} />}
+}: Props): React.ReactElement => {
+  return (
     <div
-      className={cx('govuk-radios lbh-radios', {
-        'govuk-radios--inline': isRadiosInline,
+      className={cx('govuk-form-group lbh-form-group', {
+        'govuk-form-group--error': error,
       })}
     >
-      {options.map((option) => {
-        const { value, text } =
-          typeof option === 'string' ? { value: option, text: option } : option;
-        return (
-          <div className="govuk-radios__item" key={text}>
-            <input
-              className={cx('govuk-radios__input', {
-                'govuk-input--error': error,
-              })}
-              id={`${name}_${value}`}
-              name={name}
-              type="radio"
-              value={value}
-              ref={rules ? register?.(rules) : register}
-              aria-describedby={hint && `${name}-hint`}
-              {...otherProps}
-            />
-            <label
-              className="govuk-label govuk-radios__label"
-              htmlFor={`${name}_${value}`}
-            >
-              {text}
-            </label>
-          </div>
-        );
-      })}
+      <label className={`lbh-label govuk-label`} htmlFor={name}>
+        {label} {required && <span className="govuk-required">*</span>}
+      </label>
+      {hint && (
+        <span id={`${name}-hint`} className="lbh-hint">
+          {hint}
+        </span>
+      )}
+      {children}
+
+      <FieldErrorMessage error={error} action="Select" label={label} />
+
+      <div
+        className={cx('govuk-radios lbh-radios', {
+          'govuk-radios--inline': isRadiosInline,
+        })}
+      >
+        {options.map((option) => {
+          const { value, text } =
+            typeof option === 'string'
+              ? { value: option, text: option }
+              : option;
+          return (
+            <div className="govuk-radios__item" key={text}>
+              <input
+                className={cx('govuk-radios__input', {
+                  'govuk-input--error': error,
+                })}
+                id={`${name}_${value}`}
+                name={name}
+                type="radio"
+                value={value}
+                ref={rules ? register?.(rules) : register}
+                aria-describedby={hint && `${name}-hint`}
+                {...otherProps}
+              />
+              <label
+                className="govuk-label govuk-radios__label"
+                htmlFor={`${name}_${value}`}
+              >
+                {text}
+              </label>
+            </div>
+          );
+        })}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default Radios;

--- a/components/Form/TextArea/TextArea.tsx
+++ b/components/Form/TextArea/TextArea.tsx
@@ -1,6 +1,7 @@
 import cx from 'classnames';
 
 import type { TextArea as Props } from 'components/Form/types';
+import { FieldErrorMessage } from '../FieldErrorMessage/FieldErrorMessage';
 
 const TextArea = ({
   label,
@@ -30,11 +31,14 @@ const TextArea = ({
         {hint}
       </span>
     )}
-    {error && (
-      <span id={`${name}-error`} className="govuk-error-message">
-        <span className="govuk-visually-hidden">Error:</span> {error.message}
-      </span>
-    )}
+
+    <FieldErrorMessage
+      error={error}
+      action="Enter"
+      label={label}
+      isSingular={false}
+    />
+
     <textarea
       className={cx('lbh-textarea govuk-textarea', {
         'govuk-textarea--error': Boolean(error),

--- a/components/Form/TextInput/TextInput.tsx
+++ b/components/Form/TextInput/TextInput.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 
 import type { TextInput as Props } from 'components/Form/types';
+import { FieldErrorMessage } from '../FieldErrorMessage/FieldErrorMessage';
 
 const TextInput = ({
   label,
@@ -31,7 +32,9 @@ const TextInput = ({
         {hint}
       </span>
     )}
-    {error && <ErrorMessage label={error.message} />}
+
+    <FieldErrorMessage error={error} label={label} />
+
     <input
       className={cx(`govuk-input lbh-input`, inputClassName, {
         [`govuk-input--width-${width}`]: width,

--- a/components/Form/types.ts
+++ b/components/Form/types.ts
@@ -41,7 +41,10 @@ export interface GenericField {
   label?: string;
   rules?: RegisterOptions;
   register?: UseFormMethods['register'];
-  error?: { message?: string };
+  error?: {
+    message?: string;
+    type?: string;
+  };
   required?: boolean | string;
   hint?: string;
   labelSize?: LabelSize;

--- a/data/forms/warning-note-review.tsx
+++ b/data/forms/warning-note-review.tsx
@@ -35,13 +35,13 @@ const formSteps: FormStep[] = [
         component: 'TextInput',
         name: 'managerName',
         label: 'Manager’s name',
-        rules: { required: "Add the manager's name." },
+        rules: { required: true },
       },
       {
         component: 'DateInput',
         name: 'discussedWithManagerDate',
         label: 'Date discussed with manager',
-        rules: { required: 'Pease add a valid date.' },
+        rules: { required: true },
       },
       {
         component: 'Radios',
@@ -58,7 +58,7 @@ const formSteps: FormStep[] = [
         name: 'nextReviewDate',
         label: 'Next review date',
         rules: {
-          required: 'Pease add a valid date.',
+          required: true,
           validate: {
             beforeStartDate: (value) =>
               new Date(value).getTime() >= new Date().getTime() ||

--- a/data/forms/warning-note-review.tsx
+++ b/data/forms/warning-note-review.tsx
@@ -47,7 +47,9 @@ const formSteps: FormStep[] = [
         component: 'Radios',
         name: 'reviewDecision',
         label: 'What do you want to do?',
-        rules: { required: true },
+        rules: {
+          required: 'Select what you want to do',
+        },
         options: [
           { value: 'Yes', text: 'Renew Warning Note' },
           { value: 'No', text: 'End Warning Note' },


### PR DESCRIPTION
**What**  
Adds 'required' error messages to form fields that are required. This is done through a new `<FieldErrorMessage />` component that automatically crafts an appropriate error message if `error.type`  is `required` but `error.message` is empty.

The error message automatically switches from `a` to `an` depending on whether label starts with a vowel, and formats in sentence case.

Note: Further refinement may be needed if there are specific field names that need more advanced error messages, but this can still be done in the form config by passing a string to the `required` value.

**Why**  
[SCT-355](https://hackney.atlassian.net/browse/SCT-355), [SCT-366](https://hackney.atlassian.net/browse/SCT-366)

**Anything else?**

- ~Have you added any new third-party libraries?~
- ~Are any new environment variables or configuration values needed?~
- ~Anything else in this PR that isn't covered by the what/why?~
