### PR TITLE
Improve add person flow

### DIFF
--- a/components/DuplicateWarningPanel/DuplicateWarningPanel.module.scss
+++ b/components/DuplicateWarningPanel/DuplicateWarningPanel.module.scss
@@ -1,0 +1,23 @@
+@import 'lbh-frontend/lbh/base';
+
+.mutedPanel {
+  background: lbh-colour('lbh-grey-4');
+  border: 1px solid lbh-colour('lbh-grey-3');
+  padding: 25px;
+}
+
+.warningText {
+  padding: 0;
+}
+
+.text {
+  padding-left: 55px;
+}
+
+.icon {
+  margin-top: 0;
+}
+
+.actions {
+  text-align: center;
+}

--- a/components/DuplicateWarningPanel/DuplicateWarningPanel.spec.tsx
+++ b/components/DuplicateWarningPanel/DuplicateWarningPanel.spec.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import DuplicateWarningPanel from './DuplicateWarningPanel';
+import axios from 'axios';
+
+const mockResident = {
+  firstName: 'foo',
+  lastName: 'bar',
+};
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('DuplicateWarningPanel', () => {
+  it('should render nothing if there are no matching people', () => {
+    mockedAxios.get.mockResolvedValue({
+      data: { residents: [] },
+    });
+    render(<DuplicateWarningPanel newResident={mockResident} />);
+    waitFor(() => {
+      expect(axios.get).toHaveBeenCalled();
+      expect(screen.queryByText('This person may be a duplicate')).toBeNull();
+    });
+  });
+
+  it('should render matches if there are any', () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        residents: [
+          {
+            mosaicId: 1,
+            firstName: 'firstname',
+            lastName: 'surname',
+          },
+        ],
+      },
+    });
+    render(<DuplicateWarningPanel newResident={mockResident} />);
+    waitFor(() => {
+      expect(screen.getByText('This person may be a duplicate'));
+      expect(screen.queryAllByRole('row').length).toBe(1);
+    });
+  });
+});

