### PR TITLE
feat(SCT-738): add a `useFeatureFlag()` hook for accessing feature flags

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,6 +28,10 @@ You can add a new feature to it following this structure:
 
 > ⚠️ **Warning**: Make sure to add an expiry date comment to the feature flag as shown above.
 
+### Using the feature flag
+
+#### React component
+
 To then use your feature flag in your React code, a component – `<ConditionalFeature />` is available. This component will render its children if the feature is active, otherwise it will return nothing. Use it as follows:
 
 ```tsx
@@ -40,3 +44,23 @@ To then use your feature flag in your React code, a component – `<ConditionalF
 ```
 
 In the above scenario, if the feature `some-awesome-feature` is active, the child component (`<AwesomeFeature />`) will be rendered below the heading. Otherwise, it'll be hidden.
+
+#### React hook
+
+You can also get the status of a feature flag by using the `useFeatureFlags()` React hook. This is useful if you need it inside other scripted code, such as a `useEffect()` or `useCallback()`. For example:
+
+```tsx
+const SomeComponent = () => {
+  const { isFeatureActive } = useFeatureFlags();
+
+  const handleClick = useCallback(() => {
+    if (isFeatureActive('some-awesome-feature')) {
+      // The feature is active, do something..!
+    } else {
+      // The feature isn't active, maybe do something else?
+    }
+  }, []);
+
+  return <button onClick={handleClick}>Click here</button>;
+};
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,5 +22,5 @@ module.exports = {
   moduleNameMapper: {
     '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
   },
-  moduleDirectories: ['node_modules', '.'],
+  moduleDirectories: ['node_modules', '<rootDir>/node_modules', '.'],
 };

--- a/lib/feature-flags/feature-flags.spec.tsx
+++ b/lib/feature-flags/feature-flags.spec.tsx
@@ -5,75 +5,128 @@
  *   <div>The feature is active!</div>
  * </ConditionalFeature>
  */
-
+import { renderHook } from '@testing-library/react-hooks';
 import { render, screen } from '@testing-library/react';
 
 import {
   ConditionalFeature,
   FeatureFlagProvider,
   FeatureSet,
+  useFeatureFlags,
 } from './feature-flags';
 
