### PR TITLE
make submission api route code more readable

### DIFF
--- a/pages/api/submissions/[id]/index.ts
+++ b/pages/api/submissions/[id]/index.ts
@@ -15,13 +15,13 @@ const handler = async (
       {
         const user = isAuthorised(req);
         const status = await finishSubmission(String(id), String(user?.email));
+
         res.status(status).end();
       }
       break;
     case 'GET':
       {
         const submission = await getSubmissionById(String(id));
-
         const form = forms.find((form) => form.id === submission.formId);
 
         res.json({

--- a/pages/api/submissions/[id]/steps/[stepId].tsx
+++ b/pages/api/submissions/[id]/steps/[stepId].tsx
@@ -10,12 +10,7 @@ const handler = async (
 ): Promise<void> => {
   const { id, stepId } = req.query;
 
-  const user = isAuthorised(req);
-
-  // 1. grab submission
   const submission = await getSubmissionById(String(id));
-
-  // 2. grab this particular step from the form
   const form = forms.find((form) => form.id === submission.formId);
   const step = form?.steps.find((step) => step.id === stepId);
 
@@ -26,12 +21,15 @@ const handler = async (
 
   if (req.method === 'PATCH') {
     const values = req.body;
+    const user = isAuthorised(req);
+
     patchSubmissionForStep(
       String(id),
       String(stepId),
       String(user?.email),
       values
     );
+
     res.json(submission);
   } else {
     res.json({


### PR DESCRIPTION
might result in a miniscule performance improvement too, because we only now fetch `user` when we need it