### PR TITLE
SCT-590 - Moved API endpoint to V1

### DIFF
--- a/lib/relationships.spec.ts
+++ b/lib/relationships.spec.ts
@@ -17,7 +17,7 @@ describe('relationships APIs', () => {
       const data = await relationshipsAPI.getRelationshipByResident(123);
       expect(mockedAxios.get).toHaveBeenCalled();
       expect(mockedAxios.get.mock.calls[0][0]).toEqual(
-        `${ENDPOINT_API}/residents/123/relationships`
+        `${ENDPOINT_API}/residents/123/relationships-v1`
       );
       expect(mockedAxios.get.mock.calls[0][1]?.headers).toEqual({
         'x-api-key': AWS_KEY,

--- a/lib/relationships.ts
+++ b/lib/relationships.ts
@@ -7,7 +7,7 @@ export const getRelationshipByResident = async (
   personId: number
 ): Promise<RelationshipData[] | []> => {
   const { data }: { data: RelationshipData[] } = await axios.get(
-    `${ENDPOINT_API}/residents/${personId}/relationships`,
+    `${ENDPOINT_API}/residents/${personId}/relationships-v1`,
     {
       headers,
     }


### PR DESCRIPTION
**What**  
Changed the Relationship call in the frontend to use the v1 endpoint

**Why**  
To keep functionality working while we work on the relationship