--- a/components/DuplicateWarningPanel/DuplicateWarningPanel.spec.tsx
+++ b/components/DuplicateWarningPanel/DuplicateWarningPanel.spec.tsx
@@ -1,38 +1,39 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import DuplicateWarningPanel from './DuplicateWarningPanel';
-import axios from 'axios';
+import { useResidents } from 'utils/api/residents';
 
 const mockResident = {
   firstName: 'foo',
   lastName: 'bar',
 };
 
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock('utils/api/residents');
 
 describe('DuplicateWarningPanel', () => {
   it('should render nothing if there are no matching people', () => {
-    mockedAxios.get.mockResolvedValue({
-      data: { residents: [] },
+    (useResidents as jest.Mock).mockResolvedValue({
+      data: [{ residents: [] }],
     });
     render(<DuplicateWarningPanel newResident={mockResident} />);
     waitFor(() => {
-      expect(axios.get).toHaveBeenCalled();
+      expect(useResidents).toHaveBeenCalled();
       expect(screen.queryByText('This person may be a duplicate')).toBeNull();
     });
   });
 
   it('should render matches if there are any', () => {
-    mockedAxios.get.mockResolvedValue({
-      data: {
-        residents: [
-          {
-            mosaicId: 1,
-            firstName: 'firstname',
-            lastName: 'surname',
-          },
-        ],
-      },
+    (useResidents as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          residents: [
+            {
+              mosaicId: 1,
+              firstName: 'firstname',
+              lastName: 'surname',
+            },
+          ],
+        },
+      ],
     });
     render(<DuplicateWarningPanel newResident={mockResident} />);
     waitFor(() => {

--- a/components/DuplicateWarningPanel/DuplicateWarningPanel.tsx
+++ b/components/DuplicateWarningPanel/DuplicateWarningPanel.tsx
@@ -28,8 +28,6 @@ const DuplicateWarningPanel = ({
       .then(({ data }) => setMatchingResidents(data.residents));
   }, [newResident]);
 
-  console.log(matchingResidents);
-
   if (matchingResidents?.length > 0)
     return (
       <div className={s.mutedPanel}>

--- a/components/DuplicateWarningPanel/DuplicateWarningPanel.tsx
+++ b/components/DuplicateWarningPanel/DuplicateWarningPanel.tsx
@@ -1,9 +1,8 @@
-import { useState, useEffect } from 'react';
 import cx from 'classnames';
 import s from './DuplicateWarningPanel.module.scss';
-import { LegacyResident } from 'types';
-import axios from 'axios';
 import ResidentsTable from 'components/Search/results/ResidentsTable';
+import { useResidents } from 'utils/api/residents';
+import { LegacyResident } from 'types';
 
 interface Props {
   newResident: Record<string, unknown>;
@@ -12,23 +11,14 @@ interface Props {
 const DuplicateWarningPanel = ({
   newResident,
 }: Props): React.ReactElement | null => {
-  const [matchingResidents, setMatchingResidents] = useState<LegacyResident[]>(
-    []
-  );
+  const { data } = useResidents({
+    first_name: newResident.firstName,
+    last_name: newResident.lastName,
+  });
 
-  useEffect(() => {
-    axios
-      .get(`/api/residents`, {
-        headers: { 'x-api-key': process.env.AWS_KEY },
-        params: {
-          first_name: newResident.firstName,
-          last_name: newResident.lastName,
-        },
-      })
-      .then(({ data }) => setMatchingResidents(data.residents));
-  }, [newResident]);
+  const matchingResidents = data?.[0]?.residents as LegacyResident[];
 
-  if (matchingResidents?.length > 0)
+  if (matchingResidents?.length > 0) {
     return (
       <div className={s.mutedPanel}>
         <div
@@ -52,6 +42,7 @@ const DuplicateWarningPanel = ({
         </div>
       </div>
     );
+  }
 
   return null;
 };

--- a/components/DuplicateWarningPanel/DuplicateWarningPanel.tsx
+++ b/components/DuplicateWarningPanel/DuplicateWarningPanel.tsx
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+import cx from 'classnames';
+import s from './DuplicateWarningPanel.module.scss';
+import { LegacyResident } from 'types';
+import axios from 'axios';
+import ResidentsTable from 'components/Search/results/ResidentsTable';
+
+interface Props {
+  newResident: Record<string, unknown>;
+}
+
+const DuplicateWarningPanel = ({
+  newResident,
+}: Props): React.ReactElement | null => {
+  const [matchingResidents, setMatchingResidents] = useState<LegacyResident[]>(
+    []
+  );
+
+  useEffect(() => {
+    axios
+      .get(`/api/residents`, {
+        headers: { 'x-api-key': process.env.AWS_KEY },
+        params: {
+          first_name: newResident.firstName,
+          last_name: newResident.lastName,
+        },
+      })
+      .then(({ data }) => setMatchingResidents(data.residents));
+  }, [newResident]);
+
+  console.log(matchingResidents);
+
+  if (matchingResidents?.length > 0)
+    return (
+      <div className={s.mutedPanel}>
+        <div
+          className={cx('govuk-warning-text lbh-warning-text', s.warningText)}
+        >
+          <span
+            className={cx('govuk-warning-text__icon', s.icon)}
+            aria-hidden="true"
+          >
+            !
+          </span>
+          <div className={cx('govuk-warning-text__text', s.text)}>
+            <h2>This person may be a duplicate</h2>
+            <p>
+              The details you’ve entered match one or more people. Check that
+              the person doesn’t already exist before continuing:
+            </p>
+
+            <ResidentsTable records={matchingResidents} />
+          </div>
+        </div>
+      </div>
+    );
+
+  return null;
+};
+
+export default DuplicateWarningPanel;

--- a/components/Search/Search.jsx
+++ b/components/Search/Search.jsx
@@ -151,7 +151,7 @@ const Search = ({
               <p>Can&apos;t find a match?</p>
               <p>
                 Try narrowing your search, or{' '}
-                <Link href="/people/add">
+                <Link href={`/people/add?${getQueryString(query)}`}>
                   <a className="lbh-link lbh-link--no-visited-state">
                     add a new person
                   </a>
@@ -162,7 +162,7 @@ const Search = ({
           ) : (
             <p>
               Try widening your search, or{' '}
-              <Link href="/people/add">
+              <Link href={`/people/add?${getQueryString(query)}`}>
                 <a className="lbh-link lbh-link--no-visited-state">
                   add a new person
                 </a>

--- a/components/Steps/Summary.tsx
+++ b/components/Steps/Summary.tsx
@@ -8,6 +8,7 @@ import ErrorSummary from 'components/ErrorSummary/ErrorSummary';
 import { filterDataOnCondition } from 'utils/steps';
 import { sanitiseObject } from 'utils/objects';
 import { FormStep } from 'components/Form/types';
+import DuplicateWarningPanel from 'components/DuplicateWarningPanel/DuplicateWarningPanel';
 
 interface Props {
   formData: Record<string, unknown>;
@@ -43,6 +44,7 @@ const SummaryStep = ({
     }
     setIsSubmitting(false);
   };
+
   return (
     <div>
       <div className="lbh-table-header">
@@ -57,6 +59,9 @@ const SummaryStep = ({
         canEdit
         isSummaryCollapsable={isSummaryCollapsable}
       />
+      {formPath === '/people/add/' && (
+        <DuplicateWarningPanel newResident={formData} />
+      )}
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
         <Button
           wideButton

--- a/pages/people/add/[[...stepId]].tsx
+++ b/pages/people/add/[[...stepId]].tsx
@@ -1,4 +1,5 @@
 import { useAuth } from 'components/UserContext/UserContext';
+import { useRouter } from 'next/router';
 import FormWizard from 'components/FormWizard/FormWizard';
 import { addResident } from 'utils/api/residents';
 import CustomConfirmation from 'components/Steps/PersonConfirmation';
@@ -19,6 +20,7 @@ interface FormData {
 }
 
 const CreateNewPerson = (): React.ReactElement => {
+  const { query } = useRouter();
   const { user } = useAuth() as { user: User };
   const onFormSubmit = async (formData: FormData) => {
     const ref = await addResident({
@@ -29,13 +31,18 @@ const CreateNewPerson = (): React.ReactElement => {
     });
     return ref;
   };
+
   return (
     <FormWizard
       formPath="/people/add/"
       formSteps={formSteps}
       title="Add New Person"
       onFormSubmit={onFormSubmit}
-      defaultValues={{ user }}
+      defaultValues={{
+        user,
+        firstName: query.first_name,
+        lastName: query.last_name,
+      }}
       successMessage="Add new person confirmed"
       customConfirmation={CustomConfirmation}
       stepHeader={StepHeader}

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -1,6 +1,7 @@
 export const getProtocol = (): string =>
   process.env.NODE_ENV === 'production' ? 'https' : 'http';
 
+/** utility to convert a query string object back into a string, to assist in generating links */
 export const getQueryString = (obj: Record<string, unknown>): string =>
   Object.entries(obj).reduce(
     (acc, [key, value]) =>
@@ -12,6 +13,7 @@ export const getQueryString = (obj: Record<string, unknown>): string =>
     ''
   );
 
+/** convert a url query string into an object */
 export const parseQueryString = (str: string): Record<string, unknown> =>
   str?.split('&')?.reduce((acc, curr) => {
     const [key, value] = curr.split('=');


### PR DESCRIPTION
this builds on https://github.com/LBHackney-IT/lbh-social-care-frontend/pull/444 by adding an extra "speedbump" to the add new person flow, which warns the user about potential duplicates before they hit the confirm button.

we hope this will result in fewer duplicate people being created.

it does this by:
- adding a new `DuplicateWarningPanel` component which is fed the data that the user typed about the new person they'd like to add
- the component is rendered on the "review details" step of the add new person flow
- the component searches for potential matches with the same surname and first name as the new one, if it finds none, it renders nothing. otherwise, the user sees a prompt with a table of possible duplicates

we want to improve on this further by making enhancements to the back-end resident search algorithm

it also prefills the first name and last name on the add person form from what the user originally typed into their search, to save a little bit of time

more info: https://hackit-lbh.slack.com/archives/C021P4E5C59/p1623344339143500