### PR TITLE
fix(SCT-509): safely handle residents with partial addresses

### DIFF
--- a/components/Search/results/ResidentsTable.spec.tsx
+++ b/components/Search/results/ResidentsTable.spec.tsx
@@ -44,4 +44,35 @@ describe('ResidentsTable component', () => {
 
     getByText('Restricted');
   });
+
+  it('should render a resident without a postcode', () => {
+    const { asFragment } = render(
+      <UserContext.Provider
+        value={{
+          user: userFactory.build({
+            hasAdminPermissions: false,
+            hasDevPermissions: false,
+            hasChildrenPermissions: false,
+            hasUnrestrictedPermissions: false,
+            hasAllocationsPermissions: false,
+            hasAdultPermissions: true,
+          }),
+        }}
+      >
+        <ResidentsTable
+          records={[
+            legacyResidentFactory.build({
+              ageContext: 'C',
+              address: {
+                address: 'some address',
+                postcode: null,
+              },
+            }),
+          ]}
+        />
+      </UserContext.Provider>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/components/Search/results/ResidentsTable.tsx
+++ b/components/Search/results/ResidentsTable.tsx
@@ -35,9 +35,13 @@ const ResultEntry = (person: LegacyResident): React.ReactElement => {
         {dateOfBirth && new Date(dateOfBirth).toLocaleDateString('en-GB')}
       </td>
       <td className="govuk-table__cell">
-        {address?.address && truncate(address.address, 4)}
+        {address?.address && truncate(address.address || '', 4)}
       </td>
-      <td className="govuk-table__cell">{address?.postcode.toUpperCase()}</td>
+      <td className="govuk-table__cell">
+        <span className={styles.uppercase}>
+          {(address && address.postcode) || ''}
+        </span>
+      </td>
       <td className="govuk-table__cell govuk-table__cell--numeric">
         {isRecordRestricted && (
           <span

--- a/components/Search/results/__snapshots__/ResidentsTable.spec.tsx.snap
+++ b/components/Search/results/__snapshots__/ResidentsTable.spec.tsx.snap
@@ -75,10 +75,111 @@ exports[`ResidentsTable component should render a list of residents 1`] = `
         />
         <td
           class="govuk-table__cell"
-        />
+        >
+          <span
+            class="uppercase"
+          />
+        </td>
         <td
           class="govuk-table__cell govuk-table__cell--numeric"
         />
+      </tr>
+    </tbody>
+  </table>
+</DocumentFragment>
+`;
+
+exports[`ResidentsTable component should render a resident without a postcode 1`] = `
+<DocumentFragment>
+  <table
+    class="govuk-table lbh-table"
+    data-testid="residents-table"
+  >
+    <thead
+      class="govuk-table__head"
+    >
+      <tr
+        class="govuk-table__row"
+      >
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Social care ID
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Person
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Date of birth
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Address
+        </th>
+        <th
+          class="govuk-table__header"
+          scope="col"
+        >
+          Post code
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="govuk-table__body"
+    >
+      <tr
+        class="govuk-table__row restrictedRow"
+      >
+        <td
+          class="govuk-table__cell"
+        >
+          3
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          <a
+            class="govuk-link govuk-custom-text-color"
+            href="/people/3"
+          >
+            Foo Bar
+          </a>
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          13/11/2020
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          some address
+        </td>
+        <td
+          class="govuk-table__cell"
+        >
+          <span
+            class="uppercase"
+          />
+        </td>
+        <td
+          class="govuk-table__cell govuk-table__cell--numeric"
+        >
+          <span
+            class="govuk-tag lbh-tag lbh-tag--grey uppercase"
+          >
+            Restricted
+          </span>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/types.ts
+++ b/types.ts
@@ -124,8 +124,8 @@ export interface LegacyResident {
   nhsNumber: string;
   restricted?: 'Y' | 'N';
   address?: {
-    address: string;
-    postcode: string;
+    address: string | null;
+    postcode: string | null;
     uprn?: string;
   };
   phoneNumber?: Array<{


### PR DESCRIPTION
**What**  
Some resident's have partial addresses (e.g. missing postcode). Our UI doesn't gracefully handle these situations, until now!

**Why**  
[SCT-509](https://hackney.atlassian.net/browse/SCT-509)

