### PR TITLE
add address display to form answers page

### DIFF
--- a/components/PersonWidget/PersonWidget.spec.tsx
+++ b/components/PersonWidget/PersonWidget.spec.tsx
@@ -19,6 +19,7 @@ describe('PersonWidget', () => {
     expect(getByText('Foo Bar'));
     expect(getByText('Born 13 Nov 2020'));
     expect(queryByText('FLAT 10, GEORGE LEYBOURNE HOUSE, FLETCHER STREET'));
+    expect(queryByText('E1 8HW'));
   });
 
   it('renders correctly when there is no person', () => {

--- a/components/PersonWidget/PersonWidget.tsx
+++ b/components/PersonWidget/PersonWidget.tsx
@@ -23,7 +23,6 @@ const PersonWidget = ({ person }: Props): React.ReactElement => {
   const displayAddresses = person?.addresses?.[0];
 
   if (person) {
-    console.log(displayPostcode);
     return (
       <aside className={s.aside}>
         <h2 className={`lbh-heading-h3 ${s.title}`}>
@@ -32,11 +31,14 @@ const PersonWidget = ({ person }: Props): React.ReactElement => {
         {dateOfBirth && (
           <p className={`lbh-body-s ${s.paragraph}`}>Born {dateOfBirth}</p>
         )}
-        <p className={`lbh-body-s ${s.paragraph}`}>
-          {displayAddress || displayAddresses?.addressLines}
-          <br />
-          {displayPostcode || displayAddresses?.postCode}
-        </p>
+        {displayAddress ||
+          (displayAddresses && (
+            <p className={`lbh-body-s ${s.paragraph}`}>
+              {displayAddress || displayAddresses?.addressLines}
+              <br />
+              {displayPostcode || displayAddresses?.postCode}
+            </p>
+          ))}
       </aside>
     );
   }

--- a/components/PersonWidget/PersonWidget.tsx
+++ b/components/PersonWidget/PersonWidget.tsx
@@ -18,9 +18,12 @@ interface Props {
 
 const PersonWidget = ({ person }: Props): React.ReactElement => {
   const dateOfBirth = prettyDate(person?.dateOfBirth ?? '');
-  const displayAddress = person?.address || person?.addresses?.[0];
+  const displayAddress = person?.address?.address;
+  const displayPostcode = person?.address?.postcode;
+  const displayAddresses = person?.addresses?.[0];
 
   if (person) {
+    console.log(displayPostcode);
     return (
       <aside className={s.aside}>
         <h2 className={`lbh-heading-h3 ${s.title}`}>
@@ -29,14 +32,11 @@ const PersonWidget = ({ person }: Props): React.ReactElement => {
         {dateOfBirth && (
           <p className={`lbh-body-s ${s.paragraph}`}>Born {dateOfBirth}</p>
         )}
-
-        {displayAddress && (
-          <p className={`lbh-body-s ${s.paragraph}`}>
-            {displayAddress.addressLines || displayAddress.address}
-            <br />
-            {displayAddress.postCode || displayAddress.postcode}
-          </p>
-        )}
+        <p className={`lbh-body-s ${s.paragraph}`}>
+          {displayAddress || displayAddresses?.addressLines}
+          <br />
+          {displayPostcode || displayAddresses?.postCode}
+        </p>
       </aside>
     );
   }

--- a/components/PersonWidget/PersonWidget.tsx
+++ b/components/PersonWidget/PersonWidget.tsx
@@ -18,9 +18,9 @@ interface Props {
 
 const PersonWidget = ({ person }: Props): React.ReactElement => {
   const dateOfBirth = prettyDate(person?.dateOfBirth ?? '');
-  const displayAddress = person?.address?.address;
-  const displayPostcode = person?.address?.postcode;
-  const displayAddresses = person?.addresses?.[0];
+  const displayAddress = person?.address || person?.addresses?.[0];
+  const displayPostcode =
+    person?.address?.postcode || person?.addresses?.[0].postCode;
 
   if (person) {
     return (
@@ -31,14 +31,13 @@ const PersonWidget = ({ person }: Props): React.ReactElement => {
         {dateOfBirth && (
           <p className={`lbh-body-s ${s.paragraph}`}>Born {dateOfBirth}</p>
         )}
-        {displayAddress ||
-          (displayAddresses && (
-            <p className={`lbh-body-s ${s.paragraph}`}>
-              {displayAddress || displayAddresses?.addressLines}
-              <br />
-              {displayPostcode || displayAddresses?.postCode}
-            </p>
-          ))}
+        {displayAddress && (
+          <p className={`lbh-body-s ${s.paragraph}`}>
+            {displayAddress}
+            <br />
+            {displayPostcode}
+          </p>
+        )}
       </aside>
     );
   }

--- a/components/PersonWidget/PersonWidget.tsx
+++ b/components/PersonWidget/PersonWidget.tsx
@@ -18,8 +18,7 @@ interface Props {
 
 const PersonWidget = ({ person }: Props): React.ReactElement => {
   const dateOfBirth = prettyDate(person?.dateOfBirth ?? '');
-
-  const displayAddress = person?.addresses?.[0];
+  const displayAddress = person?.address || person?.addresses?.[0];
 
   if (person) {
     return (
@@ -33,9 +32,9 @@ const PersonWidget = ({ person }: Props): React.ReactElement => {
 
         {displayAddress && (
           <p className={`lbh-body-s ${s.paragraph}`}>
-            {displayAddress.addressLines}
+            {displayAddress.addressLines || displayAddress.address}
             <br />
-            {displayAddress.postCode}
+            {displayAddress.postCode || displayAddress.postcode}
           </p>
         )}
       </aside>

--- a/components/PersonWidget/PersonWidget.tsx
+++ b/components/PersonWidget/PersonWidget.tsx
@@ -18,9 +18,8 @@ interface Props {
 
 const PersonWidget = ({ person }: Props): React.ReactElement => {
   const dateOfBirth = prettyDate(person?.dateOfBirth ?? '');
-  const displayAddress = person?.address || person?.addresses?.[0];
-  const displayPostcode =
-    person?.address?.postcode || person?.addresses?.[0].postCode;
+  const displayAddress = person?.address;
+  const firstAddress = person?.addresses?.[0];
 
   if (person) {
     return (
@@ -33,9 +32,16 @@ const PersonWidget = ({ person }: Props): React.ReactElement => {
         )}
         {displayAddress && (
           <p className={`lbh-body-s ${s.paragraph}`}>
-            {displayAddress}
+            {displayAddress?.address}
             <br />
-            {displayPostcode}
+            {displayAddress?.postcode}
+          </p>
+        )}
+        {firstAddress && (
+          <p className={`lbh-body-s ${s.paragraph}`}>
+            {firstAddress?.addressLines}
+            <br />
+            {firstAddress?.postCode}
           </p>
         )}
       </aside>

--- a/components/PersonWidget/__snapshots__/PersonWidget.spec.tsx.snap
+++ b/components/PersonWidget/__snapshots__/PersonWidget.spec.tsx.snap
@@ -15,6 +15,11 @@ exports[`PersonWidget should render properly 1`] = `
     >
       Born 13 Nov 2020
     </p>
+    <p
+      class="lbh-body-s paragraph"
+    >
+      <br />
+    </p>
   </aside>
 </DocumentFragment>
 `;

--- a/components/PersonWidget/__snapshots__/PersonWidget.spec.tsx.snap
+++ b/components/PersonWidget/__snapshots__/PersonWidget.spec.tsx.snap
@@ -18,7 +18,9 @@ exports[`PersonWidget should render properly 1`] = `
     <p
       class="lbh-body-s paragraph"
     >
+      sjakdjlk
       <br />
+      hdsadjk
     </p>
   </aside>
 </DocumentFragment>

--- a/factories/residents.ts
+++ b/factories/residents.ts
@@ -26,6 +26,10 @@ export const residentFactory = Factory.define<Resident>(({ sequence }) => ({
   otherNames: [],
   phoneNumbers: [],
   addresses: [],
+  address: {
+    address: 'sjakdjlk',
+    postcode: 'hdsadjk',
+  },
 }));
 
 export const mockedLegacyResident = legacyResidentFactory.build();

--- a/lib/residents.spec.ts
+++ b/lib/residents.spec.ts
@@ -145,6 +145,10 @@ describe('residents APIs', () => {
           { number: '12321', type: 'qwe' },
           { number: '321321', type: 'main' },
         ],
+        address: {
+          address: 'sjakdjlk',
+          postcode: 'hdsadjk',
+        },
         addresses: [],
         contextFlag: 'A',
         createdBy: 'foo@bar.com',


### PR DESCRIPTION
**What**  
small PR to update the person widget so that it uses both address and addresses when required.
This will fix the problem of the address not displaying on the form answers page.
