### PR TITLE
add confirmation banner component

### DIFF
--- a/components/ConfirmationBanner/ConfirmationBanner.module.scss
+++ b/components/ConfirmationBanner/ConfirmationBanner.module.scss
@@ -1,0 +1,48 @@
+@import 'lbh-frontend/lbh/base';
+
+.banner {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  text-align: left;
+  padding: 20px 25px;
+
+  * + * {
+    margin-top: 0;
+  }
+
+  svg {
+    margin-right: 25px;
+  }
+}
+
+.title {
+  color: lbh-colour('lbh-grey-4');
+  margin: 0;
+  font-weight: $lbh-font-weight-bold;
+  font-size: 1.3rem;
+  margin-bottom: 10px;
+}
+
+.body {
+  font-size: 1.1rem;
+
+  a {
+    display: block;
+    margin-top: 10px;
+
+    @include govuk-media-query($from: tablet) {
+      display: inline-block;
+      margin-left: 15px;
+      margin-bottom: 0;
+    }
+
+    color: lbh-colour('lbh-white');
+    font-weight: $lbh-font-weight-bold;
+
+    &:focus {
+      color: lbh-colour('lbh-text');
+    }
+  }
+}

--- a/components/ConfirmationBanner/ConfirmationBanner.spec.tsx
+++ b/components/ConfirmationBanner/ConfirmationBanner.spec.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import ConfirmationBanner from './ConfirmationBanner';
+
+describe('ConfirmationBanner', () => {
+  it('renders a title', () => {
+    render(<ConfirmationBanner title="Example title" />);
+    expect(screen.getByText('Example title'));
+  });
+
+  it('renders children, conditionally', () => {
+    expect(screen.queryByTestId('confirmation-banner-children')).toBeNull();
+
+    render(
+      <ConfirmationBanner title="Example title">
+        Example children
+      </ConfirmationBanner>
+    );
+    expect(screen.getByText('Example children'));
+  });
+});

--- a/components/ConfirmationBanner/ConfirmationBanner.stories.tsx
+++ b/components/ConfirmationBanner/ConfirmationBanner.stories.tsx
@@ -1,0 +1,16 @@
+import { Story } from '@storybook/react';
+
+import ConfirmationBanner, { Props } from './ConfirmationBanner';
+
+export default {
+  title: 'ConfirmationBanner',
+  component: ConfirmationBanner,
+};
+
+const Template: Story<Props> = (args) => <ConfirmationBanner {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  title: 'Submission successfuk',
+  children: 'Example body text here',
+};

--- a/components/ConfirmationBanner/ConfirmationBanner.tsx
+++ b/components/ConfirmationBanner/ConfirmationBanner.tsx
@@ -1,0 +1,26 @@
+import Icon from 'components/Icons/TickCircle';
+import s from './ConfirmationBanner.module.scss';
+
+export interface Props {
+  title: string;
+  children?: React.ReactChild;
+}
+
+const ConfirmationBanner = ({ title, children }: Props): React.ReactElement => (
+  <div
+    className={`govuk-panel govuk-panel--confirmation lbh-panel govuk-!-margin-bottom-8 ${s.banner}`}
+    role="alert"
+  >
+    <Icon />
+    <div>
+      <p className={s.title}>{title}</p>
+      {children && (
+        <div data-testid="confirmation-banner-children" className={s.body}>
+          {children}
+        </div>
+      )}
+    </div>
+  </div>
+);
+
+export default ConfirmationBanner;

--- a/components/Icons/TickCircle.tsx
+++ b/components/Icons/TickCircle.tsx
@@ -1,0 +1,19 @@
+const TickCircle = (): React.ReactElement => (
+  <svg
+    width="45"
+    height="45"
+    viewBox="0 0 45 45"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle cx="22.5" cy="22.5" r="22.5" fill="white" />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M35.625 16.575L19.1465 33.75L11.25 25.5197L14.56 22.0698L19.1465 26.8501L32.315 13.125L35.625 16.575Z"
+      fill="#00664F"
+    />
+  </svg>
+);
+
+export default TickCircle;


### PR DESCRIPTION
> suggestion for a new design pattern
> rather than the big chunky confirmation messages intended for resident-facing services, which take up a whole page, we're going to use something like this for the end of a submission on #sct-assessing-and-recording
> probably we should be consistent and use it elsewhere too.
> it would appear at the top of a page, and in our situation it would be the person page that a user is returned to

https://hackit-lbh.slack.com/archives/C022164F8GN/p1623666838005100

the component is basically a re-skinned `lbh-panel`, but with an extra `alert` aria role to suit the fact that is no longer the central protagonist of a page

this will be used for the new form builder/submissions engine we're building, but could also be used for situations like:

- creating a person
- adding a warning note
- updating a worker