### PR TITLE
Feature: Approval on submission history timeline

### DIFF
--- a/components/RevisionTimeline/MiniRevisionTimeline.module.scss
+++ b/components/RevisionTimeline/MiniRevisionTimeline.module.scss
@@ -24,3 +24,17 @@
     bottom: 0px;
   }
 }
+
+.approvalEvent {
+  &::after {
+    background-color: lbh-colour('lbh-text');
+  }
+  svg {
+    position: absolute;
+    left: -51px;
+
+    z-index: 2;
+    height: 14px;
+    top: 7px;
+  }
+}

--- a/components/RevisionTimeline/MiniRevisionTimeline.module.scss
+++ b/components/RevisionTimeline/MiniRevisionTimeline.module.scss
@@ -34,7 +34,7 @@
     left: -51px;
 
     z-index: 2;
-    height: 14px;
-    top: 7px;
+    height: 12px;
+    top: 10px;
   }
 }

--- a/components/RevisionTimeline/RevisionTimeline.spec.tsx
+++ b/components/RevisionTimeline/RevisionTimeline.spec.tsx
@@ -66,4 +66,19 @@ describe('RevisionTimeline', () => {
 
     expect(screen.getAllByRole('listitem').length).toBe(4);
   });
+
+  it('correctly renders an approval', () => {
+    render(
+      <RevisionTimeline
+        submission={{
+          ...mockSubmission,
+          approvedAt: '2021-07-28T11:00:00.000Z',
+          approvedBy: mockedWorker,
+        }}
+      />
+    );
+
+    expect(screen.getByText(`Approved by ${mockedWorker.email}`));
+    expect(screen.getByText('28 Jul 2021', { exact: false }));
+  });
 });

--- a/components/RevisionTimeline/RevisionTimeline.tsx
+++ b/components/RevisionTimeline/RevisionTimeline.tsx
@@ -1,5 +1,6 @@
 import { format } from 'date-fns';
 import { Submission } from 'data/flexibleForms/forms.types';
+import s from './MiniRevisionTimeline.module.scss';
 
 interface Props {
   submission: Submission;
@@ -13,6 +14,23 @@ const RevisionTimeline = ({ submission }: Props): React.ReactElement | null => {
     <>
       <h2>History</h2>
       <ol className="lbh-timeline">
+        {submission.approvedAt && (
+          <li className={`lbh-timeline__event ${s.approvalEvent}`}>
+            <svg width="34" height="30" viewBox="0 0 34 30" fill="none">
+              <path
+                d="M3 16.4167L10.4286 24L31 3"
+                stroke="white"
+                strokeWidth="8"
+              />
+            </svg>
+            <h3 className="lbh-body">
+              Approved by {submission.approvedBy?.email}
+            </h3>
+            <p className="lbh-body-xs">
+              {format(new Date(submission.approvedAt), 'dd MMM yyyy K.mm aaa')}
+            </p>
+          </li>
+        )}
         {revisions.map((revision, i) => (
           <li
             className={`lbh-timeline__event lbh-timeline__event--minor ${

--- a/factories/submissions.ts
+++ b/factories/submissions.ts
@@ -10,8 +10,8 @@ export const mockSubmission: Submission = {
   createdAt: '2021-06-21T12:00:00.000Z',
   submittedBy: mockedWorker,
   submittedAt: '2021-07-21T12:00:00.000Z',
-  approvedBy: mockedWorker,
-  approvedAt: '2021-08-21T12:00:00.000Z',
+  approvedBy: null,
+  approvedAt: null,
   workers: [],
   editHistory: [
     {


### PR DESCRIPTION
**What**  
This PR adds when a form has been approved to the submission's history timeline

**Why**  
To allow managers and workers to see when a submission has been approved, at what time and by who

**Anything else?**
![image](https://user-images.githubusercontent.com/43789512/125321689-dcf85980-e334-11eb-85a8-43bf0ff40d6d.png)


- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
