### PR TITLE
SCT-729 Sync submissions with back end

### DIFF
--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -123,7 +123,8 @@ describe('finishSubmission', () => {
       `${ENDPOINT_API}/submissions/foo`
     );
     expect(mockedAxios.patch.mock.calls[0][1]).toEqual({
-      createdBy: 'bar',
+      editedBy: 'bar',
+      submissionState: 'submitted',
     });
     expect(mockedAxios.patch.mock.calls[0][2]?.headers).toEqual({
       'x-api-key': AWS_KEY,

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -106,7 +106,8 @@ export const finishSubmission = async (
   const { status } = await axios.patch(
     `${ENDPOINT_API}/submissions/${submissionId}`,
     {
-      createdBy: finishedBy,
+      editedBy: finishedBy,
+      submissionState: 'submitted',
     },
     {
       headers: headersWithKey,


### PR DESCRIPTION
**What**  
This PR changes the `createdBy` property within the body of the finished submission endpoint to align with the back end API, the submission state has also been added

**Why**  
To align the front-end for case submissions to the back-end

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
