### PR TITLE
fix: allow CircleCI to push to GitHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,9 @@ jobs:
     executor: aws-cli/default
     steps:
       - *attach_workspace
+      - add_ssh_keys:
+          fingerprints:
+            - 'd0:bd:5a:9f:c3:17:88:3a:df:03:42:7b:f6:f7:3c:72'
       - run:
           name: delete stale draft GitHub releases
           command: yarn delete-draft-github-releases


### PR DESCRIPTION
**What**  
For CircleCI to be able to push back to GitHub, we need to give it a write-access deploy key. This has been set up in CircleCI, and this is the relevant config for it.

Assuming this works (I have a feeling we're going to hit another issue with push rights to `main`), then I will add some documentation to the `README` on how these keys are configured, should we need to change it in the future.

Relevant docs: https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-github-deploy-key