### PR TITLE
feature(SCT-808): Add gov notify variables to serverless

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -52,6 +52,9 @@ functions:
       NEXT_PUBLIC_FEEDBACK_LINK: ${ssm:/lbh-social-care/${self:provider.stage}/next-public-feedback-link}
       REDIRECT_URL: ${ssm:/lbh-social-care/${self:provider.stage}/redirect_url}
       NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: ${ssm:/lbh-social-care/${self:provider.stage}/next_public_google_analytics_id}
+      NOTIFY_API_KEY: ${ssm:/lbh-social-care/${self:provider.stage}/notify-api-key}
+      NOTIFY_APPROVER_TEMPLATE_ID: ${ssm:/lbh-social-care/${self:provider.stage}/notify-approver-template-id}
+      NOTIFY_RETURN_FOR_EDITS_TEMPLATE_ID: ${ssm:/lbh-social-care/${self:provider.stage}/notify-return-for-edits-template-id}
 resources:
   Resources:
     CloudFrontDistribution:


### PR DESCRIPTION
**What**  
This PR adds the three required gov notify environment variables to the serverless configuration. These variables exist on staging and will be added to production once it is confirmed to work.

**Why**  
To allow the approval functionality to utilise gov notify to send emails

**Anything else?**
three environment variables have been added to the staging environment: `notify-api-key`, `notify-approver-template-id` and `notify-return-for-edits-template-id`
- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