-describe('<ConditionalFeature />', () => {
-  it('should render nothing if an unknown feature name is provided', () => {
-    const features: FeatureSet = {};
+describe('feature flags', () => {
+  describe('<ConditionalFeature />', () => {
+    it('should render nothing if an unknown feature name is provided', () => {
+      const features: FeatureSet = {};
 
-    render(
-      <FeatureFlagProvider features={features}>
-        <ConditionalFeature name="some-unknown-feature-name">
-          <div data-testid="expectedElement">This should not be visible!</div>
-        </ConditionalFeature>
-      </FeatureFlagProvider>
-    );
+      render(
+        <FeatureFlagProvider features={features}>
+          <ConditionalFeature name="some-unknown-feature-name">
+            <div data-testid="expectedElement">This should not be visible!</div>
+          </ConditionalFeature>
+        </FeatureFlagProvider>
+      );
 
-    const children = screen.queryByTestId('expectedElement');
+      const children = screen.queryByTestId('expectedElement');
 
-    expect(children).toBeNull();
+      expect(children).toBeNull();
+    });
+
+    it('should render nothing if a known feature name is provided and that feature is inactive', () => {
+      const features: FeatureSet = {
+        'some-known-inactive-feature-name': {
+          isActive: false,
+        },
+      };
+
+      render(
+        <FeatureFlagProvider features={features}>
+          <ConditionalFeature name="some-known-inactive-feature-name">
+            <div data-testid="expectedElement">This should be visible!</div>
+          </ConditionalFeature>
+        </FeatureFlagProvider>
+      );
+
+      const children = screen.queryByTestId('expectedElement');
+
+      expect(children).toBeNull();
+    });
+
+    it('should render the children if a known feature name is provided and that feature is active', () => {
+      const features: FeatureSet = {
+        'some-known-active-feature-name': {
+          isActive: true,
+        },
+      };
+
+      render(
+        <FeatureFlagProvider features={features}>
+          <ConditionalFeature name="some-known-active-feature-name">
+            <div data-testid="expectedElement">This should be visible!</div>
+          </ConditionalFeature>
+        </FeatureFlagProvider>
+      );
+
+      screen.getByTestId('expectedElement');
+    });
+
+    it('should throw an exception if feature flag context is not provided', () => {
+      expect(() => {
+        render(<ConditionalFeature name="some-known-active-feature-name" />);
+      }).toThrow(
+        'A <FeatureFlagProvider /> must be provided as a parent of this component'
+      );
+    });
   });
 
-  it('should render nothing if a known feature name is provided and that feature is inactive', () => {
-    const features: FeatureSet = {
-      'some-known-inactive-feature-name': {
-        isActive: false,
-      },
+  describe('useFeatureFlags() hook', () => {
+    const getContextWrapper = (features: FeatureSet) => {
+      const ContextWrapper: React.FC = ({ children }) => (
+        <FeatureFlagProvider features={features}>
+          {children}
+        </FeatureFlagProvider>
+      );
+
+      return ContextWrapper;
     };
 
-    render(
-      <FeatureFlagProvider features={features}>
-        <ConditionalFeature name="some-known-inactive-feature-name">
-          <div data-testid="expectedElement">This should be visible!</div>
-        </ConditionalFeature>
-      </FeatureFlagProvider>
-    );
+    it('should return a method to check if a named hook is active and return true if it is', () => {
+      const { result } = renderHook(() => useFeatureFlags(), {
+        wrapper: getContextWrapper({
+          'test-feature': {
+            isActive: true,
+          },
+        }),
+      });
 
-    const children = screen.queryByTestId('expectedElement');
+      expect(result.current.isFeatureActive('test-feature')).toBe(true);
+    });
 
-    expect(children).toBeNull();
-  });
+    it("should return a method to check if a named hook is active and return false if it isn't", () => {
+      const { result } = renderHook(() => useFeatureFlags(), {
+        wrapper: getContextWrapper({
+          'test-feature': {
+            isActive: false,
+          },
+        }),
+      });
 
-  it('should render the children if a known feature name is provided and that feature is active', () => {
-    const features: FeatureSet = {
-      'some-known-active-feature-name': {
-        isActive: true,
-      },
-    };
+      expect(result.current.isFeatureActive('test-feature')).toBe(false);
+    });
 
-    render(
-      <FeatureFlagProvider features={features}>
-        <ConditionalFeature name="some-known-active-feature-name">
-          <div data-testid="expectedElement">This should be visible!</div>
-        </ConditionalFeature>
-      </FeatureFlagProvider>
-    );
+    it('should return a method to check if a named hook is active and return false if it is not defined', () => {
+      const { result } = renderHook(() => useFeatureFlags(), {
+        wrapper: getContextWrapper({
+          'test-feature': {
+            isActive: true,
+          },
+        }),
+      });
 
-    screen.getByTestId('expectedElement');
-  });
-
-  it('should throw an exception if feature flag context is not provided', () => {
-    expect(() => {
-      render(<ConditionalFeature name="some-known-active-feature-name" />);
-    }).toThrow(
-      'A <FeatureFlagProvider /> must be provided as a parent of this component'
-    );
+      expect(result.current.isFeatureActive('non-existant-feature')).toBe(
+        false
+      );
+    });
   });
 });

--- a/lib/feature-flags/feature-flags.spec.tsx
+++ b/lib/feature-flags/feature-flags.spec.tsx
@@ -91,6 +91,18 @@ describe('feature flags', () => {
       return ContextWrapper;
     };
 
+    it('should throw an exception if feature flag context is not provided', () => {
+      const { result } = renderHook(() => useFeatureFlags(), {
+        wrapper: undefined,
+      });
+
+      expect(result.error).toEqual(
+        new Error(
+          'A <FeatureFlagProvider /> must be provided as a parent of this component'
+        )
+      );
+    });
+
     it('should return a method to check if a named hook is active and return true if it is', () => {
       const { result } = renderHook(() => useFeatureFlags(), {
         wrapper: getContextWrapper({

--- a/lib/feature-flags/feature-flags.tsx
+++ b/lib/feature-flags/feature-flags.tsx
@@ -20,11 +20,24 @@ export const FeatureFlagProvider: React.FC<{
     </FeatureFlagContext.Provider>
   );
 };
+const isFeatureActive = (features: FeatureSet) => (featureName: string) => {
+  if (features[featureName] === undefined) {
+    return false;
+  }
 
-export const ConditionalFeature: React.FC<{ name: string }> = ({
-  name,
-  children,
-}) => {
+  if (features[featureName].isActive === false) {
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * React hook for accessing feature flags
+ */
+export const useFeatureFlags: () => {
+  isFeatureActive: (featureName: string) => boolean;
+} = () => {
   const features = useContext(FeatureFlagContext);
 
   if (features === undefined) {
@@ -33,11 +46,21 @@ export const ConditionalFeature: React.FC<{ name: string }> = ({
     );
   }
 
-  if (features[name] === undefined) {
-    return null;
-  }
+  return {
+    isFeatureActive: isFeatureActive(features),
+  };
+};
 
-  if (features[name].isActive === false) {
+/**
+ * React component for conditional rendering based on the active state of a feature flag
+ */
+export const ConditionalFeature: React.FC<{ name: string }> = ({
+  name,
+  children,
+}) => {
+  const { isFeatureActive } = useFeatureFlags();
+
+  if (!isFeatureActive(name)) {
     return null;
   }
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@storybook/react": "^6.1.21",
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
+    "@testing-library/react-hooks": "^7.0.1",
     "@testing-library/user-event": "^13.1.9",
     "@types/cookie": "^0.4.0",
     "@types/gtag.js": "^0.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,6 +3105,17 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.1.tgz#8429d8bf55bfe82e486bd582dd06457c2464900a"
+  integrity sha512-bpEQ2SHSBSzBmfJ437NmnP+oArQ7aVmmULiAp6Ag2rtyLBLPNFSMmgltUbFGmQOJdPWo4Ub31kpUC5T46zXNwQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^11.2.6":
   version "11.2.7"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
@@ -3451,6 +3462,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.8.tgz#3180de6d79bf53762001ad854e3ce49f36dd71fc"
+  integrity sha512-0ohAiJAx1DAUEcY9UopnfwCE9sSMDGnY/oXjWMax6g3RpzmTt2GMyMVAXcbn0mo8XAff0SbQJl2/SBU+hjSZ1A==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-modal@^3.12.0":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/@types/react-modal/-/react-modal-3.12.0.tgz#91fa86a76fd7fc57e36d2cf9b76efe5735a855a1"
@@ -3465,10 +3483,26 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^17.0.5":
   version "17.0.11"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.11.tgz#67fcd0ddbf5a0b083a0f94e926c7d63f3b836451"
   integrity sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.13"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.13.tgz#6b7c9a8f2868586ad87d941c02337c6888fb874f"
+  integrity sha512-D/G3PiuqTfE3IMNjLn/DCp6umjVCSvtZTPdtAFy5+Ved6CsdRvivfKeCzw79W4AatShtU4nGqgvOv5Gro534vQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -13142,6 +13176,13 @@ react-element-to-jsx-string@^14.3.2:
   dependencies:
     "@base2/pretty-print-object" "1.0.0"
     is-plain-object "3.0.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.3.tgz#276bfa05de8ac17b863587c9e0647522c25e2a0b"
+  integrity sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.9:
   version "6.0.9"


### PR DESCRIPTION
**What**  
Following the introduction of `<ConditionalFeature />`, this PR introduces a new hook for accessing the state of a feature flag during scripting (outside of the JSX rendering tree), for example, inside a `useEffect`.

**Why**  
[SCT-738](https://hackney.atlassian.net/browse/SCT-738)

**Anything else?**

- Have you added any new third-party libraries?
  - Yes – [`@testing-library/react-hooks`](https://github.com/testing-library/react-hooks-testing-library)
- ~Are any new environment variables or configuration values needed?~
- ~Anything else in this PR that isn't covered by the what/why?~
