### PR TITLE
fix(SCT-505): fix placement of the RESTRICTED label with new search UI

### DIFF
--- a/components/Search/results/ResidentsTable.tsx
+++ b/components/Search/results/ResidentsTable.tsx
@@ -35,9 +35,6 @@ const ResultEntry = (person: LegacyResident): React.ReactElement => {
         {dateOfBirth && new Date(dateOfBirth).toLocaleDateString('en-GB')}
       </td>
       <td className="govuk-table__cell">
-        {address?.address && truncate(address.address || '', 4)}
-      </td>
-      <td className="govuk-table__cell">
         <span className={styles.uppercase}>
           {(address && address.postcode) || ''}
         </span>
@@ -73,11 +70,9 @@ const ResultTable = ({
           Date of birth
         </th>
         <th scope="col" className="govuk-table__header">
-          Address
+          Postcode
         </th>
-        <th scope="col" className="govuk-table__header">
-          Post code
-        </th>
+        <th scope="col" className="govuk-table__header" />
       </tr>
     </thead>
     <tbody className="govuk-table__body">

--- a/components/Search/results/__snapshots__/ResidentsTable.spec.tsx.snap
+++ b/components/Search/results/__snapshots__/ResidentsTable.spec.tsx.snap
@@ -34,14 +34,12 @@ exports[`ResidentsTable component should render a list of residents 1`] = `
           class="govuk-table__header"
           scope="col"
         >
-          Address
+          Postcode
         </th>
         <th
           class="govuk-table__header"
           scope="col"
-        >
-          Post code
-        </th>
+        />
       </tr>
     </thead>
     <tbody
@@ -70,9 +68,6 @@ exports[`ResidentsTable component should render a list of residents 1`] = `
         >
           13/11/2020
         </td>
-        <td
-          class="govuk-table__cell"
-        />
         <td
           class="govuk-table__cell"
         >
@@ -123,14 +118,12 @@ exports[`ResidentsTable component should render a resident without a postcode 1`
           class="govuk-table__header"
           scope="col"
         >
-          Address
+          Postcode
         </th>
         <th
           class="govuk-table__header"
           scope="col"
-        >
-          Post code
-        </th>
+        />
       </tr>
     </thead>
     <tbody
@@ -158,11 +151,6 @@ exports[`ResidentsTable component should render a resident without a postcode 1`
           class="govuk-table__cell"
         >
           13/11/2020
-        </td>
-        <td
-          class="govuk-table__cell"
-        >
-          some address
         </td>
         <td
           class="govuk-table__cell"


### PR DESCRIPTION
**What**  
Since the new search UI went live with the dashboard, the `RESTRICTED` label has looked a little off! This removes address, and expands the header to cover the label.

### Before
![Screenshot 2021-06-11 at 15 51 14](https://user-images.githubusercontent.com/1573022/121705754-e17ae980-cacc-11eb-92b7-09a304c1ad8e.png)

### After
![Screenshot 2021-06-11 at 15 50 49](https://user-images.githubusercontent.com/1573022/121705758-e2138000-cacc-11eb-82c4-0b7a7fcce5ce.png)


**Why**  
[SCT-505](https://hackney.atlassian.net/browse/SCT-505)
