### PR TITLE
fix: Don't throw error on empty tags

### DIFF
--- a/components/FlexibleForms/TagsField.tsx
+++ b/components/FlexibleForms/TagsField.tsx
@@ -119,32 +119,33 @@ const Field = ({
         aria-live="polite"
         aria-relevant="additions"
       >
-        {tags.map((tag, i) => (
-          <li className={s.tag} key={i}>
-            {tag}{' '}
-            <button
-              type="button"
-              onClick={() => {
-                setFieldValue(
-                  name,
-                  tags.filter((existingTag) => existingTag !== tag)
-                );
-              }}
-            >
-              <span className="govuk-visually-hidden">Remove</span>
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
-                <path
-                  d="M-0.0501709 1.36379L1.36404 -0.050415L12.6778 11.2633L11.2635 12.6775L-0.0501709 1.36379Z"
-                  fill="#0B0C0C"
-                />
-                <path
-                  d="M11.2635 -0.050293L12.6778 1.36392L1.36404 12.6776L-0.0501709 11.2634L11.2635 -0.050293Z"
-                  fill="#0B0C0C"
-                />
-              </svg>
-            </button>
-          </li>
-        ))}
+        {tags &&
+          tags.map((tag, i) => (
+            <li className={s.tag} key={i}>
+              {tag}{' '}
+              <button
+                type="button"
+                onClick={() => {
+                  setFieldValue(
+                    name,
+                    tags.filter((existingTag) => existingTag !== tag)
+                  );
+                }}
+              >
+                <span className="govuk-visually-hidden">Remove</span>
+                <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+                  <path
+                    d="M-0.0501709 1.36379L1.36404 -0.050415L12.6778 11.2633L11.2635 12.6775L-0.0501709 1.36379Z"
+                    fill="#0B0C0C"
+                  />
+                  <path
+                    d="M11.2635 -0.050293L12.6778 1.36392L1.36404 12.6776L-0.0501709 11.2634L11.2635 -0.050293Z"
+                    fill="#0B0C0C"
+                  />
+                </svg>
+              </button>
+            </li>
+          ))}
       </ul>
 
       <div {...getComboboxProps()} className={s.combobox}>


### PR DESCRIPTION
**What**  
Error was being thrown because sometimes `tags` is undefined so calling .map errors out. Just a minor check to confirm tags is defined first.

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
