### PR TITLE
feat(SCT-471): add main carer, gender and details to view relationships

### DIFF
--- a/components/pages/people/relationships/view/Relationships.spec.tsx
+++ b/components/pages/people/relationships/view/Relationships.spec.tsx
@@ -4,6 +4,9 @@ import Relationships from './Relationships';
 import * as relationshipsAPI from 'utils/api/relationships';
 
 import {
+  mockedRelationshipFactory,
+  mockedRelationshipData,
+  mockedRelationPerson,
   mockedRelationship,
   mockedRelationshipPartialData,
   mockedRelationshipNoData,
@@ -51,7 +54,6 @@ describe('Relationships component', () => {
     expect(queryByText('Other')).toBeInTheDocument();
     expect(queryByText('Sibling(s)')).toBeInTheDocument();
     expect(queryByText('Unborn sibling(s)')).toBeInTheDocument();
-    expect(queryByText('Sibling of unborn child')).toBeInTheDocument();
 
     expect(queryByText('Giovanni Muciaccia')).toBeInTheDocument();
     expect(queryByText('Jambi Neverborn')).toBeInTheDocument();
@@ -75,7 +77,6 @@ describe('Relationships component', () => {
     expect(queryByText('Children')).toBeInTheDocument();
     expect(queryByText('Other')).not.toBeInTheDocument();
     expect(queryByText('Sibling(s)')).not.toBeInTheDocument();
-    expect(queryByText('Sibling of unborn child')).not.toBeInTheDocument();
 
     expect(getByText('Mastro Geppetto')).toBeInTheDocument();
     expect(getByText('Pinocchio Geppetto')).toBeInTheDocument();
@@ -205,5 +206,255 @@ describe('Relationships component', () => {
     expect(second).toHaveTextContent('Giovanni Muciaccia');
     expect(third).toHaveTextContent('Neil Muciaccia');
     expect(fourth).toHaveTextContent('Francesco Rostrini');
+  });
+
+  it('displays the gender of the related people', async () => {
+    jest.spyOn(relationshipsAPI, 'useRelationships').mockImplementation(() => ({
+      data: mockedRelationshipFactory.build({
+        personId: 33339587,
+        personalRelationships: [
+          mockedRelationshipData.build({
+            persons: [
+              mockedRelationPerson.build({ gender: 'M' }),
+              mockedRelationPerson.build({ gender: 'F' }),
+              mockedRelationPerson.build({ gender: 'I' }),
+              mockedRelationPerson.build({ gender: 'U' }),
+            ],
+          }),
+        ],
+      }),
+      isValidating: false,
+      mutate: jest.fn(),
+      revalidate: jest.fn(),
+    }));
+
+    const props = {
+      id: 33339587,
+    };
+
+    const { queryByTestId } = render(<Relationships {...props} />);
+
+    const first = queryByTestId('related-person-gender-0');
+    const second = queryByTestId('related-person-gender-1');
+    const third = queryByTestId('related-person-gender-2');
+    const fourth = queryByTestId('related-person-gender-3');
+
+    expect(first).toHaveTextContent('Male');
+    expect(second).toHaveTextContent('Female');
+    expect(third).toHaveTextContent('Indeterminate');
+    expect(fourth).toHaveTextContent('Unknown');
+  });
+
+  it('displays if related person is a main carer', async () => {
+    jest.spyOn(relationshipsAPI, 'useRelationships').mockImplementation(() => ({
+      data: mockedRelationshipFactory.build({
+        personId: 33339587,
+        personalRelationships: [
+          mockedRelationshipData.build({
+            persons: [
+              mockedRelationPerson.build({ isMainCarer: 'Y' }),
+              mockedRelationPerson.build({ isMainCarer: 'N' }),
+              mockedRelationPerson.build({ isMainCarer: undefined }),
+            ],
+          }),
+        ],
+      }),
+      isValidating: false,
+      mutate: jest.fn(),
+      revalidate: jest.fn(),
+    }));
+
+    const props = {
+      id: 33339587,
+    };
+
+    const { queryByTestId } = render(<Relationships {...props} />);
+
+    const first = queryByTestId('related-person-additional-options-0');
+    const second = queryByTestId('related-person-additional-options-1');
+    const third = queryByTestId('related-person-additional-options-2');
+
+    expect(first).toHaveTextContent('Main carer');
+    expect(second).not.toHaveTextContent('Main carer');
+    expect(third).not.toHaveTextContent('Main carer');
+  });
+
+  it('displays the details of the relationship', async () => {
+    jest.spyOn(relationshipsAPI, 'useRelationships').mockImplementation(() => ({
+      data: mockedRelationshipFactory.build({
+        personId: 33339587,
+        personalRelationships: [
+          mockedRelationshipData.build({
+            persons: [
+              mockedRelationPerson.build({ details: 'Emergency contact' }),
+              mockedRelationPerson.build({ details: undefined }),
+            ],
+          }),
+        ],
+      }),
+      isValidating: false,
+      mutate: jest.fn(),
+      revalidate: jest.fn(),
+    }));
+
+    const props = {
+      id: 33339587,
+    };
+
+    const { queryByTestId } = render(<Relationships {...props} />);
+
+    expect(queryByTestId('related-person-details-0')).toHaveTextContent(
+      'Emergency contact'
+    );
+  });
+
+  describe('when there are relationships with parent of unborn child', () => {
+    it('displays under "Parent(s)" if only relationship', async () => {
+      jest
+        .spyOn(relationshipsAPI, 'useRelationships')
+        .mockImplementation(() => ({
+          data: mockedRelationshipFactory.build({
+            personId: 33339587,
+            personalRelationships: [
+              mockedRelationshipData.build({
+                type: 'parentOfUnbornChild',
+                persons: [mockedRelationPerson.build()],
+              }),
+            ],
+          }),
+          isValidating: false,
+          mutate: jest.fn(),
+          revalidate: jest.fn(),
+        }));
+
+      const props = {
+        id: 33339587,
+      };
+
+      const { queryByTestId } = render(<Relationships {...props} />);
+
+      expect(queryByTestId('parent')).toHaveTextContent('Parent(s)');
+    });
+
+    it('displays "Parent(s)" if existing parent relationship', async () => {
+      jest
+        .spyOn(relationshipsAPI, 'useRelationships')
+        .mockImplementation(() => ({
+          data: mockedRelationshipFactory.build({
+            personId: 33339587,
+            personalRelationships: [
+              mockedRelationshipData.build({
+                type: 'parentOfUnbornChild',
+                persons: [
+                  mockedRelationPerson.build({
+                    firstName: 'Foo',
+                    lastName: 'Bar',
+                  }),
+                ],
+              }),
+              mockedRelationshipData.build({
+                type: 'parent',
+                persons: [
+                  mockedRelationPerson.build({
+                    firstName: 'Fizz',
+                    lastName: 'Buzz',
+                  }),
+                ],
+              }),
+            ],
+          }),
+          isValidating: false,
+          mutate: jest.fn(),
+          revalidate: jest.fn(),
+        }));
+
+      const props = {
+        id: 33339587,
+      };
+
+      const { queryByTestId } = render(<Relationships {...props} />);
+
+      const first = queryByTestId('related-person-name-0');
+      const second = queryByTestId('related-person-name-1');
+
+      expect(queryByTestId('parent')).toHaveTextContent('Parent(s)');
+      expect(first).toHaveTextContent('Foo Bar');
+      expect(second).toHaveTextContent('Fizz Buzz');
+    });
+  });
+
+  describe('when there are relationships with sibling of unborn child', () => {
+    it('displays under "Sibling(s)" if only relationship', async () => {
+      jest
+        .spyOn(relationshipsAPI, 'useRelationships')
+        .mockImplementation(() => ({
+          data: mockedRelationshipFactory.build({
+            personId: 33339587,
+            personalRelationships: [
+              mockedRelationshipData.build({
+                type: 'siblingOfUnbornChild',
+                persons: [mockedRelationPerson.build()],
+              }),
+            ],
+          }),
+          isValidating: false,
+          mutate: jest.fn(),
+          revalidate: jest.fn(),
+        }));
+
+      const props = {
+        id: 33339587,
+      };
+
+      const { queryByTestId } = render(<Relationships {...props} />);
+
+      expect(queryByTestId('sibling')).toHaveTextContent('Sibling(s)');
+    });
+
+    it('displays "Sibling(s)" if existing parent relationship', async () => {
+      jest
+        .spyOn(relationshipsAPI, 'useRelationships')
+        .mockImplementation(() => ({
+          data: mockedRelationshipFactory.build({
+            personId: 33339587,
+            personalRelationships: [
+              mockedRelationshipData.build({
+                type: 'siblingOfUnbornChild',
+                persons: [
+                  mockedRelationPerson.build({
+                    firstName: 'Foo',
+                    lastName: 'Bar',
+                  }),
+                ],
+              }),
+              mockedRelationshipData.build({
+                type: 'sibling',
+                persons: [
+                  mockedRelationPerson.build({
+                    firstName: 'Fizz',
+                    lastName: 'Buzz',
+                  }),
+                ],
+              }),
+            ],
+          }),
+          isValidating: false,
+          mutate: jest.fn(),
+          revalidate: jest.fn(),
+        }));
+
+      const props = {
+        id: 33339587,
+      };
+
+      const { queryByTestId } = render(<Relationships {...props} />);
+
+      const first = queryByTestId('related-person-name-0');
+      const second = queryByTestId('related-person-name-1');
+
+      expect(queryByTestId('sibling')).toHaveTextContent('Sibling(s)');
+      expect(first).toHaveTextContent('Foo Bar');
+      expect(second).toHaveTextContent('Fizz Buzz');
+    });
   });
 });

--- a/factories/relationships.ts
+++ b/factories/relationships.ts
@@ -19,6 +19,8 @@ export const mockedRelationPerson = Factory.define<RelationshipPerson>(
     firstName: 'mock_me',
     lastName: 'mock_me',
     gender: 'M',
+    isMainCarer: 'N',
+    details: 'Some context of relationship',
   })
 );
 

--- a/types.ts
+++ b/types.ts
@@ -215,6 +215,8 @@ export interface RelationshipPerson {
   firstName: string;
   lastName: string;
   gender?: string;
+  isMainCarer?: string;
+  details?: string;
 }
 
 export interface Relationship {


### PR DESCRIPTION
**What**  

Add if a related person is a main carer and display their gender and any details added to the relationship.

Before | After
--|--
![image](https://user-images.githubusercontent.com/42817036/125438754-5de8623a-d00a-4166-907b-38430439ccd2.png) | ![image](https://user-images.githubusercontent.com/42817036/125438683-2cdfb516-8421-495f-8f81-fa3aba20acfb.png)

**Why**  

We need to display what we have as fields in the add relationship form.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
