### PR TITLE
Fix/open residents in new tab when adding

### DIFF
--- a/components/DuplicateWarningPanel/DuplicateWarningPanel.tsx
+++ b/components/DuplicateWarningPanel/DuplicateWarningPanel.tsx
@@ -37,7 +37,7 @@ const DuplicateWarningPanel = ({
               the person doesn’t already exist before continuing:
             </p>
 
-            <ResidentsTable records={matchingResidents} />
+            <ResidentsTable records={matchingResidents} newTab={true} />
           </div>
         </div>
       </div>

--- a/components/Search/results/ResidentsTable.tsx
+++ b/components/Search/results/ResidentsTable.tsx
@@ -4,9 +4,14 @@ import { LegacyResident, User } from 'types';
 import { canManageCases } from '../../../lib/permissions';
 import { useAuth } from '../../UserContext/UserContext';
 import styles from './ResidentsTable.module.scss';
-import { truncate } from 'lib/utils';
 
-const ResultEntry = (person: LegacyResident): React.ReactElement => {
+const ResultEntry = ({
+  person,
+  newTab,
+}: {
+  person: LegacyResident;
+  newTab?: boolean;
+}): React.ReactElement => {
   const { user } = useAuth() as { user: User };
   const { mosaicId, firstName, lastName, dateOfBirth, address, ageContext } =
     person;
@@ -25,11 +30,21 @@ const ResultEntry = (person: LegacyResident): React.ReactElement => {
     >
       <td className="govuk-table__cell">{mosaicId}</td>
       <td className="govuk-table__cell">
-        <Link href={`/people/${mosaicId}`}>
-          <a className="govuk-link govuk-custom-text-color">
+        {newTab ? (
+          <a
+            href={`/people/${mosaicId}`}
+            target="blank"
+            className="govuk-link govuk-custom-text-color"
+          >
             {firstName} {lastName}
           </a>
-        </Link>
+        ) : (
+          <Link href={`/people/${mosaicId}`}>
+            <a className="govuk-link govuk-custom-text-color">
+              {firstName} {lastName}
+            </a>
+          </Link>
+        )}
       </td>
       <td className="govuk-table__cell">
         {dateOfBirth && new Date(dateOfBirth).toLocaleDateString('en-GB')}
@@ -54,8 +69,11 @@ const ResultEntry = (person: LegacyResident): React.ReactElement => {
 
 const ResultTable = ({
   records,
+  newTab,
 }: {
   records: LegacyResident[];
+  /** whether to open residents in a new tab? */
+  newTab?: boolean;
 }): React.ReactElement => (
   <table className="govuk-table lbh-table" data-testid="residents-table">
     <thead className="govuk-table__head">
@@ -77,7 +95,7 @@ const ResultTable = ({
     </thead>
     <tbody className="govuk-table__body">
       {records.map((result) => (
-        <ResultEntry key={result.mosaicId} {...result} />
+        <ResultEntry key={result.mosaicId} person={result} newTab={newTab} />
       ))}
     </tbody>
   </table>

--- a/components/Search/results/ResidentsTable.tsx
+++ b/components/Search/results/ResidentsTable.tsx
@@ -33,7 +33,8 @@ const ResultEntry = ({
         {newTab ? (
           <a
             href={`/people/${mosaicId}`}
-            target="blank"
+            target="_blank"
+            rel="noreferrer"
             className="govuk-link govuk-custom-text-color"
           >
             {firstName} {lastName}


### PR DESCRIPTION
duplicates flagged for review when creating a new person will now open in a new tab, as a quick fix to prevent disrupting back button behaviour.

fixing the back button behaviour itself would require re-writing parts of the formwizard, which we're not keen to do because we're already about to replace it.

https://hackit-lbh.slack.com/archives/G01CYA7LM6V/p1623679740379300