### PR TITLE
Fix(SCT-617): Set manager fields to optional

### DIFF
--- a/components/pages/warning-notes/AddWarningNoteForm/AddWarningNoteForm.spec.tsx
+++ b/components/pages/warning-notes/AddWarningNoteForm/AddWarningNoteForm.spec.tsx
@@ -479,6 +479,36 @@ describe('<AddWarningNoteForm />', () => {
         });
       });
     });
+
+    it("should NOT show an error message if a manager's name is not entered", async () => {
+      fireEvent.submit(screen.getByRole('form'));
+
+      await waitFor(() => {
+        const errorMessageElement = screen.queryByText(
+          'Enter a manager’s name',
+          {
+            selector: '.govuk-error-message',
+          }
+        );
+
+        expect(errorMessageElement).toBeNull();
+      });
+    });
+
+    it('should NOT show an error message if a manager discussion date is not entered', async () => {
+      fireEvent.submit(screen.getByRole('form'));
+
+      await waitFor(() => {
+        const errorMessageElement = screen.queryByText(
+          'Enter a date discussed with manager',
+          {
+            selector: '.govuk-error-message',
+          }
+        );
+
+        expect(errorMessageElement).toBeNull();
+      });
+    });
   });
 
   describe('for a childrens resident', () => {

--- a/components/pages/warning-notes/AddWarningNoteForm/AddWarningNoteForm.spec.tsx
+++ b/components/pages/warning-notes/AddWarningNoteForm/AddWarningNoteForm.spec.tsx
@@ -483,7 +483,7 @@ describe('<AddWarningNoteForm />', () => {
     it("should NOT show an error message if a manager's name is not entered", async () => {
       fireEvent.submit(screen.getByRole('form'));
 
-      //Making sure screen is updated after submission attenmpt before querying
+      // Making sure screen is updated after submission attempt before querying
       await waitFor(() => {
         screen.getByText('Discussed with manager');
       });

--- a/components/pages/warning-notes/AddWarningNoteForm/AddWarningNoteForm.spec.tsx
+++ b/components/pages/warning-notes/AddWarningNoteForm/AddWarningNoteForm.spec.tsx
@@ -483,30 +483,34 @@ describe('<AddWarningNoteForm />', () => {
     it("should NOT show an error message if a manager's name is not entered", async () => {
       fireEvent.submit(screen.getByRole('form'));
 
+      //Making sure screen is updated after submission attenmpt before querying
       await waitFor(() => {
-        const errorMessageElement = screen.queryByText(
-          'Enter a manager’s name',
-          {
-            selector: '.govuk-error-message',
-          }
-        );
+        screen.getByText('Discussed with manager');
+      });
 
-        expect(errorMessageElement).toBeNull();
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Enter a manager’s name', {
+            selector: '.govuk-error-message',
+          })
+        ).toBeNull();
       });
     });
 
     it('should NOT show an error message if a manager discussion date is not entered', async () => {
       fireEvent.submit(screen.getByRole('form'));
 
+      //Making sure screen is updated after submission attenmpt before querying
       await waitFor(() => {
-        const errorMessageElement = screen.queryByText(
-          'Enter a date discussed with manager',
-          {
-            selector: '.govuk-error-message',
-          }
-        );
+        screen.getByText('Discussed with manager');
+      });
 
-        expect(errorMessageElement).toBeNull();
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Enter a date discussed with manager', {
+            selector: '.govuk-error-message',
+          })
+        ).toBeNull();
       });
     });
   });

