### PR TITLE
redirect to finished submission on completion

### DIFF
--- a/pages/submissions/[id]/index.tsx
+++ b/pages/submissions/[id]/index.tsx
@@ -104,6 +104,15 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
       },
     };
 
+  if (data.submissionState !== 'In progress') {
+    return {
+      props: {},
+      redirect: {
+        destination: `/people/${data.residents[0].id}/submissions/${data.submissionId}`,
+      },
+    };
+  }
+
   return {
     props: {
       params,

--- a/pages/submissions/[id]/steps/[stepId].tsx
+++ b/pages/submissions/[id]/steps/[stepId].tsx
@@ -137,6 +137,15 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
     };
   }
 
+  if (data.submissionState !== 'In progress') {
+    return {
+      props: {},
+      redirect: {
+        destination: `/people/${data.residents[0].id}/submissions/${data.submissionId}`,
+      },
+    };
+  }
+
   return {
     props: {
       params,


### PR DESCRIPTION
Co-authored-by: Ana Bebic <anabebs@users.noreply.github.com>

**What**  
create redirect on the answers page of a submission so that a user is not able to edit already submitted forms. 

