### PR TITLE
Fix for "Allocate worker" button link

### DIFF
--- a/components/AllocatedWorkers/AllocatedWorkers.tsx
+++ b/components/AllocatedWorkers/AllocatedWorkers.tsx
@@ -45,7 +45,7 @@ const AllocatedWorkers = ({ person }: Props): React.ReactElement => {
             <Button
               label="Allocate worker"
               isSecondary
-              route={`${asPath}/allocations/add`}
+              route={`${asPath}/add`}
             />
           )}
         </div>


### PR DESCRIPTION
**What**  
Fix for the "Allocate worker" button link

**Why**  
After the page redesign, the link doesn't work anymore
