### PR TITLE
Undo change to reviewNotes component in review form step

### DIFF
--- a/data/forms/warning-note-review.tsx
+++ b/data/forms/warning-note-review.tsx
@@ -21,7 +21,7 @@ const formSteps: FormStep[] = [
       },
       {
         component: 'TextArea',
-        name: 'notes',
+        name: 'reviewNotes',
         label: 'Details of review',
         hint: 'include details of disclosure to individual, any updates and why renewing or ending',
         rules: { required: true },

--- a/types.ts
+++ b/types.ts
@@ -257,7 +257,7 @@ interface ReviewedNote {
   warningNoteId: number;
   reviewDate: string;
   disclosedWithIndividual: boolean;
-  notes: string;
+  reviewNotes: string;
   managerName: string;
   discussedWithManagerDate: string;
   createdAt: string;


### PR DESCRIPTION
**What**  
We've made a change in the structure of the API response when we request warning note reviews, so this reverses the previous change made in the frontend.

**Why**  

This was initially changed because the `reviewNotes` did not match the property
in the API response when we make a GET request for warning note reviews. 
See changes made in this [PR](https://github.com/LBHackney-IT/lbh-social-care-frontend/pull/391) for better context.

The API response was returning a `Notes` property for each warning note review object.

From discussing the current naming conventions for the warning note data model,
it was agreed that any details of a review should be saved as `review notes`
and `notes` should be reserved for the original warning note.