### PR TITLE
SCT-828 - Public ENV variable

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -36,6 +36,7 @@ functions:
       securityGroupIds: ${self:custom.securityGroups.${self:provider.stage}}
       subnetIds: ${self:custom.subnets.${self:provider.stage}}
     environment:
+      NEXT_PUBLIC_ENV: ${opt:stage}
       AWS_KEY: ${ssm:/lbh-social-care/${self:provider.stage}/aws-key}
       ENDPOINT_API: ${ssm:/lbh-social-care/${self:provider.stage}/endpoint-case-viewer}
       GSSO_URL: ${ssm:/lbh-social-care/${self:provider.stage}/gsso-url}


### PR DESCRIPTION
**What**  
Added the NEXT_PUBLIC_ENV variable in serverless.yml with value ${opt:stage}.
The final value should be "Staging" or "Production" based on the stage.

**Why**  
This is necessary for [this PR](https://github.com/LBHackney-IT/lbh-social-care-frontend/pull/562) so Cypress can read the new variable and pass the tests for the new feature/fix, which is currently failing as Staging doesn't have this variable set
