### PR TITLE
chore(SCT-727): Remove ended date parameter from PATCH warning note request body

### DIFF
--- a/components/pages/warning-notes/ReviewWarningNoteForm/ReviewWarningNoteForm.tsx
+++ b/components/pages/warning-notes/ReviewWarningNoteForm/ReviewWarningNoteForm.tsx
@@ -34,10 +34,6 @@ export const ReviewWarningNoteForm: React.FC<{
         warningNoteId,
         reviewedBy: user.email,
         endedBy: formData.reviewDecision === 'No' ? user.email : undefined,
-        endedDate:
-          formData.reviewDecision === 'No'
-            ? new Date().toISOString()
-            : undefined,
         status: formData.reviewDecision === 'No' ? 'closed' : 'open',
         ...formData,
       });

--- a/lib/warningNotes.spec.ts
+++ b/lib/warningNotes.spec.ts
@@ -84,7 +84,6 @@ describe('warningNotesAPI', () => {
       await warningNotesAPI.updateWarningNote({
         status: 'Closed',
         endedBy: 'foo@bar.com',
-        endedDate: '2021-04-29',
       });
       expect(mockedAxios.patch).toHaveBeenCalled();
       expect(mockedAxios.patch.mock.calls[0][0]).toEqual(
@@ -93,7 +92,6 @@ describe('warningNotesAPI', () => {
       expect(mockedAxios.patch.mock.calls[0][1]).toEqual({
         status: 'Closed',
         endedBy: 'foo@bar.com',
-        endedDate: '2021-04-29',
       });
       expect(mockedAxios.patch.mock.calls[0][2]?.headers).toEqual({
         'Content-Type': 'application/json',


### PR DESCRIPTION
We don't need to grab the time from the client machine and pass it as an `endedDate` value from the frontend when a warning note is closed.

The end date is saved to a closed warning note automatically within the backend.

This removes the `endedDate` parameter from the `formData` passed to the `updateWarningNote` method.