### PR TITLE
Fix for "add relationship" link after page design change

### DIFF
--- a/components/pages/people/relationships/view/Relationships.tsx
+++ b/components/pages/people/relationships/view/Relationships.tsx
@@ -86,7 +86,7 @@ const Relationships = ({ id }: Props): React.ReactElement => {
           <ConditionalFeature name="add-relationships">
             <Button
               label="Add a new relationship"
-              route={`${id}/relationships/add`}
+              route={`/people/${id}/relationships/add`}
             />
           </ConditionalFeature>
         </div>


### PR DESCRIPTION
**What**  
Fixed the "add a new relationship" button link so it works again

**Why**  
After the page redesign, the link was not working anymore