### PR TITLE
Fix(SCT-507): Update ASC warning note review form to include a disclosure question

### DIFF
--- a/components/WarningNote/WarningNoteRecap/WarningNoteRecap.tsx
+++ b/components/WarningNote/WarningNoteRecap/WarningNoteRecap.tsx
@@ -5,7 +5,10 @@ import { useWarningNote } from 'utils/api/warningNotes';
 import { formStepsAdult, formStepsChild } from 'data/forms/warning-note';
 import { Resident } from 'types';
 import SummaryList from '../../Summary/SummaryList';
-import reviewFormSteps from 'data/forms/warning-note-review';
+import {
+  reviewFormStepsAdult,
+  reviewFormStepsChild,
+} from 'data/forms/warning-note-review';
 
 export interface Props {
   person: Resident;
@@ -38,6 +41,9 @@ const WarningNoteRecap = ({
     ...warningNote.warningNoteReviews,
   ].reverse();
 
+  const reviewFormSteps =
+    person.contextFlag === 'A' ? reviewFormStepsAdult : reviewFormStepsChild;
+
   return (
     <>
       {shouldPageDisplayNoteReviews(noteDetails) &&
@@ -49,6 +55,9 @@ const WarningNoteRecap = ({
               key={review.id}
               formData={{
                 ...review,
+                disclosedWithIndividual: review.disclosedWithIndividual
+                  ? 'Yes'
+                  : 'No',
                 outputAsDetailedSummary: 'Yes',
                 endDate: isSelectedReviewTheMostRecent
                   ? warningNote.endDate
@@ -56,7 +65,6 @@ const WarningNoteRecap = ({
                 nextReviewDate: isSelectedReviewTheMostRecent
                   ? warningNote.nextReviewDate
                   : null,
-                person,
               }}
               formSteps={reviewFormSteps.map((step) => {
                 return {

--- a/cypress/integration/view_warning_note_details.ts
+++ b/cypress/integration/view_warning_note_details.ts
@@ -44,8 +44,13 @@ describe('Viewing a created warning note', () => {
       cy.contains(Cypress.env('ADULT_RECORD_FULL_NAME')).should('be.visible');
       cy.contains('Show details').click();
       cy.contains('Hide details').should('be.visible');
+
       cy.contains('Warning Note Review Details').should('be.visible');
       cy.contains('WARNING REVIEW DETAILS').should('be.visible');
+      cy.contains('Have you discussed this review with the individual').should(
+        'be.visible'
+      );
+
       cy.contains('WARNING DETAILS').should('be.visible');
     });
 
@@ -65,8 +70,13 @@ describe('Viewing a created warning note', () => {
       cy.contains(Cypress.env('ADULT_RECORD_FULL_NAME')).should('be.visible');
       cy.contains('Show details').click();
       cy.contains('Hide details').should('be.visible');
+
       cy.contains('Warning Note End Details').should('be.visible');
       cy.contains('WARNING REVIEW DETAILS').should('be.visible');
+      cy.contains('Have you discussed this review with the individual').should(
+        'be.visible'
+      );
+
       cy.contains('WARNING DETAILS').should('be.visible');
     });
   });
@@ -118,8 +128,13 @@ describe('Viewing a created warning note', () => {
       );
       cy.contains('Show details').click();
       cy.contains('Hide details').should('be.visible');
+
       cy.contains('Warning Note Review Details').should('be.visible');
       cy.contains('WARNING REVIEW DETAILS').should('be.visible');
+      cy.contains('Have you discussed this review with the individual').should(
+        'not.exist'
+      );
+
       cy.contains('WARNING DETAILS').should('be.visible');
     });
 
@@ -141,8 +156,13 @@ describe('Viewing a created warning note', () => {
       );
       cy.contains('Show details').click();
       cy.contains('Hide details').should('be.visible');
+
       cy.contains('Warning Note End Details').should('be.visible');
       cy.contains('WARNING REVIEW DETAILS').should('be.visible');
+      cy.contains('Have you discussed this review with the individual').should(
+        'not.exist'
+      );
+
       cy.contains('WARNING DETAILS').should('be.visible');
     });
   });

--- a/data/forms/warning-note-review.tsx
+++ b/data/forms/warning-note-review.tsx
@@ -21,7 +21,6 @@ const REVIEW_DISCLOSURE: Array<FormComponentStep> = [
     component: 'Radios',
     name: 'disclosedWithIndividual',
     label: 'Have you discussed this review with the individual',
-    isRadiosInline: true,
     rules: { required: true },
   },
 ];

--- a/data/forms/warning-note-review.tsx
+++ b/data/forms/warning-note-review.tsx
@@ -1,112 +1,152 @@
-import { FormStep } from 'components/Form/types';
+import { FormComponentStep, FormStep } from 'components/Form/types';
 
-const formSteps: FormStep[] = [
+const REVIEW_UNDERTAKEN_DATE: Array<FormComponentStep> = [
   {
-    id: 'review-warning-note',
-    title: 'Warning Review Details',
-    components: [
-      {
-        component: 'DateInput',
-        name: 'reviewDate',
-        label: 'Date review undertaken',
-        rules: {
-          required: true,
-          validate: {
-            notInFuture: (value) =>
-              new Date(value).getTime() <= new Date().getTime() ||
-              "Date review undertaken can't be in the future",
-          },
-        },
+    component: 'DateInput',
+    name: 'reviewDate',
+    label: 'Date review undertaken',
+    rules: {
+      required: true,
+      validate: {
+        notInFuture: (value) =>
+          new Date(value).getTime() <= new Date().getTime() ||
+          "Date review undertaken can't be in the future",
       },
-      {
-        component: 'Radios',
-        name: 'disclosedWithIndividual',
-        label: 'Have you discussed this review with the individual',
-        isRadiosInline: true,
-        rules: { required: true },
-        conditionalRender: ({ person }) => person.ageContext === 'A',
+    },
+  },
+];
+
+const REVIEW_DISCLOSURE: Array<FormComponentStep> = [
+  {
+    component: 'Radios',
+    name: 'disclosedWithIndividual',
+    label: 'Have you discussed this review with the individual',
+    isRadiosInline: true,
+    rules: { required: true },
+  },
+];
+
+const REVIEW_DETAILS: Array<FormComponentStep> = [
+  {
+    component: 'TextArea',
+    name: 'reviewNotes',
+    label: 'Details of review',
+    hint: 'include details of disclosure to individual, any updates and why renewing or ending',
+    rules: { required: true },
+  },
+];
+
+const REVIEW_DISCUSSED_WITH_MANAGER: Array<FormComponentStep> = [
+  <h3 key="manager review discussion">Review discussed with manager</h3>,
+  <span key="manager review caption" className="govuk-caption-m">
+    This Warning Note review has been discussed and agreed by the manager named
+    below
+  </span>,
+  {
+    component: 'TextInput',
+    name: 'managerName',
+    label: 'Manager’s name',
+    rules: { required: true },
+  },
+  {
+    component: 'DateInput',
+    name: 'discussedWithManagerDate',
+    label: 'Date discussed with manager',
+    rules: {
+      required: true,
+      validate: {
+        notInFuture: (value) =>
+          new Date(value).getTime() <= new Date().getTime() ||
+          "Date discussed with manager can't be in the future",
       },
-      {
-        component: 'TextArea',
-        name: 'reviewNotes',
-        label: 'Details of review',
-        hint: 'include details of disclosure to individual, any updates and why renewing or ending',
-        rules: { required: true },
-      },
-      <h3 key="manager review discussion">Review discussed with manager</h3>,
-      <span key="manager review caption" className="govuk-caption-m">
-        This Warning Note review has been discussed and agreed by the manager
-        named below
-      </span>,
-      {
-        component: 'TextInput',
-        name: 'managerName',
-        label: 'Manager’s name',
-        rules: { required: true },
-      },
-      {
-        component: 'DateInput',
-        name: 'discussedWithManagerDate',
-        label: 'Date discussed with manager',
-        rules: {
-          required: true,
-          validate: {
-            notInFuture: (value) =>
-              new Date(value).getTime() <= new Date().getTime() ||
-              "Date discussed with manager can't be in the future",
-          },
-        },
-      },
-      <h3 key="next steps">Next steps</h3>,
-      {
-        component: 'Radios',
-        name: 'reviewDecision',
-        label: 'What do you want to do?',
-        rules: {
-          required: 'Select what you want to do',
-        },
-        options: [
-          { value: 'Yes', text: 'Renew Warning Note' },
-          { value: 'No', text: 'End Warning Note' },
-        ],
-      },
-      {
-        component: 'DateInput',
-        name: 'nextReviewDate',
-        label: 'Next review date',
-        rules: {
-          required: true,
-          validate: {
-            beforeStartDate: (value) =>
-              new Date(value).getTime() >= new Date().getTime() ||
-              'Next review date cannot be earlier than today.',
-            notMoreThanOneYear: (value, { reviewDate }) =>
-              new Date(value).getTime() - new Date(reviewDate).getTime() <=
-                365 * 24 * 60 * 60 * 1000 ||
-              'Next review date cannot be more than 1 year from date review undertaken.',
-          },
-        },
-        showConditionalGuides: true,
-        hint: 'Next review date cannot be more than 1 year from date review undertaken. ',
-        conditionalRender: ({ reviewDecision, outputAsDetailedSummary }) =>
-          reviewDecision === 'Yes' || outputAsDetailedSummary === 'Yes',
-      },
-      {
-        component: 'DateInput',
-        name: 'endDate',
-        label: 'End Date',
-        conditionalRender: ({ outputAsDetailedSummary }) =>
-          outputAsDetailedSummary === 'Yes',
-      },
-      {
-        component: 'TextInput',
-        name: 'lastModifiedBy',
-        label: 'Review done by',
-        conditionalRender: ({ outputAsDetailedSummary }) =>
-          outputAsDetailedSummary === 'Yes',
-      },
+    },
+  },
+];
+
+const REVIEW_DECISION: Array<FormComponentStep> = [
+  <h3 key="next steps">Next steps</h3>,
+  {
+    component: 'Radios',
+    name: 'reviewDecision',
+    label: 'What do you want to do?',
+    rules: {
+      required: 'Select what you want to do',
+    },
+    options: [
+      { value: 'Yes', text: 'Renew Warning Note' },
+      { value: 'No', text: 'End Warning Note' },
     ],
   },
 ];
 
-export default formSteps;
+const NEXT_REVIEW_DETAILS: Array<FormComponentStep> = [
+  {
+    component: 'DateInput',
+    name: 'nextReviewDate',
+    label: 'Next review date',
+    rules: {
+      required: true,
+      validate: {
+        beforeStartDate: (value) =>
+          new Date(value).getTime() >= new Date().getTime() ||
+          'Next review date cannot be earlier than today.',
+        notMoreThanOneYear: (value, { reviewDate }) =>
+          new Date(value).getTime() - new Date(reviewDate).getTime() <=
+            365 * 24 * 60 * 60 * 1000 ||
+          'Next review date cannot be more than 1 year from date review undertaken.',
+      },
+    },
+    showConditionalGuides: true,
+    hint: 'Next review date cannot be more than 1 year from date review undertaken. ',
+    conditionalRender: ({ reviewDecision, outputAsDetailedSummary }) =>
+      reviewDecision === 'Yes' || outputAsDetailedSummary === 'Yes',
+  },
+];
+
+const DETAILS_FOR_SUMMARY_VIEW: Array<FormComponentStep> = [
+  {
+    component: 'DateInput',
+    name: 'endDate',
+    label: 'End Date',
+    conditionalRender: ({ outputAsDetailedSummary }) =>
+      outputAsDetailedSummary === 'Yes',
+  },
+  {
+    component: 'TextInput',
+    name: 'lastModifiedBy',
+    label: 'Review done by',
+    conditionalRender: ({ outputAsDetailedSummary }) =>
+      outputAsDetailedSummary === 'Yes',
+  },
+];
+
+export const reviewFormStepsAdult: FormStep[] = [
+  {
+    id: 'review-warning-note',
+    title: 'Warning Review Details',
+    components: [
+      ...REVIEW_UNDERTAKEN_DATE,
+      ...REVIEW_DISCLOSURE,
+      ...REVIEW_DETAILS,
+      ...REVIEW_DISCUSSED_WITH_MANAGER,
+      ...REVIEW_DECISION,
+      ...NEXT_REVIEW_DETAILS,
+      ...DETAILS_FOR_SUMMARY_VIEW,
+    ],
+  },
+];
+
+export const reviewFormStepsChild: FormStep[] = [
+  {
+    id: 'review-warning-note',
+    title: 'Warning Review Details',
+    components: [
+      ...REVIEW_UNDERTAKEN_DATE,
+      ...REVIEW_DETAILS,
+      ...REVIEW_DISCUSSED_WITH_MANAGER,
+      ...REVIEW_DECISION,
+      ...NEXT_REVIEW_DETAILS,
+      ...DETAILS_FOR_SUMMARY_VIEW,
+    ],
+  },
+];

--- a/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
+++ b/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
@@ -34,6 +34,7 @@ const ReviewWarningNote = (): React.ReactElement => {
             : undefined,
         status: formData.reviewDecision === 'No' ? 'closed' : 'open',
         ...formData,
+        disclosedWithIndividual: formData.disclosedWithIndividual === 'Yes',
       });
     },
     [user.email]

--- a/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
+++ b/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
@@ -5,7 +5,10 @@ import PersonView from 'components/PersonView/PersonView';
 import WarningNoteRecap from 'components/WarningNote/WarningNoteRecap/WarningNoteRecap';
 import { Resident, User } from 'types';
 import FormWizard from 'components/FormWizard/FormWizard';
-import formSteps from 'data/forms/warning-note-review';
+import {
+  reviewFormStepsAdult,
+  reviewFormStepsChild,
+} from 'data/forms/warning-note-review';
 import { useAuth } from 'components/UserContext/UserContext';
 import CustomConfirmation from 'components/Steps/ReviewWarningNoteConfirmation';
 import { updateWarningNote } from 'utils/api/warningNotes';
@@ -81,7 +84,11 @@ const ReviewWarningNote = (): React.ReactElement => {
             )}
             <FormWizard
               formPath={`/people/${personId}/warning-notes/${warningNoteId}/`}
-              formSteps={formSteps}
+              formSteps={
+                person.contextFlag === 'A'
+                  ? reviewFormStepsAdult
+                  : reviewFormStepsChild
+              }
               title="Review Warning Note"
               onFormSubmit={onFormSubmit}
               onProgressStep={handleProgressStep}


### PR DESCRIPTION
**What**  

The form for submitting an adult warning note review was not displaying a radio option component that would ask the user if they have discussed the warning note review with the individual.

## Adult Warning Note Review Form
_**Before**_
<img width="988" alt="Screenshot 2021-06-10 at 4 47 51 pm" src="https://user-images.githubusercontent.com/32823756/121556376-bbd9db80-ca0b-11eb-9fdb-32a7de855519.png">

_**After**_
<img width="1012" alt="Screenshot 2021-06-10 at 4 48 06 pm" src="https://user-images.githubusercontent.com/32823756/121556421-c4caad00-ca0b-11eb-98d3-9be19b703930.png">


**Why**  
The changes made include separating the `formSteps` used for generating the warning note review form into two:
- reviewFormStepsAdult
- reviewFormStepsChild

Previously, we used the `conditionalRender` parameter to display the `disclosure question` component depending on whether the person was an adult or child. However, this `conditionalRender` required the person object to be passed into the relevant formsStep component, and it did not seem to be picking up the person object. 
(Attempted to pass the person object in as part of the `formSteps` but couldn't get it to work 😅 )

Since this component was exclusive to Adult warning note reviews decided to separate the aformStepsa as detailed above and use the relevant formStep where required.

**Other related changes**
- Convert the value of `disclosedWithIndividual` from boolean to string answer (i.e. Yes/No) to display on the warning note review details page
- Convert `disclosedWithIndividual` form response (i.e. Yes/No) to the respective boolean when constructing the `PATCH` request.