### PR TITLE
show submissions in records table

### DIFF
--- a/components/Cases/CaseLink.spec.tsx
+++ b/components/Cases/CaseLink.spec.tsx
@@ -9,6 +9,8 @@ describe('CaseLink component', () => {
       recordId: '123',
       externalUrl: 'https://foo.bar',
       caseFormData: mockedDeallocationNote.caseFormData,
+      personId: 1,
+      formName: 'foo',
     };
     const { asFragment } = render(<CaseLink {...props} />);
     expect(asFragment()).toMatchInlineSnapshot(`
@@ -29,6 +31,8 @@ describe('CaseLink component', () => {
     const props = {
       recordId: '123',
       caseFormData: mockedDeallocationNote.caseFormData,
+      personId: 1,
+      formName: 'foo',
     };
     const { asFragment } = render(<CaseLink {...props} />);
     expect(asFragment()).toMatchInlineSnapshot(`
@@ -50,6 +54,8 @@ describe('CaseLink component', () => {
         ...mockedDeallocationNote.caseFormData,
         form_name_overall: '',
       },
+      personId: 1,
+      formName: 'foo',
     };
     const { asFragment } = render(<CaseLink {...props} />);
     expect(asFragment()).toMatchInlineSnapshot(`<DocumentFragment />`);
@@ -62,6 +68,8 @@ describe('CaseLink component', () => {
         ...mockedWarningNoteCase.caseFormData,
         form_name: 'Warning Note Created',
       },
+      personId: 1,
+      formName: 'foo',
     };
     const { asFragment } = render(<CaseLink {...props} />);
     expect(asFragment()).toMatchSnapshot();

--- a/components/Cases/CaseLink.spec.tsx
+++ b/components/Cases/CaseLink.spec.tsx
@@ -14,7 +14,7 @@ describe('CaseLink component', () => {
     expect(asFragment()).toMatchInlineSnapshot(`
       <DocumentFragment>
         <a
-          class="govuk-link lbh-link"
+          class="lbh-link"
           href="https://foo.bar"
           rel="noreferrer noopener"
           target="_blank"
@@ -34,7 +34,7 @@ describe('CaseLink component', () => {
     expect(asFragment()).toMatchInlineSnapshot(`
       <DocumentFragment>
         <a
-          class="govuk-link lbh-link"
+          class="lbh-link"
           href="/people/123/allocations/321?recordId=123"
         >
           View

--- a/components/Cases/CaseLink.tsx
+++ b/components/Cases/CaseLink.tsx
@@ -7,7 +7,6 @@ import {
   DeallocationCaseFormData,
   WarningNoteCaseFormData,
 } from 'types';
-import { isLocalURL } from 'next/dist/next-server/lib/router/router';
 
 const getWarningNoteDetailsPageName = (form_name: string) => {
   switch (form_name) {

--- a/components/Cases/CaseLink.tsx
+++ b/components/Cases/CaseLink.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-
+import forms from 'data/flexibleForms';
 import * as form from 'data/forms';
 import {
   AllocationCaseFormData,
@@ -7,6 +7,7 @@ import {
   DeallocationCaseFormData,
   WarningNoteCaseFormData,
 } from 'types';
+import { isLocalURL } from 'next/dist/next-server/lib/router/router';
 
 const getWarningNoteDetailsPageName = (form_name: string) => {
   switch (form_name) {
@@ -55,20 +56,32 @@ interface Props {
   recordId: string;
   externalUrl?: string;
   caseFormData: CaseFormData;
+  formName: string;
+  personId: number;
 }
 
 const CaseLink = ({
-  recordId,
+  formName,
   externalUrl,
   caseFormData,
+  recordId,
+  personId,
 }: Props): React.ReactElement | null => {
+  const form = forms.find((form) => form.id === formName);
+  if (form)
+    return (
+      <Link href={`/people/${personId}/submissions/${recordId}`}>
+        <a className="lbh-link">View</a>
+      </Link>
+    );
+
   if (externalUrl) {
     return (
       <a
         href={externalUrl}
         target="_blank"
         rel="noreferrer noopener"
-        className="govuk-link lbh-link"
+        className="lbh-link"
       >
         View
       </a>
@@ -77,7 +90,7 @@ const CaseLink = ({
   const internalLink = getLink(recordId, caseFormData);
   return internalLink ? (
     <Link href={internalLink}>
-      <a className="govuk-link lbh-link">View</a>
+      <a className="lbh-link">View</a>
     </Link>
   ) : null;
 };

--- a/components/Cases/Cases.spec.tsx
+++ b/components/Cases/Cases.spec.tsx
@@ -46,7 +46,7 @@ describe('Cases component', () => {
     await waitFor(() => {
       expect(asFragment()).toMatchSnapshot();
     });
-    const button = getByRole('button', { name: 'load more' });
+    const button = getByRole('button', { name: 'Load more' });
     expect(getAllByText('View')).toHaveLength(2);
     fireEvent.click(button);
     expect(mockSetSize).toHaveBeenCalled();

--- a/components/Cases/Cases.tsx
+++ b/components/Cases/Cases.tsx
@@ -50,7 +50,7 @@ const Cases = ({ id }: Props): React.ReactElement => {
           <Spinner />
         ) : (
           results.nextCursor && (
-            <Button label="load more" onClick={() => setSize(size + 1)} />
+            <Button label="Load more" onClick={() => setSize(size + 1)} />
           )
         )}
       </div>

--- a/components/Cases/CasesTable.tsx
+++ b/components/Cases/CasesTable.tsx
@@ -1,3 +1,4 @@
+import forms from 'data/flexibleForms';
 import { Case } from 'types';
 import { formatDate, isDateValid } from 'utils/date';
 
@@ -20,21 +21,31 @@ const CaseNoteDate = ({ dateOfEvent, caseFormTimestamp }: Case) => (
   </td>
 );
 
-const CaseNoteTitle = ({ formName, caseFormData }: Case) => (
-  <td key="title" className="govuk-table__cell">
-    {
-      <>
-        {['ASC_case_note', 'CFS_case_note'].includes(
-          caseFormData.form_name_overall
-        ) && 'Case Note - '}
-        {formName}
-        {caseFormData.case_note_title && (
-          <div>{caseFormData.case_note_title}</div>
-        )}
-      </>
-    }
-  </td>
-);
+const CaseNoteTitle = ({ formName, caseFormData }: Case) => {
+  // 1. handle case notes
+  if (
+    ['ASC_case_note', 'CFS_case_note'].includes(
+      caseFormData?.form_name_overall
+    ) &&
+    'Case Note - '
+  )
+    return (
+      <td className="govuk-table__cell">
+        Case note: {formName}
+        <br />
+        <p className="lbh-body-s govuk-!-margin-top-2">
+          {caseFormData?.case_note_title}
+        </p>
+      </td>
+    );
+
+  // 2. handle flexible form submissions
+  const form = forms.find((form) => form.id === formName);
+  if (form) return <td className="govuk-table__cell">{form.name}</td>;
+
+  // 3. handle everything else
+  return <td className="govuk-table__cell">{formName}</td>;
+};
 
 const CaseNoteOfficer = ({ officerEmail }: Case) => (
   <td key="officer" className="govuk-table__cell">
@@ -42,7 +53,13 @@ const CaseNoteOfficer = ({ officerEmail }: Case) => (
   </td>
 );
 
-const CaseNoteAction = ({ recordId, caseFormUrl, caseFormData }: Case) => (
+const CaseNoteAction = ({
+  recordId,
+  caseFormUrl,
+  caseFormData,
+  formName,
+  personId,
+}: Case) => (
   <td
     key="action"
     className="govuk-table__cell govuk-table__cell--numeric"
@@ -52,6 +69,8 @@ const CaseNoteAction = ({ recordId, caseFormUrl, caseFormData }: Case) => (
       recordId={recordId}
       externalUrl={caseFormUrl}
       caseFormData={caseFormData}
+      formName={formName}
+      personId={personId}
     />
   </td>
 );
@@ -70,7 +89,7 @@ const CaseNoteBirthday = ({ dateOfBirth }: Case) => (
 
 const tableEntities = {
   person_id: { text: 'Person ID', component: CaseNotePersonId },
-  first_name: { text: 'Client Name', component: CaseNoteName },
+  first_name: { text: 'Client name', component: CaseNoteName },
   date_of_birth: { text: 'Date of birth', component: CaseNoteBirthday },
   date_of_event: { text: 'Date created', component: CaseNoteDate },
   formName: { text: 'Record type', component: CaseNoteTitle },

--- a/components/Cases/__snapshots__/CaseLink.spec.tsx.snap
+++ b/components/Cases/__snapshots__/CaseLink.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CaseLink component should render properly - with handled link for viewing warning notes 1`] = `
 <DocumentFragment>
   <a
-    class="govuk-link lbh-link"
+    class="lbh-link"
     href="/people/123/warning-notes/456/view/note-created"
   >
     View

--- a/components/Cases/__snapshots__/Cases.spec.tsx.snap
+++ b/components/Cases/__snapshots__/Cases.spec.tsx.snap
@@ -85,7 +85,7 @@ exports[`Cases component should render no records  1`] = `
         class="lbh-button govuk-button"
         data-module="govuk-button"
       >
-        load more
+        Load more
       </button>
     </div>
   </div>
@@ -182,7 +182,7 @@ exports[`Cases component should render records properly 1`] = `
             style="width: 50px; text-align: center;"
           >
             <a
-              class="govuk-link lbh-link"
+              class="lbh-link"
               href="https://foo.bar"
               rel="noreferrer noopener"
               target="_blank"
@@ -215,7 +215,7 @@ exports[`Cases component should render records properly 1`] = `
             style="width: 50px; text-align: center;"
           >
             <a
-              class="govuk-link lbh-link"
+              class="lbh-link"
               href="/people/123/allocations/321?recordId=2"
             >
               View
@@ -231,7 +231,7 @@ exports[`Cases component should render records properly 1`] = `
         class="lbh-button govuk-button"
         data-module="govuk-button"
       >
-        load more
+        Load more
       </button>
     </div>
   </div>
@@ -278,7 +278,7 @@ exports[`Cases component should work properly if person is restricted but user.h
         class="lbh-button govuk-button"
         data-module="govuk-button"
       >
-        load more
+        Load more
       </button>
     </div>
   </div>

--- a/components/Cases/__snapshots__/CasesTable.spec.tsx.snap
+++ b/components/Cases/__snapshots__/CasesTable.spec.tsx.snap
@@ -64,7 +64,7 @@ exports[`CasesTable component should render properly 1`] = `
           style="width: 50px; text-align: center;"
         >
           <a
-            class="govuk-link lbh-link"
+            class="lbh-link"
             href="https://foo.bar"
             rel="noreferrer noopener"
             target="_blank"
@@ -97,7 +97,7 @@ exports[`CasesTable component should render properly 1`] = `
           style="width: 50px; text-align: center;"
         >
           <a
-            class="govuk-link lbh-link"
+            class="lbh-link"
             href="/people/123/allocations/321?recordId=2"
           >
             View
@@ -116,10 +116,13 @@ exports[`CasesTable component should render properly 1`] = `
         <td
           class="govuk-table__cell"
         >
-          Case Note - foorm
-          <div>
+          Case note: foorm
+          <br />
+          <p
+            class="lbh-body-s govuk-!-margin-top-2"
+          >
             i am a case title
-          </div>
+          </p>
         </td>
         <td
           class="govuk-table__cell"
@@ -131,7 +134,7 @@ exports[`CasesTable component should render properly 1`] = `
           style="width: 50px; text-align: center;"
         >
           <a
-            class="govuk-link lbh-link"
+            class="lbh-link"
             href="/people/123/records/4"
           >
             View

--- a/components/Search/Search.spec.jsx
+++ b/components/Search/Search.spec.jsx
@@ -69,7 +69,7 @@ describe(`Search`, () => {
     );
     const searchResult = await findByText('PEOPLE SEARCH RESULT');
     expect(searchResult).toBeInTheDocument();
-    expect(queryByText('load more')).not.toBeInTheDocument();
+    expect(queryByText('Load more')).not.toBeInTheDocument();
   });
 
   it('should update the queryString on search and run a new search', async () => {


### PR DESCRIPTION
modify the records table code to show submissions made with the new flexible form builder.

essentially, it works by grabbing the `recordName`, checks whether it matches the id of any of the configured flexible forms, and if so, treats it as a flexible form submission.

if not, the existing logic applies.

it also makes some minor tweaks to use sentence case.