### PR TITLE
feat(SCT-628): update descriptions of search features on Search page

### DIFF
--- a/components/Search/MainSearchWrapper.tsx
+++ b/components/Search/MainSearchWrapper.tsx
@@ -11,8 +11,7 @@ const MainSearchWrapper = ({ type, columns }: Props): React.ReactElement => (
   <>
     <h1 className="lbh-heading-l">Search</h1>
     <p className="lbh-body govuk-!-margin-bottom-3">
-      Use search to find a person before adding a new person or record. Records
-      will need to be linked to person.
+      Use search to find a person before adding a new person or record.
     </p>
     <Tabs
       title="Contents"
@@ -30,9 +29,16 @@ const MainSearchWrapper = ({ type, columns }: Props): React.ReactElement => (
       <Search
         type={type}
         subHeader={
-          type === 'records'
-            ? 'Search and filter by any combination of fields'
-            : 'Search for a person by any combination of fields below'
+          type === 'records' ? (
+            <>
+              Here you can search for{' '}
+              <span className="lbh-!-font-weight-bold">all</span> records that
+              have been created for a person. This search will also find records
+              that have not been linked to a person’s profile yet.
+            </>
+          ) : (
+            <>Search for a person by any combination of the fields below</>
+          )
         }
         resultHeader={`${type.toUpperCase()} SEARCH RESULT`}
         // @ts-expect-error TODO: fixed when search.jsx is migrated */}

--- a/components/Search/Search.jsx
+++ b/components/Search/Search.jsx
@@ -206,7 +206,7 @@ const Search = ({
 
 Search.propTypes = {
   type: PropTypes.oneOf(['people', 'records']).isRequired,
-  subHeader: PropTypes.string.isRequired,
+  subHeader: PropTypes.element.isRequired,
   resultHeader: PropTypes.string.isRequired,
   showOnlyMyResults: PropTypes.bool,
   columns: PropTypes.array,

--- a/components/Search/Search.spec.jsx
+++ b/components/Search/Search.spec.jsx
@@ -27,7 +27,7 @@ jest.mock('utils/api/cases', () => ({
 describe(`Search`, () => {
   const props = {
     onFormSubmit: jest.fn(),
-    subHeader: 'Filter results by (any combination)',
+    subHeader: <>Filter results by (any combination)</>,
     resultHeader: 'PEOPLE SEARCH RESULT',
   };
 

--- a/components/Search/__snapshots__/MainSearchWrapper.spec.tsx.snap
+++ b/components/Search/__snapshots__/MainSearchWrapper.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`MainSearchWrapper should render properly 1`] = `
   <p
     class="lbh-body govuk-!-margin-bottom-3"
   >
-    Use search to find a person before adding a new person or record. Records will need to be linked to person.
+    Use search to find a person before adding a new person or record.
   </p>
   <div
     class="lbh-tabs govuk-tabs"

--- a/pages/my-records.tsx
+++ b/pages/my-records.tsx
@@ -10,7 +10,7 @@ const MyCasesPage = (): React.ReactElement => (
         <p className="govuk-body">All records you have added</p>
         <Search
           type="records"
-          subHeader="Filter results by (any combination)"
+          subHeader={<>Filter results by (any combination)</>}
           resultHeader="All records you have added"
           showOnlyMyResults
           columns={[


### PR DESCRIPTION
**What**  

This PR updates the content at the top of the Search page.

Before | After
-- | --
![image](https://user-images.githubusercontent.com/42817036/123661229-4e5fe480-d82c-11eb-8059-0867747c34c5.png) | ![image](https://user-images.githubusercontent.com/42817036/123661029-1789ce80-d82c-11eb-9cee-2ae2ae1e2f27.png)
![image](https://user-images.githubusercontent.com/42817036/123661101-2ec8bc00-d82c-11eb-9bda-8f41fae20cb2.png) | ![image](https://user-images.githubusercontent.com/42817036/123661156-3be5ab00-d82c-11eb-9f4d-3277e2885440.png)

**Why**

To provide better clarity around the difference between "Search for a person" and "Search for a record".

**Link to Jira ticket**

https://hackney.atlassian.net/browse/SCT-628

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
