### PR TITLE
SCT-491 - Date of death, once set, can't be removed

### DIFF
--- a/components/Form/DateInput/DateInput.tsx
+++ b/components/Form/DateInput/DateInput.tsx
@@ -81,13 +81,8 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
                 name={`${name}-day`}
                 pattern="^\d{2}$"
                 inputMode="numeric"
-                defaultValue={date.day}
-                onChange={({
-                  target: {
-                    value,
-                    validity: { valid },
-                  },
-                }) => valid && setNewDate({ day: value })}
+                value={date.day}
+                onChange={({ target: { value } }) => setNewDate({ day: value })}
                 ref={ref}
                 {...otherProps}
               />
@@ -113,13 +108,10 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
                 name={`${name}-month`}
                 pattern="^\d{2}$"
                 inputMode="numeric"
-                defaultValue={date.month}
-                onChange={({
-                  target: {
-                    value,
-                    validity: { valid },
-                  },
-                }) => valid && setNewDate({ month: value })}
+                value={date.month}
+                onChange={({ target: { value } }) =>
+                  setNewDate({ month: value })
+                }
                 {...otherProps}
               />
             </div>
@@ -144,13 +136,11 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
                 name={`${name}-year`}
                 pattern="^\d{4}$"
                 inputMode="numeric"
-                defaultValue={date.year}
-                onChange={({
-                  target: {
-                    value,
-                    validity: { valid },
-                  },
-                }) => valid && setNewDate({ year: value })}
+                value={date.year}
+                // onChange={(value) => setNewDate({year: value})}
+                onChange={({ target: { value } }) =>
+                  setNewDate({ year: value })
+                }
                 {...otherProps}
               />
             </div>

--- a/components/Form/DateInput/DateInput.tsx
+++ b/components/Form/DateInput/DateInput.tsx
@@ -137,7 +137,6 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
                 pattern="^\d{4}$"
                 inputMode="numeric"
                 value={date.year}
-                // onChange={(value) => setNewDate({year: value})}
                 onChange={({ target: { value } }) =>
                   setNewDate({ year: value })
                 }


### PR DESCRIPTION
[Link to the ticket](https://hackney.atlassian.net/browse/SCT-491)

**What**  
Internal fields (day/month/year) "onChange" validation has been removed. 
The internal validation was preventing the fields to be set to empty, as it was being triggered by the onChange function.
Validation now is at the ControlledDateInput component level, where it checks if the date is valid (or null)

**Why**  
Fixed the date input component so dates can be set to null.