### PR TITLE
Fix(SCT-461): Add missing date validation for Date Informed form component

### DIFF
--- a/data/forms/warning-note.tsx
+++ b/data/forms/warning-note.tsx
@@ -303,7 +303,14 @@ const WARNING_DISCLOSURE: Array<FormComponentStep> = [
     name: 'disclosedDate',
     label: 'Date informed',
     labelSize: 's',
-    rules: { required: true },
+    rules: {
+      required: true,
+      validate: {
+        notInFuture: (value) =>
+          new Date(value).getTime() <= new Date().getTime() ||
+          "Date informed can't be in the future",
+      },
+    },
     showConditionalGuides: true,
     conditionalRender: ({ disclosedWithIndividual }) =>
       disclosedWithIndividual === 'Yes',


### PR DESCRIPTION
A follow up to this PR #443.

This adds a check to prevent a user from setting a `Date Informed` value for the future.