### PR TITLE
style(SCT-628): update search for records tab name to "Search for records"

### DIFF
--- a/components/Search/MainSearchWrapper.tsx
+++ b/components/Search/MainSearchWrapper.tsx
@@ -22,7 +22,7 @@ const MainSearchWrapper = ({ type, columns }: Props): React.ReactElement => (
         },
         {
           url: '/cases',
-          text: 'Search for records by person',
+          text: 'Search for records',
         },
       ]}
     >

--- a/components/Search/__snapshots__/MainSearchWrapper.spec.tsx.snap
+++ b/components/Search/__snapshots__/MainSearchWrapper.spec.tsx.snap
@@ -40,7 +40,7 @@ exports[`MainSearchWrapper should render properly 1`] = `
           class="lbh-tabs govuk-tabs__tab"
           href="/cases"
         >
-          Search for records by person
+          Search for records
         </a>
       </li>
     </ul>


### PR DESCRIPTION
**What**  

Update the tab "Search for records by person" to "Search for records".

**Why**  

In https://github.com/LBHackney-IT/lbh-social-care-frontend/pull/505, we updated the descriptions for the search features but we missed out a very smol content change that was supposed to be a part of request design changes.

**Link to Jira ticket**

https://hackney.atlassian.net/browse/SCT-628