### PR TITLE
fix: only build the app once in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - ./build
+            - project/build
 
   e2e:
     executor: node-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
           root: *workspace_root
           paths: .
 
-  tests:
+  unit-tests:
     executor: node-executor
     steps:
       - *attach_workspace
@@ -64,7 +64,8 @@ jobs:
           command: yarn build
       - persist_to_workspace:
           root: *workspace_root
-          paths: .
+          paths:
+            - build/*
 
   e2e:
     executor: node-executor
@@ -150,18 +151,18 @@ workflows:
   continuous-delivery:
     jobs:
       - install-dependencies
-      - tests:
+      - unit-tests:
           requires:
             - install-dependencies
       - build:
           requires:
-            - tests
+            - unit-tests
       - e2e:
           requires:
             - build
       - generate-draft-github-release:
           requires:
-            - tests
+            - unit-tests
             - e2e
             - build
           filters:
@@ -170,8 +171,9 @@ workflows:
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:
-            - tests
+            - unit-tests
             - e2e
+            - build
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,14 @@ jobs:
           name: Run tests
           command: yarn test -w 2
 
+  build:
+    executor: node-executor
+    steps:
+      - *attach_workspace
+      - run:
+          name: Build app
+          command: yarn build
+
   e2e:
     executor: node-executor
     steps:
@@ -73,7 +81,7 @@ jobs:
       - *attach_workspace
       - run:
           name: deploy
-          command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage staging
+          command: yarn --production=true && sudo npm i -g serverless && sls deploy --stage staging
 
   build-deploy-production:
     executor: aws-cli/default
@@ -81,7 +89,7 @@ jobs:
       - *attach_workspace
       - run:
           name: deploy
-          command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy -s production
+          command: yarn --production=true && sudo npm i -g serverless && sls deploy -s production
 
   generate-draft-github-release:
     executor: aws-cli/default
@@ -142,13 +150,17 @@ workflows:
       - tests:
           requires:
             - install-dependencies
+      - build:
+          requires:
+            - tests
       - e2e:
           requires:
-            - install-dependencies
+            - build
       - generate-draft-github-release:
           requires:
             - tests
             - e2e
+            - build
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,9 @@ jobs:
       - run:
           name: Build app
           command: yarn build
+      - persist_to_workspace:
+          root: *workspace_root
+          paths: .
 
   e2e:
     executor: node-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - build/*
+            - ./build
 
   e2e:
     executor: node-executor

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "prestart": "next build",
     "start": "next start -p $PORT",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx && echo 'Lint complete.'",


### PR DESCRIPTION
**What**  
At the moment our pipeline builds the app three times:
1. To run end-to-end tests
2. To deploy to staging
3. (Optionally) To deploy to production

The downside here is that _technically_ the artefact used for running our tests is not the same artefact we release to staging and production. This introduces a small opportunity for bugs to be introduced. To eliminate this, and also speed up the whole process, I have split out the build step as an independent job that runs just once, after the unit tests have passed.

_Draft while I do some testing in CI_
