### PR TITLE
fix(SCT-661): display warning notes for all users

### DIFF
--- a/components/WarningNote/WarningNotes.spec.tsx
+++ b/components/WarningNote/WarningNotes.spec.tsx
@@ -32,7 +32,7 @@ describe(`useWarningNotes`, () => {
     jest.spyOn(warningNotes, 'useWarningNotes').mockImplementation(() => ({
       data: [
         warningNoteFactory.build({
-          nextReviewDate: '2020-12-30',
+          nextReviewDate: '2020-11-12',
         }),
       ],
       mutate: jest.fn(),

--- a/components/WarningNote/WarningNotes.spec.tsx
+++ b/components/WarningNote/WarningNotes.spec.tsx
@@ -4,7 +4,7 @@ import * as residentsAPI from 'utils/api/residents';
 import * as warningNotes from 'utils/api/warningNotes';
 import WarningNotes from './WarningNotes';
 
-import { mockedWarningNote, warningNoteFactory } from 'factories/warningNotes';
+import { warningNoteFactory } from 'factories/warningNotes';
 import { AuthProvider } from '../UserContext/UserContext';
 import { userFactory } from '../../factories/users';
 import { residentFactory } from '../../factories/residents';

--- a/components/WarningNote/WarningNotes.spec.tsx
+++ b/components/WarningNote/WarningNotes.spec.tsx
@@ -1,9 +1,24 @@
 import { render } from '@testing-library/react';
 
+import * as residentsAPI from 'utils/api/residents';
 import * as warningNotes from 'utils/api/warningNotes';
 import WarningNotes from './WarningNotes';
 
 import { mockedWarningNote, warningNoteFactory } from 'factories/warningNotes';
+import { AuthProvider } from '../UserContext/UserContext';
+import { userFactory } from '../../factories/users';
+import { residentFactory } from '../../factories/residents';
+
+const mockedAdultsUser = userFactory.build({
+  hasAdminPermissions: false,
+  hasUnrestrictedPermissions: false,
+  hasChildrenPermissions: false,
+  hasAdultPermissions: true,
+});
+
+const mockedAdultsResident = residentFactory.build({
+  contextFlag: 'A',
+});
 
 jest.mock('next/router', () => ({
   useRouter: () => ({
@@ -13,23 +28,11 @@ jest.mock('next/router', () => ({
 }));
 
 describe(`useWarningNotes`, () => {
-  it('should render a list of warning notes', () => {
-    jest.spyOn(warningNotes, 'useWarningNotes').mockImplementation(() => ({
-      data: mockedWarningNote,
-      mutate: jest.fn(),
-      revalidate: jest.fn(),
-      isValidating: false,
-    }));
-
-    const { asFragment } = render(<WarningNotes id={123} />);
-    expect(asFragment()).toMatchSnapshot();
-  });
-
-  it('should not render the review date if there is a scheduled future review date', () => {
+  beforeEach(() => {
     jest.spyOn(warningNotes, 'useWarningNotes').mockImplementation(() => ({
       data: [
         warningNoteFactory.build({
-          nextReviewDate: '2020-11-12',
+          nextReviewDate: '2020-12-30',
         }),
       ],
       mutate: jest.fn(),
@@ -37,9 +40,32 @@ describe(`useWarningNotes`, () => {
       isValidating: false,
     }));
 
-    const { getByText, queryByText } = render(<WarningNotes id={123} />);
+    jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+      data: mockedAdultsResident,
+      isValidating: false,
+      mutate: jest.fn(),
+      revalidate: jest.fn(),
+    }));
+  });
+
+  it('should render a list of warning notes', () => {
+    const { asFragment } = render(
+      <AuthProvider user={mockedAdultsUser}>
+        <WarningNotes id={123} />
+      </AuthProvider>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should not render the review date if there is a scheduled future review date', () => {
+    const { getByText, queryByText } = render(
+      <AuthProvider user={mockedAdultsUser}>
+        <WarningNotes id={123} />
+      </AuthProvider>
+    );
 
     getByText('Next review date');
+
     expect(
       queryByText('Review date', {
         exact: true,

--- a/components/WarningNote/WarningNotes.tsx
+++ b/components/WarningNote/WarningNotes.tsx
@@ -3,9 +3,12 @@ import Link from 'next/link';
 
 import { useWarningNotes } from 'utils/api/warningNotes';
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
-import { WarningNote } from 'types';
+import { User, WarningNote } from 'types';
 
 import styles from './WarningNotes.module.scss';
+import { useResident } from '../../utils/api/residents';
+import { canManageCases } from '../../lib/permissions';
+import { useAuth } from '../UserContext/UserContext';
 
 export interface Props {
   personId: number;
@@ -13,6 +16,13 @@ export interface Props {
 }
 
 export const WarningBox = ({ notes, personId }: Props): React.ReactElement => {
+  const { data: resident } = useResident(personId);
+  const { user } = useAuth() as { user: User };
+
+  if (!resident) {
+    return <></>;
+  }
+
   return (
     <div
       className={cx('govuk-error-summary', styles.container)}
@@ -68,9 +78,13 @@ export const WarningBox = ({ notes, personId }: Props): React.ReactElement => {
                   </>
                 )}
               </dl>
-              <Link href={`/people/${personId}/warning-notes/${note.id}`}>
-                <a className="govuk-link govuk-link-underline">Review / end</a>
-              </Link>
+              {canManageCases(user, resident) && (
+                <Link href={`/people/${personId}/warning-notes/${note.id}`}>
+                  <a className="govuk-link govuk-link-underline">
+                    Review / end
+                  </a>
+                </Link>
+              )}
             </div>
           ))}
           <p>For further information see Warning Note in Records History</p>

--- a/components/WarningNote/__snapshots__/WarningNotes.spec.tsx.snap
+++ b/components/WarningNote/__snapshots__/WarningNotes.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`useWarningNotes should render a list of warning notes 1`] = `
               Next review date
             </dt>
             <dd>
-              30/12/2020 
+              12/11/2020 
             </dd>
           </dl>
           <a

--- a/components/WarningNote/__snapshots__/WarningNotes.spec.tsx.snap
+++ b/components/WarningNote/__snapshots__/WarningNotes.spec.tsx.snap
@@ -28,42 +28,6 @@ exports[`useWarningNotes should render a list of warning notes 1`] = `
               Type
             </dt>
             <dd>
-              Risk to Adults
-            </dd>
-            <dt>
-              Start date
-            </dt>
-            <dd>
-              13/11/2020 
-              <i>
-                created by
-              </i>
-               Foo
-            </dd>
-            <dt>
-              Review date
-            </dt>
-            <dd>
-              01/12/2020 
-            </dd>
-          </dl>
-          <a
-            class="govuk-link govuk-link-underline"
-            href="/people/123/warning-notes/1"
-          >
-            Review / end
-          </a>
-        </div>
-        <div
-          class="note"
-        >
-          <dl
-            class="noteDetails"
-          >
-            <dt>
-              Type
-            </dt>
-            <dd>
               Risk to Staff
             </dd>
             <dt>
@@ -77,15 +41,15 @@ exports[`useWarningNotes should render a list of warning notes 1`] = `
                Foo
             </dd>
             <dt>
-              Review date
+              Next review date
             </dt>
             <dd>
-              01/01/2021 
+              30/12/2020 
             </dd>
           </dl>
           <a
             class="govuk-link govuk-link-underline"
-            href="/people/123/warning-notes/2"
+            href="/people/123/warning-notes/3"
           >
             Review / end
           </a>

--- a/components/pages/people/PersonDetailsPage.spec.tsx
+++ b/components/pages/people/PersonDetailsPage.spec.tsx
@@ -1,5 +1,6 @@
 import { render, RenderResult, screen } from '@testing-library/react';
 
+import * as residentsAPI from '../../../utils/api/residents';
 import { residentFactory } from '../../../factories/residents';
 import { AuthProvider } from '../../UserContext/UserContext';
 import PersonView from '../../PersonView/PersonView';
@@ -71,6 +72,14 @@ describe('<PersonDetailsPage />', () => {
       (PersonView as jest.Mock).mockImplementationOnce(
         createMockedPersonView(mockedAdultsResident)
       );
+
+      jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+        data: mockedAdultsResident,
+        isValidating: false,
+        mutate: jest.fn(),
+        revalidate: jest.fn(),
+      }));
+
       renderResult = render(
         <AuthProvider user={mockedAdultsUser}>
           <PersonDetailsPage personId={100} />
@@ -89,6 +98,13 @@ describe('<PersonDetailsPage />', () => {
         createMockedPersonView(mockedAdultsResident)
       );
 
+      jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+        data: mockedAdultsResident,
+        isValidating: false,
+        mutate: jest.fn(),
+        revalidate: jest.fn(),
+      }));
+
       render(
         <AuthProvider user={mockedAdultsUser}>
           <PersonDetailsPage personId={100} />
@@ -102,6 +118,13 @@ describe('<PersonDetailsPage />', () => {
       (PersonView as jest.Mock).mockImplementationOnce(
         createMockedPersonView(mockedChildrensResident)
       );
+
+      jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+        data: mockedChildrensResident,
+        isValidating: false,
+        mutate: jest.fn(),
+        revalidate: jest.fn(),
+      }));
 
       render(
         <AuthProvider user={mockedAdultsUser}>
@@ -117,6 +140,13 @@ describe('<PersonDetailsPage />', () => {
         createMockedPersonView(mockedChildrensResident)
       );
 
+      jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+        data: mockedChildrensResident,
+        isValidating: false,
+        mutate: jest.fn(),
+        revalidate: jest.fn(),
+      }));
+
       render(
         <AuthProvider user={mockedAdultsUser}>
           <PersonDetailsPage personId={100} />
@@ -127,6 +157,48 @@ describe('<PersonDetailsPage />', () => {
         'Some details for this person are restricted due to your permissions.'
       );
     });
+
+    it('should show an edit link on active warning notes if the person is an adult', () => {
+      (PersonView as jest.Mock).mockImplementationOnce(
+        createMockedPersonView(mockedAdultsResident)
+      );
+
+      jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+        data: mockedAdultsResident,
+        isValidating: false,
+        mutate: jest.fn(),
+        revalidate: jest.fn(),
+      }));
+
+      render(
+        <AuthProvider user={mockedAdultsUser}>
+          <PersonDetailsPage personId={100} />
+        </AuthProvider>
+      );
+
+      screen.getAllByText('Review / end');
+    });
+
+    it('should not show an edit link on active warning notes if the person is a child', () => {
+      (PersonView as jest.Mock).mockImplementationOnce(
+        createMockedPersonView(mockedChildrensResident)
+      );
+
+      jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+        data: mockedChildrensResident,
+        isValidating: false,
+        mutate: jest.fn(),
+        revalidate: jest.fn(),
+      }));
+
+      render(
+        <AuthProvider user={mockedAdultsUser}>
+          <PersonDetailsPage personId={100} />
+        </AuthProvider>
+      );
+
+      expect(screen.queryByText('Review / end')).toBeNull();
+    });
   });
 
   describe('as a childrens user', () => {
@@ -134,6 +206,13 @@ describe('<PersonDetailsPage />', () => {
       (PersonView as jest.Mock).mockImplementationOnce(
         createMockedPersonView(mockedChildrensResident)
       );
+
+      jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+        data: mockedChildrensResident,
+        isValidating: false,
+        mutate: jest.fn(),
+        revalidate: jest.fn(),
+      }));
 
       render(
         <AuthProvider user={mockedChildrensUser}>
@@ -149,6 +228,13 @@ describe('<PersonDetailsPage />', () => {
         createMockedPersonView(mockedAdultsResident)
       );
 
+      jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+        data: mockedAdultsResident,
+        isValidating: false,
+        mutate: jest.fn(),
+        revalidate: jest.fn(),
+      }));
+
       render(
         <AuthProvider user={mockedChildrensUser}>
           <PersonDetailsPage personId={100} />
@@ -163,6 +249,13 @@ describe('<PersonDetailsPage />', () => {
         createMockedPersonView(mockedAdultsResident)
       );
 
+      jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+        data: mockedAdultsResident,
+        isValidating: false,
+        mutate: jest.fn(),
+        revalidate: jest.fn(),
+      }));
+
       render(
         <AuthProvider user={mockedChildrensUser}>
           <PersonDetailsPage personId={100} />
@@ -172,6 +265,48 @@ describe('<PersonDetailsPage />', () => {
       screen.getByText(
         'Some details for this person are restricted due to your permissions.'
       );
+    });
+
+    it('should show an edit link on active warning notes if the person is a child', () => {
+      (PersonView as jest.Mock).mockImplementationOnce(
+        createMockedPersonView(mockedChildrensResident)
+      );
+
+      jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+        data: mockedChildrensResident,
+        isValidating: false,
+        mutate: jest.fn(),
+        revalidate: jest.fn(),
+      }));
+
+      render(
+        <AuthProvider user={mockedChildrensUser}>
+          <PersonDetailsPage personId={100} />
+        </AuthProvider>
+      );
+
+      screen.getAllByText('Review / end');
+    });
+
+    it('should not show an edit link on active warning notes if the person is an adult', () => {
+      (PersonView as jest.Mock).mockImplementationOnce(
+        createMockedPersonView(mockedAdultsResident)
+      );
+
+      jest.spyOn(residentsAPI, 'useResident').mockImplementation(() => ({
+        data: mockedAdultsResident,
+        isValidating: false,
+        mutate: jest.fn(),
+        revalidate: jest.fn(),
+      }));
+
+      render(
+        <AuthProvider user={mockedChildrensUser}>
+          <PersonDetailsPage personId={100} />
+        </AuthProvider>
+      );
+
+      expect(screen.queryByText('Review / end')).toBeNull();
     });
   });
 });

--- a/components/pages/people/PersonDetailsPage.spec.tsx
+++ b/components/pages/people/PersonDetailsPage.spec.tsx
@@ -55,6 +55,13 @@ describe('<PersonDetailsPage />', () => {
       mutate: jest.fn(),
       revalidate: jest.fn(),
     }));
+
+    jest.spyOn(warningNotes, 'useWarningNotes').mockImplementation(() => ({
+      data: mockedWarningNote,
+      mutate: jest.fn(),
+      revalidate: jest.fn(),
+      isValidating: false,
+    }));
   });
 
   describe('for all users', () => {
@@ -82,13 +89,6 @@ describe('<PersonDetailsPage />', () => {
         createMockedPersonView(mockedAdultsResident)
       );
 
-      jest.spyOn(warningNotes, 'useWarningNotes').mockImplementation(() => ({
-        data: mockedWarningNote,
-        mutate: jest.fn(),
-        revalidate: jest.fn(),
-        isValidating: false,
-      }));
-
       render(
         <AuthProvider user={mockedAdultsUser}>
           <PersonDetailsPage personId={100} />
@@ -98,17 +98,10 @@ describe('<PersonDetailsPage />', () => {
       screen.getByText('WARNING NOTE');
     });
 
-    it('should not show any active warning notes for the person if the person is a child', () => {
+    it('should show any active warning notes for the person if the person is a child', () => {
       (PersonView as jest.Mock).mockImplementationOnce(
         createMockedPersonView(mockedChildrensResident)
       );
-
-      jest.spyOn(warningNotes, 'useWarningNotes').mockImplementation(() => ({
-        data: mockedWarningNote,
-        mutate: jest.fn(),
-        revalidate: jest.fn(),
-        isValidating: false,
-      }));
 
       render(
         <AuthProvider user={mockedAdultsUser}>
@@ -116,7 +109,7 @@ describe('<PersonDetailsPage />', () => {
         </AuthProvider>
       );
 
-      expect(screen.queryByText('WARNING NOTE')).toBeNull();
+      screen.getByText('WARNING NOTE');
     });
 
     it('should show a restricted banner for a childrens person', () => {
@@ -142,13 +135,6 @@ describe('<PersonDetailsPage />', () => {
         createMockedPersonView(mockedChildrensResident)
       );
 
-      jest.spyOn(warningNotes, 'useWarningNotes').mockImplementation(() => ({
-        data: mockedWarningNote,
-        mutate: jest.fn(),
-        revalidate: jest.fn(),
-        isValidating: false,
-      }));
-
       render(
         <AuthProvider user={mockedChildrensUser}>
           <PersonDetailsPage personId={100} />
@@ -158,17 +144,10 @@ describe('<PersonDetailsPage />', () => {
       screen.getByText('WARNING NOTE');
     });
 
-    it('should not show any active warning notes for the person if the person is an adult', () => {
+    it('should show any active warning notes for the person if the person is an adult', () => {
       (PersonView as jest.Mock).mockImplementationOnce(
         createMockedPersonView(mockedAdultsResident)
       );
-
-      jest.spyOn(warningNotes, 'useWarningNotes').mockImplementation(() => ({
-        data: mockedWarningNote,
-        mutate: jest.fn(),
-        revalidate: jest.fn(),
-        isValidating: false,
-      }));
 
       render(
         <AuthProvider user={mockedChildrensUser}>
@@ -176,7 +155,7 @@ describe('<PersonDetailsPage />', () => {
         </AuthProvider>
       );
 
-      expect(screen.queryByText('WARNING NOTE')).toBeNull();
+      screen.getByText('WARNING NOTE');
     });
 
     it('should show a restricted banner for an adult person', () => {

--- a/components/pages/people/PersonDetailsPage.tsx
+++ b/components/pages/people/PersonDetailsPage.tsx
@@ -5,7 +5,7 @@ import AllocatedWorkers from 'components/AllocatedWorkers/AllocatedWorkers';
 import Relationships from 'components/Relationships/Relationships';
 import WarningNotes from 'components/WarningNote/WarningNotes';
 import Stack from 'components/Stack/Stack';
-import { canManageCases, canViewRelationships } from 'lib/permissions';
+import { canViewRelationships } from 'lib/permissions';
 import { useAuth } from '../../UserContext/UserContext';
 import { User } from '../../../types';
 
@@ -18,11 +18,7 @@ export const PersonDetailsPage: React.FC<{ personId: number }> = ({
     <PersonView personId={personId} showPersonDetails={false}>
       {(person) => (
         <Stack space={7} className="govuk-!-margin-top-7">
-          {canManageCases(user, person) ? (
-            <WarningNotes id={personId} />
-          ) : (
-            <></>
-          )}
+          <WarningNotes id={personId} />
           <PersonDetails person={person} />
           <AllocatedWorkers person={person} />
           {canViewRelationships(user, person) ? (

--- a/components/pages/people/__snapshots__/PersonDetailsPage.spec.tsx.snap
+++ b/components/pages/people/__snapshots__/PersonDetailsPage.spec.tsx.snap
@@ -8,16 +8,100 @@ exports[`<PersonDetailsPage /> for all users should render the details for the p
     <div
       class=""
     >
-      <span
-        class="govuk-error-message"
+      <div
+        aria-labelledby="warning-note-title"
+        class="govuk-error-summary container"
+        role="complementary"
+        tabindex="-1"
       >
-        <span
-          class="govuk-visually-hidden"
+        <h2
+          class="govuk-error-summary__title"
+          id="warning-note-title"
         >
-          Error:
-        </span>
-         There was a problem. Please refresh the page or try again later.
-      </span>
+          WARNING NOTE
+        </h2>
+        <div>
+          <div
+            class="govuk-error-summary__body"
+          >
+            <div
+              class="note"
+            >
+              <dl
+                class="noteDetails"
+              >
+                <dt>
+                  Type
+                </dt>
+                <dd>
+                  Risk to Adults
+                </dd>
+                <dt>
+                  Start date
+                </dt>
+                <dd>
+                  13/11/2020 
+                  <i>
+                    created by
+                  </i>
+                   Foo
+                </dd>
+                <dt>
+                  Review date
+                </dt>
+                <dd>
+                  01/12/2020 
+                </dd>
+              </dl>
+              <a
+                class="govuk-link govuk-link-underline"
+                href="/people/100/warning-notes/1"
+              >
+                Review / end
+              </a>
+            </div>
+            <div
+              class="note"
+            >
+              <dl
+                class="noteDetails"
+              >
+                <dt>
+                  Type
+                </dt>
+                <dd>
+                  Risk to Staff
+                </dd>
+                <dt>
+                  Start date
+                </dt>
+                <dd>
+                  22/11/2020 
+                  <i>
+                    created by
+                  </i>
+                   Foo
+                </dd>
+                <dt>
+                  Review date
+                </dt>
+                <dd>
+                  01/01/2021 
+                </dd>
+              </dl>
+              <a
+                class="govuk-link govuk-link-underline"
+                href="/people/100/warning-notes/2"
+              >
+                Review / end
+              </a>
+            </div>
+            <p>
+              For further information see Warning Note in Records History
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
     <div
       class="govuk-!-margin-top-7"


### PR DESCRIPTION
**What**  
We did a fix to ensure practitioners could see warning notes for their residents last week. This extends that change to show warning notes for all users (but only users with the right permissions can `review / end` them).

**Why**  
[SCT-661](https://hackney.atlassian.net/browse/SCT-661)
