### PR TITLE
fix: clear out old draft releases before creating a new one

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,16 +88,22 @@ jobs:
     steps:
       - *attach_workspace
       - run:
+          name: delete stale draft GitHub releases
+          command: yarn delete-draft-github-releases
+      - run:
           name: generate draft GitHub release
-          command: yarn release --no-git.push --github.draft
+          command: yarn release --github.draft --no-git.push --no-git.tag
 
   generate-github-release:
     executor: aws-cli/default
     steps:
       - *attach_workspace
       - run:
+          name: delete stale draft GitHub releases
+          command: yarn delete-draft-github-releases
+      - run:
           name: generate release
-          command: yarn release --no-github.draft
+          command: yarn release
 
   assume-role-staging:
     executor: docker-python

--- a/ci-scripts/delete-draft-github-releases.js
+++ b/ci-scripts/delete-draft-github-releases.js
@@ -1,0 +1,72 @@
+const fetch = require('cross-fetch');
+
+/**
+ * Deletes all GitHub releases marked as 'draft'
+ *
+ * Usage: `GITHUB_TOKEN= node delete-draft-github-releases.js`
+ */
+const deleteDraftGitHubReleases = async () => {
+  const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+  if (!GITHUB_TOKEN) {
+    console.error('Please provide a `GITHUB_TOKEN` environment variable');
+    process.exit(0);
+    return;
+  }
+
+  const [error, draftReleases] = await getDraftReleases(GITHUB_TOKEN);
+
+  if (error) {
+    console.error(error.message);
+    process.exit(0);
+    return;
+  }
+
+  for (let release of draftReleases) {
+    await deleteRelease(GITHUB_TOKEN, release.id);
+  }
+};
+
+async function getDraftReleases(token) {
+  const res = await fetch(
+    `https://api.github.com/repos/chrishutchinson/test-release-it/releases`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  if (!res.ok) {
+    return [new Error(res.statusText), null];
+  }
+
+  const releases = await res.json();
+
+  return [null, releases.filter((r) => r.draft === true)];
+}
+
+async function deleteRelease(token, releaseId) {
+  return fetch(
+    `https://api.github.com/repos/chrishutchinson/test-release-it/releases/${releaseId}`,
+    {
+      method: 'delete',
+      headers: {
+        Accept: 'application/vnd.github.v3+json',
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+}
+
+if (require.main === module) {
+  deleteDraftGitHubReleases().then(() => {
+    console.log('Done!');
+  });
+}
+
+module.exports = {
+  deleteDraftGitHubReleases,
+};

--- a/ci-scripts/delete-draft-github-releases.js
+++ b/ci-scripts/delete-draft-github-releases.js
@@ -29,7 +29,7 @@ const deleteDraftGitHubReleases = async () => {
 
 async function getDraftReleases(token) {
   const res = await fetch(
-    `https://api.github.com/repos/chrishutchinson/test-release-it/releases`,
+    `https://api.github.com/repos/LBHackney-IT/lbh-social-care-frontend/releases`,
     {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -49,7 +49,7 @@ async function getDraftReleases(token) {
 
 async function deleteRelease(token, releaseId) {
   return fetch(
-    `https://api.github.com/repos/chrishutchinson/test-release-it/releases/${releaseId}`,
+    `https://api.github.com/repos/LBHackney-IT/lbh-social-care-frontend/releases/${releaseId}`,
     {
       method: 'delete',
       headers: {

--- a/ci-scripts/delete-draft-github-releases.spec.js
+++ b/ci-scripts/delete-draft-github-releases.spec.js
@@ -1,0 +1,63 @@
+import fetch from 'cross-fetch';
+import { deleteDraftGitHubReleases } from './delete-draft-github-releases';
+
+jest.mock('cross-fetch');
+
+describe('#deleteDraftGitHubReleases()', () => {
+  beforeEach(() => {
+    delete global.process.env.GITHUB_TOKEN;
+
+    jest.resetAllMocks();
+  });
+
+  it('should exit the process if no GITHUB_TOKEN environment variable is provided', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => [],
+    });
+    global.process.exit = jest.fn();
+
+    await deleteDraftGitHubReleases();
+
+    expect(global.process.exit).toHaveBeenCalled();
+  });
+
+  it('should exit if the GitHub GET releases call fails', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Some error',
+      json: () => [],
+    });
+    global.process.exit = jest.fn();
+    global.process.env.GITHUB_TOKEN = 'GITHUB_TOKEN';
+
+    await deleteDraftGitHubReleases();
+
+    expect(global.process.exit).toHaveBeenCalled();
+  });
+
+  it('should call the DELETE releases GitHub API for each draft release found', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => [
+        {
+          id: 123,
+          draft: true,
+        },
+        {
+          id: 456,
+          draft: true,
+        },
+        {
+          id: 789,
+          draft: true,
+        },
+      ],
+    });
+    global.process.env.GITHUB_TOKEN = 'GITHUB_TOKEN';
+
+    await deleteDraftGitHubReleases();
+
+    expect(fetch).toHaveBeenCalledTimes(4); // 1 (GET) + 3 (DELETE)
+  });
+});

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "husky": "^4.3.7",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",
-    "jest-fetch-mock": "^3.0.3",
     "lint-staged": ">=10",
     "mockdate": "^3.0.5",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "cy:run": "cypress run",
     "cy:open": "cypress open",
     "build-storybook": "build-storybook",
-    "release": "release-it"
+    "release": "release-it",
+    "delete-draft-github-releases": "node ./ci-scripts/delete-draft-github-releases.js"
   },
   "dependencies": {
     "axios": "^0.21.1",
@@ -71,6 +72,7 @@
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",
     "cpx": "^1.5.0",
+    "cross-fetch": "^3.1.4",
     "css-loader": "^5.2.4",
     "cypress": "^6.8.0",
     "cypress-dotenv": "^1.2.2",
@@ -87,6 +89,7 @@
     "husky": "^4.3.7",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",
+    "jest-fetch-mock": "^3.0.3",
     "lint-staged": ">=10",
     "mockdate": "^3.0.5",
     "prettier": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6080,6 +6080,13 @@ create-react-context@0.3.0:
     gud "^1.0.0"
     warning "^4.0.3"
 
+cross-fetch@^3.0.4, cross-fetch@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -9795,6 +9802,14 @@ jest-environment-node@^26.6.2:
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
@@ -12686,6 +12701,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-polyfill@^8.1.3:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.0.tgz#367394726da7561457aba2133c9ceefbd6267da0"
+  integrity sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==
 
 promise.allsettled@^1.0.0:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6080,7 +6080,7 @@ create-react-context@0.3.0:
     gud "^1.0.0"
     warning "^4.0.3"
 
-cross-fetch@^3.0.4, cross-fetch@^3.1.4:
+cross-fetch@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
   integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
@@ -9802,14 +9802,6 @@ jest-environment-node@^26.6.2:
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
-jest-fetch-mock@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
-  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
-  dependencies:
-    cross-fetch "^3.0.4"
-    promise-polyfill "^8.1.3"
-
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
@@ -12701,11 +12693,6 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
-
-promise-polyfill@^8.1.3:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.0.tgz#367394726da7561457aba2133c9ceefbd6267da0"
-  integrity sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==
 
 promise.allsettled@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
**What**  
When we create draft releases with `release-it`, instead of extending the previous draft, it creates a new one, meaning we end up with a deluge of draft releases!

I've written a small script which clears up old draft releases automatically, meaning the one `release-it` creates is always fresh, and contains all changes since the last production releases. 

This draft is then removed and replaced when a full production release is made.

