### PR TITLE
fix(SCT-724): set the GitHub username and email

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,9 @@ jobs:
       - run:
           name: Install Dependencies
           command: yarn
+      - run:
+          name: Set GitHub username and email
+          command: git config user.email "ci@hackney.gov.uk" && git config user.name "lbhackney-automation"
       - save_cache:
           key: dependency-cache-{{ checksum "yarn.lock" }}
           paths:

--- a/.release-it.json
+++ b/.release-it.json
@@ -3,7 +3,7 @@
     "publish": false
   },
   "git": {
-    "commitMessage": "chore: release v${version}"
+    "commitMessage": "chore: release v${version} [skip ci]"
   },
   "github": {
     "release": true


### PR DESCRIPTION
**What**  
We have to set the GitHub username and email when we run `git commit` inside the CircleCI context

