### PR TITLE
feat(SCT-471): update add relationship form to show select person name

### DIFF
--- a/components/pages/people/relationships/add/AddRelationshipForm.spec.tsx
+++ b/components/pages/people/relationships/add/AddRelationshipForm.spec.tsx
@@ -184,7 +184,11 @@ describe('<AddRelationshipForm />', () => {
         </AuthProvider>
       );
 
-      expect(screen.queryByText(/There was a problem./)).toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          /There was a problem with getting current personal relationships./
+        )
+      ).toBeInTheDocument();
     });
   });
 
@@ -319,6 +323,10 @@ describe('<AddRelationshipForm />', () => {
       </AuthProvider>
     );
 
-    expect(screen.queryByText(/There was a problem./)).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        /There was a problem with getting the details of the selected resident./
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/components/pages/people/relationships/add/AddRelationshipForm.tsx
+++ b/components/pages/people/relationships/add/AddRelationshipForm.tsx
@@ -2,6 +2,7 @@ import Seo from 'components/Layout/Seo/Seo';
 import PersonView from 'components/PersonView/PersonView';
 import FormWizard from 'components/FormWizard/FormWizard';
 import formSteps from 'data/forms/add-relationship';
+import { useResident } from 'utils/api/residents';
 import { addRelationships, useRelationships } from 'utils/api/relationships';
 import PersonLinkConfirmation from 'components/Steps/PersonLinkConfirmation';
 import RELATIONSHIP_TYPE_OPTIONS from 'data/relationships';
@@ -31,11 +32,20 @@ const AddRelationshipForm: React.FC<{
     return data;
   };
 
-  const { data: relationships, error } = useRelationships(personId);
+  const { data: secondPerson, error: secondPersonError } =
+    useResident(secondPersonId);
 
-  if (!relationships && !error) return <Spinner />;
+  const { data: relationships, error: relationshipsError } =
+    useRelationships(personId);
 
-  if (error || relationships === undefined) return <ErrorMessage />;
+  if (!secondPerson && !secondPersonError) return <Spinner />;
+
+  if (secondPersonError || secondPerson === undefined) return <ErrorMessage />;
+
+  if (!relationships && !relationshipsError) return <Spinner />;
+
+  if (relationshipsError || relationships === undefined)
+    return <ErrorMessage />;
 
   const existingRelationshipTypes = relationships.personalRelationships.map(
     (relationship) => {
@@ -66,7 +76,7 @@ const AddRelationshipForm: React.FC<{
         {() => (
           <FormWizard
             formPath={`/people/${personId}/relationships/add/${secondPersonId}/`}
-            formSteps={formSteps(sortedRelationshipTypeOptions)}
+            formSteps={formSteps(sortedRelationshipTypeOptions, secondPerson)}
             title="Add new relationship"
             onFormSubmit={onFormSubmit}
             successMessage="Relationship has been added"

--- a/components/pages/people/relationships/add/AddRelationshipForm.tsx
+++ b/components/pages/people/relationships/add/AddRelationshipForm.tsx
@@ -40,12 +40,17 @@ const AddRelationshipForm: React.FC<{
 
   if (!secondPerson && !secondPersonError) return <Spinner />;
 
-  if (secondPersonError || secondPerson === undefined) return <ErrorMessage />;
+  if (secondPersonError || secondPerson === undefined)
+    return (
+      <ErrorMessage label="There was a problem with getting the details of the selected resident. Please refresh the page or try again later." />
+    );
 
   if (!relationships && !relationshipsError) return <Spinner />;
 
   if (relationshipsError || relationships === undefined)
-    return <ErrorMessage />;
+    return (
+      <ErrorMessage label="There was a problem with getting current personal relationships. Please refresh the page or try again later." />
+    );
 
   const existingRelationshipTypes = relationships.personalRelationships.map(
     (relationship) => {

--- a/data/forms/add-relationship.tsx
+++ b/data/forms/add-relationship.tsx
@@ -1,17 +1,30 @@
 import { FormStep, Option, Options } from 'components/Form/types';
+import { Resident } from 'types';
 
-const formSteps = (relationshipTypeOptions: Options): FormStep[] => {
+const formSteps = (
+  relationshipTypeOptions: Options,
+  secondPerson: Resident
+): FormStep[] => {
   return [
     {
       id: 'add-relationship',
       title: 'Add Relationship',
       components: [
-        <h2
+        <h1
           key="subtitle-details"
           className="govuk-fieldset__legend--l gov-weight-lighter govuk-!-margin-bottom-5"
         >
           Add new relationship
+        </h1>,
+        <h2
+          className="lbh-heading-h2 lbh-!-font-weight-light"
+          key="define-relationship-for"
+        >
+          Define a relationship for
         </h2>,
+        <h3 className="lbh-heading-h3" key="selected-person-name">
+          {`${secondPerson.firstName} ${secondPerson.lastName}`}
+        </h3>,
         {
           component: 'Select',
           placeHolder: 'Relationship type',

--- a/data/forms/add-relationship.tsx
+++ b/data/forms/add-relationship.tsx
@@ -16,13 +16,16 @@ const formSteps = (
         >
           Add new relationship
         </h1>,
-        <h2
-          className="lbh-heading-h2 lbh-!-font-weight-light"
+        <p
+          className="lbh-body govuk-!-font-size-27"
           key="define-relationship-for"
         >
           Define a relationship for
-        </h2>,
-        <h3 className="lbh-heading-h3" key="selected-person-name">
+        </p>,
+        <h3
+          className="lbh-body lbh-!-font-weight-bold govuk-!-font-size-24"
+          key="selected-person-name"
+        >
           {`${secondPerson.firstName} ${secondPerson.lastName}`}
         </h3>,
         {


### PR DESCRIPTION
**What**  

Update add relationship form to show select person name.

Before | After
--|--
![image](https://user-images.githubusercontent.com/42817036/125320857-049af200-e334-11eb-8038-c8c1652a79ae.png) | ![image](https://user-images.githubusercontent.com/42817036/125322996-3dd46180-e336-11eb-922a-47b3217acf17.png)


**Why**  

So the practitioners don't have to remember the person they've selected to add the relationship with.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
