### PR TITLE
fix/weird top margin

### DIFF
--- a/stylesheets/all.scss
+++ b/stylesheets/all.scss
@@ -10,6 +10,10 @@ $screen-sm-min: 576px;
   font-family: Open Sans, Arial, sans-serif !important;
 }
 
+#__next {
+  margin-top: 0;
+}
+
 [role='button'] {
   cursor: pointer;
 }


### PR DESCRIPTION
the design system uses default margins between sibling elements to establish sensible layout defaults.

we put a `<noscript/>` tag above the entire app in some recent work, and now the entire app has a margin across the top of it.

this removes that.