### PR TITLE
feature/only return submissions from current service on dashboard

### DIFF
--- a/components/SubmissionsTable/index.spec.tsx
+++ b/components/SubmissionsTable/index.spec.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { mockSubmission } from 'factories/submissions';
 import SubmissionsTable from './index';
 import { useAuth } from 'components/UserContext/UserContext';
+import { mockedResident } from 'factories/residents';
 
 jest.mock('components/UserContext/UserContext');
 
@@ -16,6 +17,26 @@ describe('SubmissionsTable', () => {
     render(<SubmissionsTable submissions={[]} />);
     expect(screen.queryAllByRole('listitem').length).toBe(0);
     expect(screen.getByText('No unfinished submissions to show'));
+  });
+
+  it('hides restricted records', () => {
+    render(
+      <SubmissionsTable
+        submissions={[
+          {
+            ...mockSubmission,
+            residents: [
+              {
+                ...mockedResident,
+                restricted: 'Y',
+              },
+            ],
+          },
+        ]}
+      />
+    );
+
+    expect(screen.queryAllByRole('listitem').length).toBe(0);
   });
 
   it("correctly renders user's own submissions", () => {

--- a/components/SubmissionsTable/index.tsx
+++ b/components/SubmissionsTable/index.tsx
@@ -72,6 +72,13 @@ export const SubmissionsTable = ({
   const [searchQuery, setSearchQuery] = useState<string>('');
 
   const filteredSubmissions = submissions.filter((submission) => {
+    // hide any restricted records unless the user has permission to see them
+    if (
+      !user?.hasUnrestrictedPermissions &&
+      submission.residents.every((resident) => resident.restricted === 'Y')
+    )
+      return false;
+
     // Filter out those that don't match the search term
     const haystack = `${submission.residents[0].id} ${submission.residents[0].firstName} ${submission.residents[0].lastName}`;
 

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -1,4 +1,4 @@
-import { LegacyResident, Resident, User, Worker } from 'types';
+import { Resident, User, Worker } from 'types';
 
 export interface Choice {
   value: string;
@@ -25,7 +25,7 @@ export interface Field {
   error?: string;
   choices?: Choice[];
   /** Checkbox, file and repeater fields don't support prefilling */
-  prefill?: keyof LegacyResident | keyof Resident;
+  prefill?: keyof Resident;
   className?: string;
   /** For file fields only */
   // multiple?: boolean

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -70,7 +70,7 @@ export interface Submission {
   formId: string;
   createdBy: User;
   createdAt: string;
-  residents: LegacyResident[];
+  residents: Resident[];
   workers: Worker[];
   editHistory: {
     worker: Worker;

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -1,4 +1,4 @@
-import { Resident, User, Worker } from 'types';
+import { LegacyResident, Resident, User, Worker } from 'types';
 
 export interface Choice {
   value: string;
@@ -25,7 +25,7 @@ export interface Field {
   error?: string;
   choices?: Choice[];
   /** Checkbox, file and repeater fields don't support prefilling */
-  prefill?: keyof Resident;
+  prefill?: keyof LegacyResident | keyof Resident;
   className?: string;
   /** For file fields only */
   // multiple?: boolean
@@ -70,7 +70,7 @@ export interface Submission {
   formId: string;
   createdBy: User;
   createdAt: string;
-  residents: Resident[];
+  residents: LegacyResident[];
   workers: Worker[];
   editHistory: {
     worker: Worker;

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -7,6 +7,7 @@ import {
   startSubmission,
 } from './submissions';
 import MockDate from 'mockdate';
+import { mockedLegacyResident } from 'factories/residents';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -29,10 +30,39 @@ describe('getUnfinishedSubmissions', () => {
     expect(mockedAxios.get.mock.calls[0][1]?.headers).toEqual({
       'x-api-key': AWS_KEY,
     });
-
     expect(data).toEqual([
       { submissionId: '123', formAnswers: {} },
       { submissionId: '456', formAnswers: {} },
+    ]);
+  });
+
+  it('only returns submissions in the requested age context', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: [
+        {
+          submissionId: '123',
+          formAnswers: {},
+          residents: [mockedLegacyResident],
+        },
+        {
+          submissionId: '456',
+          formAnswers: {},
+          residents: [
+            {
+              ...mockedLegacyResident,
+              ageContext: 'C',
+            },
+          ],
+        },
+      ],
+    });
+    const data = await getUnfinishedSubmissions('A');
+    expect(data).toEqual([
+      {
+        submissionId: '123',
+        formAnswers: {},
+        residents: [mockedLegacyResident],
+      },
     ]);
   });
 });

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -4,6 +4,7 @@ import {
   StepAnswers,
   FlexibleAnswers,
 } from 'data/flexibleForms/forms.types';
+import { LegacyResident, AgeContext } from 'types';
 
 type RawSubmission = Omit<Submission, 'formAnswers'> & {
   formAnswers: {
@@ -17,12 +18,20 @@ const headersWithKey = {
   'x-api-key': AWS_KEY,
 };
 
-/** get a list of all unfinished submissions  */
-export const getUnfinishedSubmissions = async (): Promise<Submission[]> => {
+/** get a list of all unfinished submissions in the current social care service context  */
+export const getUnfinishedSubmissions = async (
+  ageContext?: AgeContext
+): Promise<Submission[]> => {
   const { data } = await axios.get(`${ENDPOINT_API}/submissions`, {
     headers: headersWithKey,
   });
-  return data;
+  return ageContext
+    ? data.filter((submission: Submission) =>
+        submission.residents.some(
+          (resident: LegacyResident) => resident.ageContext === ageContext
+        )
+      )
+    : data;
 };
 
 /** create a new submission for the given form, resident and worker  */

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -4,7 +4,7 @@ import {
   StepAnswers,
   FlexibleAnswers,
 } from 'data/flexibleForms/forms.types';
-import { LegacyResident, AgeContext } from 'types';
+import { Resident, AgeContext } from 'types';
 
 type RawSubmission = Omit<Submission, 'formAnswers'> & {
   formAnswers: {
@@ -28,7 +28,7 @@ export const getUnfinishedSubmissions = async (
   return ageContext
     ? data.filter((submission: Submission) =>
         submission.residents.some(
-          (resident: LegacyResident) => resident.ageContext === ageContext
+          (resident: Resident) => resident.ageContext === ageContext
         )
       )
     : data;

--- a/pages/forms-in-progress.tsx
+++ b/pages/forms-in-progress.tsx
@@ -5,6 +5,7 @@ import { GetServerSideProps } from 'next';
 import { getUnfinishedSubmissions } from 'lib/submissions';
 import { Submission } from 'data/flexibleForms/forms.types';
 import SubmissionsTable from 'components/SubmissionsTable';
+import { isAuthorised } from 'utils/auth';
 
 interface Props {
   submissions: Submission[];
@@ -26,8 +27,9 @@ const UnfinishedSubmissions = ({ submissions }: Props): React.ReactElement => (
 
 export default UnfinishedSubmissions;
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  const submissions = await getUnfinishedSubmissions();
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const user = isAuthorised(req);
+  const submissions = await getUnfinishedSubmissions(user?.permissionFlag);
 
   return {
     props: {

--- a/types.ts
+++ b/types.ts
@@ -149,6 +149,7 @@ export interface Resident {
   lastName: string;
   gender: string;
   contextFlag: AgeContext;
+  ageContext?: AgeContext;
   createdBy: string;
   otherNames: Array<{
     firstName: string;


### PR DESCRIPTION
it makes sense to only show unfinished submissions within the user's own service context.

we also don't want to show restricted unfinished submissions

this does that by:

- enhancing the `getUnfinishedSubmissions` api function to accept, and then filter the results by, an `ageContext` string
- supplying the logged in user's `ageContext` string on the relevant page
- filter out submissions if the attached residents are restricted and the current user doesn't have permission to see that

to be forward-compatible with group recording:
- a submission will be shown if _any_ of its attached residents are in the logged in user's service context.
- a submission will only be hidden if _all_ of its attached residents are restricted

