### PR TITLE
feat: improve testing for worker allocation behaviour

### DIFF
--- a/components/AllocatedWorkers/AllocatedWorkers.tsx
+++ b/components/AllocatedWorkers/AllocatedWorkers.tsx
@@ -8,31 +8,11 @@ import { useAuth } from 'components/UserContext/UserContext';
 import { useAllocatedWorkers } from 'utils/api/allocatedWorkers';
 
 import { Resident, User } from 'types';
+import { canUserAllocateWorkerToPerson } from '../../lib/permissions';
 
 interface Props {
   person: Resident;
 }
-
-const canUserAllocateWorkerToPerson = (user: User, person: Resident) => {
-  if (user.hasAdminPermissions || user.hasDevPermissions) {
-    return true;
-  }
-
-  if (user.hasChildrenPermissions && person.contextFlag === 'C') {
-    // Children's doesn't require `hasAllocationsPermissions`, as anyone can allocate in CFS
-    return true;
-  }
-
-  if (
-    user.hasAdultPermissions &&
-    person.contextFlag === 'A' &&
-    (user.hasAllocationsPermissions || false)
-  ) {
-    return true;
-  }
-
-  return false;
-};
 
 const AllocatedWorkers = ({ person }: Props): React.ReactElement => {
   const { data: { allocations } = {}, error } = useAllocatedWorkers(person.id);

--- a/cypress/integration/allocate_worker.ts
+++ b/cypress/integration/allocate_worker.ts
@@ -1,0 +1,72 @@
+import { AuthRoles } from '../support/commands';
+
+describe('Allocating workers', () => {
+  describe('As a user in the Adults group', () => {
+    it('should show the allocate worker button on an adult resident if the user has allocator permissions', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('ADULT_RECORD_PERSON_ID')}`,
+        AuthRoles.AdultsAllocatorGroup
+      );
+
+      cy.contains('Allocate worker').should('be.visible');
+    });
+
+    it('should not show the allocate worker button on an adult resident if the user does not have allocator permissions', () => {
+      cy.intercept(
+        `http://localhost:3000/api/residents/${Cypress.env(
+          'ADULT_RECORD_PERSON_ID'
+        )}/allocations`
+      ).as('getAllocations');
+
+      cy.visitAs(
+        `/people/${Cypress.env('ADULT_RECORD_PERSON_ID')}`,
+        AuthRoles.AdultsGroup
+      );
+
+      cy.wait('@getAllocations');
+
+      cy.contains('Allocate worker').should('not.exist');
+    });
+
+    it('should show the allocate worker form for an adult resident if the user has allocator permissions', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('ADULT_RECORD_PERSON_ID')}/allocations/add`,
+        AuthRoles.AdultsAllocatorGroup
+      );
+
+      cy.contains('Allocate worker to');
+    });
+
+    it('should redirect away from the allocate worker form for an adult resident if the user does not have allocator permissions', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('ADULT_RECORD_PERSON_ID')}/allocations/add`,
+        AuthRoles.AdultsGroup
+      );
+
+      cy.location('pathname').should(
+        'eq',
+        `/people/${Cypress.env('ADULT_RECORD_PERSON_ID')}`
+      );
+    });
+  });
+
+  describe('As a user in the Childrens group', () => {
+    it('should show the allocate worker button on a child resident', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}`,
+        AuthRoles.ChildrensGroup
+      );
+
+      cy.contains('Allocate worker').should('be.visible');
+    });
+
+    it('should show the allocate worker form for an child resident', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}/allocations/add`,
+        AuthRoles.ChildrensGroup
+      );
+
+      cy.contains('Allocate worker to');
+    });
+  });
+});

--- a/cypress/integration/allocate_worker.ts
+++ b/cypress/integration/allocate_worker.ts
@@ -48,6 +48,18 @@ describe('Allocating workers', () => {
         `/people/${Cypress.env('ADULT_RECORD_PERSON_ID')}`
       );
     });
+
+    it('should redirect away from the allocate worker form for a childrens resident', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}/allocations/add`,
+        AuthRoles.AdultsGroup
+      );
+
+      cy.location('pathname').should(
+        'eq',
+        `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}`
+      );
+    });
   });
 
   describe('As a user in the Childrens group', () => {
@@ -67,6 +79,18 @@ describe('Allocating workers', () => {
       );
 
       cy.contains('Allocate worker to');
+    });
+
+    it('should redirect away from the allocate worker form for an adults resident', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('ADULT_RECORD_PERSON_ID')}/allocations/add`,
+        AuthRoles.ChildrensGroup
+      );
+
+      cy.location('pathname').should(
+        'eq',
+        `/people/${Cypress.env('ADULT_RECORD_PERSON_ID')}`
+      );
     });
   });
 });

--- a/lib/permissions.spec.ts
+++ b/lib/permissions.spec.ts
@@ -6,21 +6,90 @@ import {
   canManageCases,
   canViewRelationships,
   canUserViewWarningNotes,
+  canUserAllocateWorkerToPerson,
 } from './permissions';
+
+const users = {
+  none: userFactory.build({
+    hasAdminPermissions: false,
+    hasAdultPermissions: false,
+    hasChildrenPermissions: false,
+    hasUnrestrictedPermissions: false,
+    hasDevPermissions: false,
+    hasAllocationsPermissions: false,
+  }),
+  admin: userFactory.build({
+    hasAdminPermissions: true,
+    hasAdultPermissions: false,
+    hasChildrenPermissions: false,
+    hasUnrestrictedPermissions: false,
+    hasDevPermissions: false,
+    hasAllocationsPermissions: false,
+  }),
+  adminUnrestricted: userFactory.build({
+    hasAdminPermissions: true,
+    hasAdultPermissions: false,
+    hasChildrenPermissions: false,
+    hasUnrestrictedPermissions: true,
+    hasDevPermissions: false,
+    hasAllocationsPermissions: false,
+  }),
+  dev: userFactory.build({
+    hasAdminPermissions: false,
+    hasAdultPermissions: false,
+    hasChildrenPermissions: false,
+    hasUnrestrictedPermissions: false,
+    hasDevPermissions: true,
+    hasAllocationsPermissions: false,
+  }),
+  adults: userFactory.build({
+    hasAdminPermissions: false,
+    hasAdultPermissions: true,
+    hasChildrenPermissions: false,
+    hasUnrestrictedPermissions: false,
+    hasDevPermissions: false,
+    hasAllocationsPermissions: false,
+  }),
+  adultsUnrestricted: userFactory.build({
+    hasAdminPermissions: false,
+    hasAdultPermissions: true,
+    hasChildrenPermissions: false,
+    hasUnrestrictedPermissions: true,
+    hasDevPermissions: false,
+    hasAllocationsPermissions: false,
+  }),
+  adultsAllocator: userFactory.build({
+    hasAdminPermissions: false,
+    hasAdultPermissions: true,
+    hasChildrenPermissions: false,
+    hasUnrestrictedPermissions: false,
+    hasDevPermissions: false,
+    hasAllocationsPermissions: true,
+  }),
+  childrens: userFactory.build({
+    hasAdminPermissions: false,
+    hasAdultPermissions: false,
+    hasChildrenPermissions: true,
+    hasUnrestrictedPermissions: false,
+    hasDevPermissions: false,
+    hasAllocationsPermissions: false,
+  }),
+  childrensUnrestricted: userFactory.build({
+    hasAdminPermissions: false,
+    hasAdultPermissions: false,
+    hasChildrenPermissions: true,
+    hasUnrestrictedPermissions: true,
+    hasDevPermissions: false,
+    hasAllocationsPermissions: false,
+  }),
+};
 
 describe('permissions', () => {
   describe('#canUserEditPerson()', () => {
     it('should return false when the user has no permissions', () => {
       expect(
         canUserEditPerson(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.none,
           residentFactory.build({
             restricted: 'N',
             contextFlag: 'C',
@@ -32,14 +101,7 @@ describe('permissions', () => {
     it('should return true when the user is in CFS and the resident is a child', () => {
       expect(
         canUserEditPerson(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: true,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.childrens,
           residentFactory.build({
             restricted: 'N',
             contextFlag: 'C',
@@ -51,14 +113,7 @@ describe('permissions', () => {
     it('should return true when the user is in CFS, has unrestricted permissions, and the resident is a restricted child', () => {
       expect(
         canUserEditPerson(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: true,
-            hasUnrestrictedPermissions: true,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.childrensUnrestricted,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'C',
@@ -70,14 +125,7 @@ describe('permissions', () => {
     it('should return false when the user is in CFS, does not have unrestricted permissions, and the resident is a restricted child', () => {
       expect(
         canUserEditPerson(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: true,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.childrens,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'C',
@@ -89,14 +137,7 @@ describe('permissions', () => {
     it('should return true when the user is in ASC and the resident is an adult', () => {
       expect(
         canUserEditPerson(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: true,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.adults,
           residentFactory.build({
             restricted: 'N',
             contextFlag: 'A',
@@ -108,14 +149,7 @@ describe('permissions', () => {
     it('should return true when the user is in ASC, has unrestricted permissions, and the resident is a restricted adult', () => {
       expect(
         canUserEditPerson(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: true,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: true,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.adultsUnrestricted,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'A',
@@ -127,14 +161,7 @@ describe('permissions', () => {
     it('should return false when the user is in ASC, does not have unrestricted permissions, and the resident is a restricted adult', () => {
       expect(
         canUserEditPerson(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: true,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.adults,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'A',
@@ -146,14 +173,7 @@ describe('permissions', () => {
     it('should return true when the user is an admin and the resident is not restricted', () => {
       expect(
         canUserEditPerson(
-          userFactory.build({
-            hasAdminPermissions: true,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.admin,
           residentFactory.build({
             restricted: 'N',
             contextFlag: 'C',
@@ -165,14 +185,7 @@ describe('permissions', () => {
     it('should return true when the user is an admin, has unrestricted permissions, and the resident is restricted', () => {
       expect(
         canUserEditPerson(
-          userFactory.build({
-            hasAdminPermissions: true,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: true,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.adminUnrestricted,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'C',
@@ -184,14 +197,7 @@ describe('permissions', () => {
     it('should return false when the user is an admin and the resident is restricted', () => {
       expect(
         canUserEditPerson(
-          userFactory.build({
-            hasAdminPermissions: true,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.admin,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'C',
@@ -205,14 +211,7 @@ describe('permissions', () => {
     it('should return false when the user has no permissions', () => {
       expect(
         canManageCases(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.none,
           residentFactory.build({
             restricted: 'N',
             contextFlag: 'C',
@@ -224,14 +223,7 @@ describe('permissions', () => {
     it('should return true when the user is in ACS and the person is an adult', () => {
       expect(
         canManageCases(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: true,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.adults,
           residentFactory.build({
             restricted: 'N',
             contextFlag: 'A',
@@ -243,14 +235,7 @@ describe('permissions', () => {
     it('should return false when the user is in ACS and the person is a restricted adult', () => {
       expect(
         canManageCases(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: true,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.adults,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'A',
@@ -262,14 +247,7 @@ describe('permissions', () => {
     it('should return true when the user is in ACS, has unrestricted access, and the person is a restricted adult', () => {
       expect(
         canManageCases(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: true,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: true,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.adultsUnrestricted,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'A',
@@ -281,14 +259,7 @@ describe('permissions', () => {
     it('should return true when the user is in CFS and the person is a child', () => {
       expect(
         canManageCases(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: true,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.childrens,
           residentFactory.build({
             restricted: 'N',
             contextFlag: 'C',
@@ -300,14 +271,7 @@ describe('permissions', () => {
     it('should return false when the user is in CFS and the person is a restricted child', () => {
       expect(
         canManageCases(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: true,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.childrens,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'C',
@@ -319,14 +283,7 @@ describe('permissions', () => {
     it('should return true when the user is in CFS, has unrestricted access, and the person is a restricted child', () => {
       expect(
         canManageCases(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: true,
-            hasUnrestrictedPermissions: true,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.childrensUnrestricted,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'C',
@@ -338,14 +295,7 @@ describe('permissions', () => {
     it('should return true when the user is an admin and the person is not restricted', () => {
       expect(
         canManageCases(
-          userFactory.build({
-            hasAdminPermissions: true,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.admin,
           residentFactory.build({
             restricted: 'N',
             contextFlag: 'C',
@@ -357,14 +307,7 @@ describe('permissions', () => {
     it('should return false when the user is an admin and the person is restricted', () => {
       expect(
         canManageCases(
-          userFactory.build({
-            hasAdminPermissions: true,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.admin,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'C',
@@ -376,14 +319,7 @@ describe('permissions', () => {
     it('should return true when the user is an admin, has unrestricted access, and the person is restricted', () => {
       expect(
         canManageCases(
-          userFactory.build({
-            hasAdminPermissions: true,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: true,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.adminUnrestricted,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'C',
@@ -397,14 +333,7 @@ describe('permissions', () => {
     it('should return false when the user has no permissions', () => {
       expect(
         canViewRelationships(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.none,
           residentFactory.build({
             restricted: 'N',
             contextFlag: 'C',
@@ -416,14 +345,7 @@ describe('permissions', () => {
     it('should return true when the user is a dev', () => {
       expect(
         canViewRelationships(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: true,
-            hasAllocationsPermissions: false,
-          }),
+          users.dev,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'C',
@@ -435,14 +357,7 @@ describe('permissions', () => {
     it('should return true when the user has children permissions and the resident is a child', () => {
       expect(
         canViewRelationships(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: true,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.childrens,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'C',
@@ -454,14 +369,7 @@ describe('permissions', () => {
     it('should return true when the user has adult permissions and the resident is an adult', () => {
       expect(
         canViewRelationships(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: true,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.adults,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'A',
@@ -472,14 +380,7 @@ describe('permissions', () => {
     it('should return false when the user has adult permissions and the resident is a child', () => {
       expect(
         canViewRelationships(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: true,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.adults,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'C',
@@ -490,14 +391,7 @@ describe('permissions', () => {
     it('should return false when the user has children permissions and the resident is an adult', () => {
       expect(
         canViewRelationships(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: true,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          }),
+          users.childrens,
           residentFactory.build({
             restricted: 'Y',
             contextFlag: 'A',
@@ -509,34 +403,13 @@ describe('permissions', () => {
 
   describe('#canUserViewWarningNotes()', () => {
     it('should return false when the user has no permissions', () => {
-      expect(
-        canUserViewWarningNotes(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: false,
-            hasAllocationsPermissions: false,
-          })
-        )
-      ).toEqual(false);
+      expect(canUserViewWarningNotes(users.none)).toEqual(false);
     });
 
     it('should return true when the user is a dev', () => {
-      expect(
-        canUserViewWarningNotes(
-          userFactory.build({
-            hasAdminPermissions: false,
-            hasAdultPermissions: false,
-            hasChildrenPermissions: false,
-            hasUnrestrictedPermissions: false,
-            hasDevPermissions: true,
-            hasAllocationsPermissions: false,
-          })
-        )
-      ).toEqual(true);
+      expect(canUserViewWarningNotes(users.dev)).toEqual(true);
     });
+
     it('should return false when the user is not a dev', () => {
       expect(
         canUserViewWarningNotes(
@@ -547,6 +420,73 @@ describe('permissions', () => {
             hasUnrestrictedPermissions: true,
             hasDevPermissions: false,
             hasAllocationsPermissions: true,
+          })
+        )
+      ).toEqual(false);
+    });
+  });
+
+  describe('#canUserAllocateWorkerToPerson()', () => {
+    it('should return true when the user is an admin', () => {
+      expect(
+        canUserAllocateWorkerToPerson(users.admin, residentFactory.build())
+      ).toEqual(true);
+    });
+
+    it('should return true when the user is a dev', () => {
+      expect(canUserAllocateWorkerToPerson(users.dev, residentFactory.build()));
+    });
+
+    it('should return true when the user is in the childrens group and the resident is a child', () => {
+      expect(
+        canUserAllocateWorkerToPerson(
+          users.dev,
+          residentFactory.build({
+            contextFlag: 'C',
+          })
+        )
+      ).toEqual(true);
+    });
+
+    it('should return true when the user is in the adults group and the resident is an adult and the user has the allocators permission', () => {
+      expect(
+        canUserAllocateWorkerToPerson(
+          users.adultsAllocator,
+          residentFactory.build({
+            contextFlag: 'A',
+          })
+        )
+      ).toEqual(true);
+    });
+
+    it('should return false when the user is in the adults group and the resident is an adult and the user does not have the allocators permission', () => {
+      expect(
+        canUserAllocateWorkerToPerson(
+          users.adults,
+          residentFactory.build({
+            contextFlag: 'A',
+          })
+        )
+      ).toEqual(false);
+    });
+
+    it('should return false when the user is in the adults group and the resident is a child', () => {
+      expect(
+        canUserAllocateWorkerToPerson(
+          users.adults,
+          residentFactory.build({
+            contextFlag: 'C',
+          })
+        )
+      ).toEqual(false);
+    });
+
+    it('should return false when the user is in the childrens group and the resident is an adult', () => {
+      expect(
+        canUserAllocateWorkerToPerson(
+          users.childrens,
+          residentFactory.build({
+            contextFlag: 'A',
           })
         )
       ).toEqual(false);

--- a/lib/permissions.spec.ts
+++ b/lib/permissions.spec.ts
@@ -434,7 +434,9 @@ describe('permissions', () => {
     });
 
     it('should return true when the user is a dev', () => {
-      expect(canUserAllocateWorkerToPerson(users.dev, residentFactory.build()));
+      expect(
+        canUserAllocateWorkerToPerson(users.dev, residentFactory.build())
+      ).toEqual(true);
     });
 
     it('should return true when the user is in the childrens group and the resident is a child', () => {

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -65,17 +65,18 @@ export const canManageCases = (
   return false;
 };
 
-export const canUserViewWarningNotes = (user: User) => {
+export const canUserViewWarningNotes = (user: User): boolean => {
   if (user.hasDevPermissions) {
     return true;
   }
 
   return false;
 };
+
 export const canViewRelationships = (
   user: User,
   person: Pick<Resident, 'restricted' | 'contextFlag'>
-) => {
+): boolean => {
   if (user.hasDevPermissions) {
     return true;
   }
@@ -85,5 +86,29 @@ export const canViewRelationships = (
   if (user.hasChildrenPermissions && person.contextFlag === 'C') {
     return true;
   }
+  return false;
+};
+
+export const canUserAllocateWorkerToPerson = (
+  user: User,
+  person: Resident
+): boolean => {
+  if (user.hasAdminPermissions || user.hasDevPermissions) {
+    return true;
+  }
+
+  if (user.hasChildrenPermissions && person.contextFlag === 'C') {
+    // Children's doesn't require `hasAllocationsPermissions`, as anyone can allocate in CFS
+    return true;
+  }
+
+  if (
+    user.hasAdultPermissions &&
+    person.contextFlag === 'A' &&
+    (user.hasAllocationsPermissions || false)
+  ) {
+    return true;
+  }
+
   return false;
 };

--- a/pages/people/[id]/allocations/add.tsx
+++ b/pages/people/[id]/allocations/add.tsx
@@ -5,15 +5,31 @@ import AddAllocatedWorker from 'components/AllocatedWorkers/AddAllocatedWorker/A
 import PersonView from 'components/PersonView/PersonView';
 import { useAuth } from 'components/UserContext/UserContext';
 import { isBrowser } from 'utils/ssr';
+import { canUserAllocateWorkerToPerson } from '../../../../lib/permissions';
+import { User } from '../../../../types';
+import { useResident } from '../../../../utils/api/residents';
+import ErrorMessage from '../../../../components/ErrorMessage/ErrorMessage';
+import Spinner from '../../../../components/Spinner/Spinner';
 
 const AddNewAllocationPage = (): React.ReactElement => {
   const { query, replace } = useRouter();
   const personId = Number(query.id as string);
-  const { user } = useAuth();
-  if (isBrowser() && !user?.hasAllocationsPermissions) {
+  const { user } = useAuth() as { user: User };
+  const { data: person, error } = useResident(personId);
+
+  if (error) {
+    return <ErrorMessage />;
+  }
+
+  if (!person) {
+    return <Spinner />;
+  }
+
+  if (isBrowser() && !canUserAllocateWorkerToPerson(user, person)) {
     replace(`/people/${personId}`);
     return <></>;
   }
+
   return (
     <>
       <Seo title={`Allocate Worker to #${query.id} Allocate Worker`} />


### PR DESCRIPTION
**What**  
It has been raised that we were having some issues with allocating workers. As part of my investigation it seemed we didn't have many (if any) automation tests around the behaviour, especially the permissions. 

This PR:

* Refactors the logic used for rendering the allocation form to use the same permission function as rendering the "Allocate worker" button
* Adds Cypress tests for the button and add allocation form
* Adds unit tests for the updated permission method

**Why**  
To give us confidence the system works, which it does, this is just a refactor!

