### PR TITLE
Fix(SCT-492): Add missing "s" in URL path when saving a form

### DIFF
--- a/components/FormWizard/FormWizard.jsx
+++ b/components/FormWizard/FormWizard.jsx
@@ -142,7 +142,7 @@ const FormWizard = ({
                 : window.location.pathname,
               personDetails: includesDetails && personDetails,
             });
-            Router.push('/form-in-progress');
+            Router.push('/forms-in-progress');
           }}
           onFormSubmit={onFormSubmit}
           successMessage={successMessage}


### PR DESCRIPTION
When we click on `save and finish later` we are redirected to a page not found. URL path: `/form-in-progress`.

We checked the URL of the forms to complete tab in the dashboard and realised that the path for the forms tab was: `/forms-in-progress`

This corrects the path when clicking the save and finish later buttonto redirect the user to the dashboard forms to the complete tab.