### PR TITLE
launch the new review 3c form!

### DIFF
--- a/components/AddForm/AddForm.tsx
+++ b/components/AddForm/AddForm.tsx
@@ -6,6 +6,7 @@ import { Autocomplete } from 'components/Form/Autocomplete/Autocomplete';
 import { populateChildForm } from 'utils/populate';
 import ADULT_FORMS from 'data/googleForms/adultForms';
 import CHILD_FORMS from 'data/googleForms/childForms';
+import flexibleForms from 'data/flexibleForms';
 import { Resident, User } from 'types';
 
 const AddForm = ({ person }: { person: Resident }): React.ReactElement => {
@@ -14,7 +15,7 @@ const AddForm = ({ person }: { person: Resident }): React.ReactElement => {
   const ageContext = person && person.contextFlag;
   const forms = ageContext === 'C' ? CHILD_FORMS : ADULT_FORMS;
 
-  const internalForms = [
+  let internalForms = [
     ageContext === 'A' && {
       text: 'Case Note Recording',
       value: `/people/${person.id}/records/case-notes-recording`,
@@ -27,6 +28,16 @@ const AddForm = ({ person }: { person: Resident }): React.ReactElement => {
     text: string;
     value: string;
   }[];
+
+  // handle new flexible forms
+  if (ageContext === 'A') {
+    internalForms = internalForms.concat(
+      flexibleForms.map((form) => ({
+        text: form.name,
+        value: `/submissions/new?social_care_id=${person.id}&form_id=${form.id}`,
+      }))
+    );
+  }
 
   return (
     <>

--- a/data/googleForms/adultForms.ts
+++ b/data/googleForms/adultForms.ts
@@ -42,12 +42,6 @@ export default [
     category: 'Information Assessment',
   },
   {
-    text: 'Review of Care and Support Plan',
-    value:
-      'https://docs.google.com/forms/d/e/1FAIpQLSdfdu9TIGu6KoNFGu9gBlWj170MvoeCNeNay8IHmvBkeffjaA/viewform',
-    category: 'Information Assessment',
-  },
-  {
     text: 'Conversation 1',
     value:
       'https://docs.google.com/forms/d/e/1FAIpQLSdcITf67BouyUDCulb0oaSOyU1vSiqGC2qxmg_4GHBdV7we7A/viewform',


### PR DESCRIPTION
this launches the new flexible form builder by making the new review 3c form accessible from `dev.hackney.gov.uk:3000/people/1/records`, effectively removing the feature flag for the feature.

out first few forms will be adults, so we check for an adults `ageContext` before showing the new options.

when we branch out into children's forms too, we should refactor the way this works, likely by adding an availability key to each form's config indicating who it should be available to