### PR TITLE
use a more appropriate default error message

### DIFF
--- a/components/AllocatedCases/MyAllocatedCases.spec.tsx
+++ b/components/AllocatedCases/MyAllocatedCases.spec.tsx
@@ -24,7 +24,9 @@ describe(`MyAllocatedCases`, () => {
       isValidating: false,
     }));
     const { asFragment, getByText } = render(<MyAllocatedCases />);
-    getByText('Oops an error occurred');
+    getByText(
+      'There was a problem. Please refresh the page or try again later.'
+    );
     expect(asFragment()).toMatchSnapshot();
   });
   it('should render a message when there is no worker for the current user', async () => {

--- a/components/AllocatedCases/__snapshots__/MyAllocatedCases.spec.tsx.snap
+++ b/components/AllocatedCases/__snapshots__/MyAllocatedCases.spec.tsx.snap
@@ -20,7 +20,7 @@ exports[`MyAllocatedCases should render an error if the API returns a 500 1`] = 
     >
       Error:
     </span>
-     Oops an error occurred
+     There was a problem. Please refresh the page or try again later.
   </span>
 </DocumentFragment>
 `;

--- a/components/Cases/CaseRecap/__snapshots__/HistoricVisit.spec.tsx.snap
+++ b/components/Cases/CaseRecap/__snapshots__/HistoricVisit.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`HistoricNote should display historic case note 1`] = `
     >
       Error:
     </span>
-     Oops an error occurred
+     There was a problem. Please refresh the page or try again later.
   </span>
 </DocumentFragment>
 `;

--- a/components/Dashboard/__snapshots__/DashboardWrapper.spec.tsx.snap
+++ b/components/Dashboard/__snapshots__/DashboardWrapper.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`DashboardWrapper should render properly 1`] = `
         >
           Error:
         </span>
-         Oops an error occurred
+         There was a problem. Please refresh the page or try again later.
       </span>
     </div>
     <div

--- a/components/ErrorMessage/ErrorMessage.tsx
+++ b/components/ErrorMessage/ErrorMessage.tsx
@@ -6,7 +6,7 @@ export interface Props {
 }
 
 const ErrorMessage = ({
-  label = 'Oops an error occurred',
+  label = 'There was a problem. Please refresh the page or try again later.',
   className,
 }: Props): React.ReactElement => (
   <span className={cx('govuk-error-message', className)}>

--- a/components/ErrorMessage/__snapshots__/ErrorMessage.spec.tsx.snap
+++ b/components/ErrorMessage/__snapshots__/ErrorMessage.spec.tsx.snap
@@ -25,7 +25,7 @@ exports[`ErrorMessage component should render properly with the default message 
     >
       Error:
     </span>
-     Oops an error occurred
+     There was a problem. Please refresh the page or try again later.
   </span>
 </DocumentFragment>
 `;

--- a/components/Form/FieldErrorMessage/FieldErrorMessage.spec.tsx
+++ b/components/Form/FieldErrorMessage/FieldErrorMessage.spec.tsx
@@ -11,7 +11,9 @@ describe('<FieldErrorMessage />', () => {
   it('should render an unknown error if no message or type is provided on the error object', () => {
     const { getByText } = render(<FieldErrorMessage error={{}} />);
 
-    getByText('Oops an error occurred');
+    getByText(
+      'There was a problem. Please refresh the page or try again later.'
+    );
   });
 
   it('should render the provided error message if one is given', () => {

--- a/components/Search/Search.spec.jsx
+++ b/components/Search/Search.spec.jsx
@@ -123,7 +123,9 @@ describe(`Search`, () => {
         <Search {...props} type="people" />
       </UserContext.Provider>
     );
-    const errorLabel = await findByText('Oops an error occurred');
+    const errorLabel = await findByText(
+      'There was a problem. Please refresh the page or try again later.'
+    );
     expect(errorLabel).toBeInTheDocument();
   });
 

--- a/components/WorkerView/__snapshots__/WorkerSearch.spec.tsx.snap
+++ b/components/WorkerView/__snapshots__/WorkerSearch.spec.tsx.snap
@@ -83,7 +83,7 @@ exports[`WorkerSearch should display search results 1`] = `
       >
         Error:
       </span>
-       Oops an error occurred
+       There was a problem. Please refresh the page or try again later.
     </span>
     <div
       style="display: flex; justify-content: space-between;"


### PR DESCRIPTION
this professionalises our default error message

from the [gov uk design system](https://design-system.service.gov.uk/components/error-message/):

> Do not use humourous, informal language like ‘oops’
