### PR TITLE
SCT-511 - App redirects to login when "Clear search" is used

### DIFF
--- a/components/Search/Search.jsx
+++ b/components/Search/Search.jsx
@@ -67,10 +67,11 @@ const Search = ({
     query,
     hasQuery || showOnlyMyResults
   );
-  const results = data && {
-    records: data?.reduce((acc, d) => [...acc, ...getRecords(d)], []),
-    nextCursor: data[data.length - 1].nextCursor,
-  };
+  const results = data &&
+    data != 1 && {
+      records: data?.reduce((acc, d) => [...acc, ...getRecords(d)], []),
+      nextCursor: data[data.length - 1].nextCursor,
+    };
   const onFormSubmit = useCallback(
     (formData) => {
       const qs = formData
@@ -142,7 +143,7 @@ const Search = ({
           )
         )}
       </div>
-      {error && <ErrorMessage />}
+      {error && data != 1 && <ErrorMessage />}
 
       {type === 'people' && results && !results?.nextCursor && (
         <>

--- a/components/Search/Search.jsx
+++ b/components/Search/Search.jsx
@@ -68,7 +68,7 @@ const Search = ({
     hasQuery || showOnlyMyResults
   );
   const results = data &&
-    data != 1 && {
+    data !== 1 && {
       records: data?.reduce((acc, d) => [...acc, ...getRecords(d)], []),
       nextCursor: data[data.length - 1].nextCursor,
     };
@@ -143,7 +143,7 @@ const Search = ({
           )
         )}
       </div>
-      {error && data != 1 && <ErrorMessage />}
+      {error && data !== 1 && <ErrorMessage />}
 
       {type === 'people' && results && !results?.nextCursor && (
         <>

--- a/cypress/integration/search_for_person.ts
+++ b/cypress/integration/search_for_person.ts
@@ -33,6 +33,18 @@ describe('Search for a person', () => {
         Cypress.env('ADULT_RECORD_FULL_NAME')
       );
     });
+
+    it('should not redirect to login page after clicking "clear search" twice', () => {
+      cy.visitAs('/search', AuthRoles.ChildrensGroup);
+
+      cy.contains('First name').type(Cypress.env('ADULT_RECORD_FIRST_NAME'));
+      cy.contains('Last name').type(Cypress.env('ADULT_RECORD_LAST_NAME'));
+
+      cy.get('#clear-link').click();
+      cy.get('#clear-link').click();
+
+      cy.url().should('include', '/search');
+    });
   });
 
   describe('As a user in the Adults group', () => {


### PR DESCRIPTION
**What**  
Added  check for data != 1 (useSWRinfinite)

**Why**  
When searching for residents, and using the "Clear search" mechanism, the app redirects to the login page due to an error

This is not the definitive solution, but it will prevents the app from breaking when the user search twice