--- a/components/pages/warning-notes/AddWarningNoteForm/AddWarningNoteForm.spec.tsx
+++ b/components/pages/warning-notes/AddWarningNoteForm/AddWarningNoteForm.spec.tsx
@@ -500,7 +500,7 @@ describe('<AddWarningNoteForm />', () => {
     it('should NOT show an error message if a manager discussion date is not entered', async () => {
       fireEvent.submit(screen.getByRole('form'));
 
-      //Making sure screen is updated after submission attenmpt before querying
+      // Making sure screen is updated after submission attempt before querying
       await waitFor(() => {
         screen.getByText('Discussed with manager');
       });

--- a/components/pages/warning-notes/AddWarningNoteForm/AddWarningNoteForm.spec.tsx
+++ b/components/pages/warning-notes/AddWarningNoteForm/AddWarningNoteForm.spec.tsx
@@ -234,26 +234,6 @@ describe('<AddWarningNoteForm />', () => {
       });
     });
 
-    it("should show an error message if a manager's name is not entered", async () => {
-      fireEvent.submit(screen.getByRole('form'));
-
-      await waitFor(() => {
-        screen.getByText('Enter a manager’s name', {
-          selector: '.govuk-error-message',
-        });
-      });
-    });
-
-    it('should show an error message if a manager discussion date is not entered', async () => {
-      fireEvent.submit(screen.getByRole('form'));
-
-      await waitFor(() => {
-        screen.getByText('Enter a date discussed with manager', {
-          selector: '.govuk-error-message',
-        });
-      });
-    });
-
     it('should show an error message if the manager discussion date entered is invalid', async () => {
       setDateFieldValue('discussedWithManagerDate', {
         date: '56',
@@ -518,6 +498,26 @@ describe('<AddWarningNoteForm />', () => {
 
     it('should render the warning notes form', () => {
       expect(renderResult.asFragment()).toMatchSnapshot();
+    });
+
+    it("should show an error message if a manager's name is not entered", async () => {
+      fireEvent.submit(screen.getByRole('form'));
+
+      await waitFor(() => {
+        screen.getByText('Enter a manager’s name', {
+          selector: '.govuk-error-message',
+        });
+      });
+    });
+
+    it('should show an error message if a manager discussion date is not entered', async () => {
+      fireEvent.submit(screen.getByRole('form'));
+
+      await waitFor(() => {
+        screen.getByText('Enter a date discussed with manager', {
+          selector: '.govuk-error-message',
+        });
+      });
     });
   });
 });

--- a/components/pages/warning-notes/AddWarningNoteForm/__snapshots__/AddWarningNoteForm.spec.tsx.snap
+++ b/components/pages/warning-notes/AddWarningNoteForm/__snapshots__/AddWarningNoteForm.spec.tsx.snap
@@ -1383,11 +1383,6 @@ exports[`<AddWarningNoteForm /> for an adults resident should render the warning
                 for="managerName"
               >
                 Manager’s name 
-                <span
-                  class="govuk-required"
-                >
-                  *
-                </span>
               </label>
               <input
                 class="govuk-input lbh-input"
@@ -1409,11 +1404,6 @@ exports[`<AddWarningNoteForm /> for an adults resident should render the warning
                 class="govuk-label"
               >
                 Date discussed with manager 
-                <span
-                  class="govuk-required"
-                >
-                  *
-                </span>
               </legend>
               <span
                 class="lbh-hint"

--- a/data/forms/warning-note-review.tsx
+++ b/data/forms/warning-note-review.tsx
@@ -35,7 +35,33 @@ const REVIEW_DETAILS: Array<FormComponentStep> = [
   },
 ];
 
-const REVIEW_DISCUSSED_WITH_MANAGER: Array<FormComponentStep> = [
+// This is optional on an adults form
+const REVIEW_DISCUSSED_WITH_MANAGER_ADULTS: Array<FormComponentStep> = [
+  <h3 key="manager review discussion">Review discussed with manager</h3>,
+  <span key="manager review caption" className="govuk-caption-m">
+    This Warning Note review has been discussed and agreed by the manager named
+    below
+  </span>,
+  {
+    component: 'TextInput',
+    name: 'managerName',
+    label: 'Manager’s name',
+  },
+  {
+    component: 'DateInput',
+    name: 'discussedWithManagerDate',
+    label: 'Date discussed with manager',
+    rules: {
+      validate: {
+        notInFuture: (value) =>
+          new Date(value).getTime() <= new Date().getTime() ||
+          "Date discussed with manager can't be in the future",
+      },
+    },
+  },
+];
+
+const REVIEW_DISCUSSED_WITH_MANAGER_CHILDREN: Array<FormComponentStep> = [
   <h3 key="manager review discussion">Review discussed with manager</h3>,
   <span key="manager review caption" className="govuk-caption-m">
     This Warning Note review has been discussed and agreed by the manager named
@@ -127,7 +153,7 @@ export const reviewFormStepsAdult: FormStep[] = [
       ...REVIEW_UNDERTAKEN_DATE,
       ...REVIEW_DISCLOSURE,
       ...REVIEW_DETAILS,
-      ...REVIEW_DISCUSSED_WITH_MANAGER,
+      ...REVIEW_DISCUSSED_WITH_MANAGER_ADULTS,
       ...REVIEW_DECISION,
       ...NEXT_REVIEW_DETAILS,
       ...DETAILS_FOR_SUMMARY_VIEW,
@@ -142,7 +168,7 @@ export const reviewFormStepsChild: FormStep[] = [
     components: [
       ...REVIEW_UNDERTAKEN_DATE,
       ...REVIEW_DETAILS,
-      ...REVIEW_DISCUSSED_WITH_MANAGER,
+      ...REVIEW_DISCUSSED_WITH_MANAGER_CHILDREN,
       ...REVIEW_DECISION,
       ...NEXT_REVIEW_DETAILS,
       ...DETAILS_FOR_SUMMARY_VIEW,

--- a/data/forms/warning-note.tsx
+++ b/data/forms/warning-note.tsx
@@ -397,6 +397,7 @@ const WARNING_NARRATIVE_CHILDREN: Array<FormComponentStep> = [
   },
 ];
 
+// This is optional on an adults form
 const DISCUSSED_WITH_MANAGER_ADULTS: Array<FormComponentStep> = [
   <div key="discussed with manager">
     <h2>Discussed with manager</h2>

--- a/data/forms/warning-note.tsx
+++ b/data/forms/warning-note.tsx
@@ -397,7 +397,34 @@ const WARNING_NARRATIVE_CHILDREN: Array<FormComponentStep> = [
   },
 ];
 
-const DISCUSSED_WITH_MANAGER: Array<FormComponentStep> = [
+const DISCUSSED_WITH_MANAGER_ADULTS: Array<FormComponentStep> = [
+  <div key="discussed with manager">
+    <h2>Discussed with manager</h2>
+    <div className="govuk-body">
+      Adding this Warning Note has been discussed and agreed by the manager
+      named below.
+    </div>
+  </div>,
+  {
+    component: 'TextInput',
+    name: 'managerName',
+    label: 'Manager’s name',
+  },
+  {
+    component: 'DateInput',
+    name: 'discussedWithManagerDate',
+    label: 'Date discussed with manager',
+    rules: {
+      validate: {
+        notInFuture: (value) =>
+          new Date(value).getTime() <= new Date().getTime() ||
+          "Date discussed with manager can't be in the future",
+      },
+    },
+  },
+];
+
+const DISCUSSED_WITH_MANAGER_CHILDREN: Array<FormComponentStep> = [
   <div key="discussed with manager">
     <h2>Discussed with manager</h2>
     <div className="govuk-body">
@@ -436,7 +463,7 @@ export const formStepsAdult: FormStep[] = [
       ...WARNING_DATES,
       ...WARNING_DISCLOSURE,
       ...WARNING_NARRATIVE_ADULTS,
-      ...DISCUSSED_WITH_MANAGER,
+      ...DISCUSSED_WITH_MANAGER_ADULTS,
     ],
   },
 ];
@@ -450,7 +477,7 @@ export const formStepsChild: FormStep[] = [
       ...WARNING_TYPE_CHILDREN,
       ...WARNING_DATES,
       ...WARNING_NARRATIVE_CHILDREN,
-      ...DISCUSSED_WITH_MANAGER,
+      ...DISCUSSED_WITH_MANAGER_CHILDREN,
     ],
   },
 ];


### PR DESCRIPTION
**What**  
Make the `Manager's Name` and `Discussed With Manager` fields optional for ASC warning notes.

**Before: (Both fields required on a ASC warning note form)**
<img width="997" alt="Screenshot 2021-06-18 at 11 19 30 am" src="https://user-images.githubusercontent.com/32823756/122546649-159f5e80-d027-11eb-978e-bef0c52399d6.png">

**After: (Both now optional)**
<img width="1017" alt="Screenshot 2021-06-18 at 11 18 47 am" src="https://user-images.githubusercontent.com/32823756/122546767-32d42d00-d027-11eb-9652-f19f8a6fe05b.png">

**Why**  
Request from a stakeholder review was that the two manager fields on an ASC warning note be set to optional.

**Anything else?**

Test in staging