### PR TITLE
feat(SCT-481): create flow for removal of a personal relationship

### DIFF
--- a/components/pages/people/relationships/remove/RemoveRelationshipDialog.module.scss
+++ b/components/pages/people/relationships/remove/RemoveRelationshipDialog.module.scss
@@ -1,0 +1,17 @@
+@import 'lbh-frontend/lbh/base';
+
+.actions {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+
+    * {
+      margin-top: 0;
+    }
+    *:last-child {
+      margin-left: 1.5rem;
+    }
+  }
+}

--- a/components/pages/people/relationships/remove/RemoveRelationshipDialog.spec.tsx
+++ b/components/pages/people/relationships/remove/RemoveRelationshipDialog.spec.tsx
@@ -1,0 +1,52 @@
+import RemoveRelationshipDialog from './RemoveRelationshipDialog';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { residentFactory } from 'factories/residents';
+
+describe('RemoveRelationshipDialog', () => {
+  it('displays the name of the person as part of the title', () => {
+    render(
+      <RemoveRelationshipDialog
+        isOpen={true}
+        onDismiss={jest.fn()}
+        onFormSubmit={jest.fn()}
+        person={residentFactory.build({ firstName: 'Foo', lastName: 'Bar' })}
+      />
+    );
+
+    expect(screen.queryByText(/Foo Bar/)).toBeInTheDocument();
+  });
+
+  it('calls onFormSubmit when button is clicked', () => {
+    const onFormSubmit = jest.fn();
+
+    render(
+      <RemoveRelationshipDialog
+        isOpen={true}
+        onDismiss={jest.fn()}
+        onFormSubmit={onFormSubmit}
+        person={residentFactory.build()}
+      />
+    );
+
+    fireEvent.click(screen.getByText(/Yes/));
+
+    expect(onFormSubmit).toHaveBeenCalled();
+  });
+
+  it('calls onDismiss when "Cancel" is clicked', () => {
+    const onDismiss = jest.fn();
+
+    render(
+      <RemoveRelationshipDialog
+        isOpen={true}
+        onDismiss={onDismiss}
+        onFormSubmit={jest.fn()}
+        person={residentFactory.build()}
+      />
+    );
+
+    fireEvent.click(screen.getByText(/Cancel/));
+
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});

--- a/components/pages/people/relationships/remove/RemoveRelationshipDialog.tsx
+++ b/components/pages/people/relationships/remove/RemoveRelationshipDialog.tsx
@@ -1,0 +1,49 @@
+import Dialog from 'components/Dialog/Dialog';
+import { Resident } from 'types';
+import style from './RemoveRelationshipDialog.module.scss';
+
+interface Props {
+  isOpen: boolean;
+  onDismiss: () => void;
+  person: Resident;
+  onFormSubmit: () => void;
+}
+
+const RemoveRelationshipDialog = ({
+  person,
+  isOpen,
+  onDismiss,
+  onFormSubmit,
+}: Props): React.ReactElement => {
+  return (
+    <Dialog
+      title={`You are about to remove ${person.firstName} ${person.lastName}`}
+      isOpen={isOpen}
+      onDismiss={onDismiss}
+    >
+      <p className="lbh-body">
+        Are you sure you want to remove this relationship?
+      </p>
+      <p className="lbh-body">
+        <u>
+          This feature is currently under development and does not actually
+          remove a relationship yet. It&apos;s not visible on production.
+        </u>
+      </p>
+      <div className={style.actions}>
+        <button onClick={onFormSubmit} className="govuk-button lbh-button">
+          Yes, remove
+        </button>
+        <a
+          className="lbh-link lbh-link--no-visited-state"
+          href="#"
+          onClick={onDismiss}
+        >
+          Cancel
+        </a>
+      </div>
+    </Dialog>
+  );
+};
+
+export default RemoveRelationshipDialog;

--- a/components/pages/people/relationships/view/Relationships.spec.tsx
+++ b/components/pages/people/relationships/view/Relationships.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import Relationships from './Relationships';
 import {
   FeatureFlagProvider,
@@ -19,6 +19,7 @@ import {
   mockedUnbornSiblingRelationship,
   mockedOrderedRelationship,
 } from 'factories/relationships';
+import { mockedResident } from 'factories/residents';
 
 jest.mock('next/router', () => ({
   useRouter: () => ({
@@ -29,16 +30,16 @@ jest.mock('next/router', () => ({
 
 jest.mock('components/Spinner/Spinner', () => () => 'MockedSpinner');
 
+const person = mockedResident;
+
 describe('Relationships component', () => {
   it('should display properly', () => {
-    const props = {
-      id: 33339587,
-    };
     const { getByText } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
+
     expect(getByText('MockedSpinner')).toBeInTheDocument();
   });
 
@@ -49,13 +50,10 @@ describe('Relationships component', () => {
       mutate: jest.fn(),
       revalidate: jest.fn(),
     }));
-    const props = {
-      id: 33339587,
-    };
 
     const { queryByText } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
 
@@ -77,14 +75,13 @@ describe('Relationships component', () => {
       mutate: jest.fn(),
       revalidate: jest.fn(),
     }));
-    const props = {
-      id: 33339587,
-    };
+
     const { getByText, queryByText } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
+
     expect(queryByText('Parent(s)')).toBeInTheDocument();
     expect(queryByText('Children')).toBeInTheDocument();
     expect(queryByText('Other')).not.toBeInTheDocument();
@@ -101,14 +98,13 @@ describe('Relationships component', () => {
       mutate: jest.fn(),
       revalidate: jest.fn(),
     }));
-    const props = {
-      id: 33339587,
-    };
+
     const { queryByText } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
+
     expect(queryByText('No relationship found')).toBeInTheDocument();
   });
 
@@ -119,12 +115,10 @@ describe('Relationships component', () => {
       mutate: jest.fn(),
       revalidate: jest.fn(),
     }));
-    const props = {
-      id: 33339587,
-    };
+
     const { queryByText } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
 
@@ -134,7 +128,7 @@ describe('Relationships component', () => {
   it('should populate the list converting the type to display name', async () => {
     jest.spyOn(relationshipsAPI, 'useRelationships').mockImplementation(() => ({
       data: {
-        personId: 33339587,
+        personId: person.id,
         personalRelationships: [mockedParentRelationship],
       },
       isValidating: false,
@@ -142,13 +136,9 @@ describe('Relationships component', () => {
       revalidate: jest.fn(),
     }));
 
-    const props = {
-      id: 33339587,
-    };
-
     const { queryByText } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
 
@@ -160,7 +150,7 @@ describe('Relationships component', () => {
   it('should populate the list converting the type to display name', async () => {
     jest.spyOn(relationshipsAPI, 'useRelationships').mockImplementation(() => ({
       data: {
-        personId: 33339587,
+        personId: person.id,
         personalRelationships: [mockedUnbornSiblingRelationship],
       },
       isValidating: false,
@@ -168,13 +158,9 @@ describe('Relationships component', () => {
       revalidate: jest.fn(),
     }));
 
-    const props = {
-      id: 33339587,
-    };
-
     const { queryByText } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
 
@@ -185,7 +171,7 @@ describe('Relationships component', () => {
   it('should populate the list in alphabetical order (by surname/name) with same surname', async () => {
     jest.spyOn(relationshipsAPI, 'useRelationships').mockImplementation(() => ({
       data: {
-        personId: 33339587,
+        personId: person.id,
         personalRelationships: [mockedOrderedRelationship],
       },
       isValidating: false,
@@ -193,13 +179,9 @@ describe('Relationships component', () => {
       revalidate: jest.fn(),
     }));
 
-    const props = {
-      id: 33339587,
-    };
-
     const { queryAllByText } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
 
@@ -212,7 +194,7 @@ describe('Relationships component', () => {
   it('should populate the list in alphabetical order (by surname/name) different people', async () => {
     jest.spyOn(relationshipsAPI, 'useRelationships').mockImplementation(() => ({
       data: {
-        personId: 33339587,
+        personId: person.id,
         personalRelationships: [mockedOrderedRelationship],
       },
       isValidating: false,
@@ -220,13 +202,9 @@ describe('Relationships component', () => {
       revalidate: jest.fn(),
     }));
 
-    const props = {
-      id: 33339587,
-    };
-
     const { queryByTestId } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
 
@@ -244,7 +222,7 @@ describe('Relationships component', () => {
   it('displays the gender of the related people', async () => {
     jest.spyOn(relationshipsAPI, 'useRelationships').mockImplementation(() => ({
       data: mockedRelationshipFactory.build({
-        personId: 33339587,
+        personId: person.id,
         personalRelationships: [
           mockedRelationshipData.build({
             relationships: [
@@ -261,13 +239,9 @@ describe('Relationships component', () => {
       revalidate: jest.fn(),
     }));
 
-    const props = {
-      id: 33339587,
-    };
-
     const { queryByTestId } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
 
@@ -285,7 +259,7 @@ describe('Relationships component', () => {
   it('displays if related person is a main carer', async () => {
     jest.spyOn(relationshipsAPI, 'useRelationships').mockImplementation(() => ({
       data: mockedRelationshipFactory.build({
-        personId: 33339587,
+        personId: person.id,
         personalRelationships: [
           mockedRelationshipData.build({
             relationships: [
@@ -301,13 +275,9 @@ describe('Relationships component', () => {
       revalidate: jest.fn(),
     }));
 
-    const props = {
-      id: 33339587,
-    };
-
     const { queryByTestId } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
 
@@ -323,7 +293,7 @@ describe('Relationships component', () => {
   it('displays the details of the relationship', async () => {
     jest.spyOn(relationshipsAPI, 'useRelationships').mockImplementation(() => ({
       data: mockedRelationshipFactory.build({
-        personId: 33339587,
+        personId: person.id,
         personalRelationships: [
           mockedRelationshipData.build({
             relationships: [
@@ -340,13 +310,9 @@ describe('Relationships component', () => {
       revalidate: jest.fn(),
     }));
 
-    const props = {
-      id: 33339587,
-    };
-
     const { queryByTestId } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
 
@@ -361,7 +327,7 @@ describe('Relationships component', () => {
         .spyOn(relationshipsAPI, 'useRelationships')
         .mockImplementation(() => ({
           data: mockedRelationshipFactory.build({
-            personId: 33339587,
+            personId: person.id,
             personalRelationships: [
               mockedRelationshipData.build({
                 type: 'parentOfUnbornChild',
@@ -374,13 +340,9 @@ describe('Relationships component', () => {
           revalidate: jest.fn(),
         }));
 
-      const props = {
-        id: 33339587,
-      };
-
       const { queryByTestId } = render(
         <FeatureFlagProvider features={{}}>
-          <Relationships {...props} />
+          <Relationships person={person} />
         </FeatureFlagProvider>
       );
 
@@ -392,7 +354,7 @@ describe('Relationships component', () => {
         .spyOn(relationshipsAPI, 'useRelationships')
         .mockImplementation(() => ({
           data: mockedRelationshipFactory.build({
-            personId: 33339587,
+            personId: person.id,
             personalRelationships: [
               mockedRelationshipData.build({
                 type: 'parentOfUnbornChild',
@@ -419,13 +381,9 @@ describe('Relationships component', () => {
           revalidate: jest.fn(),
         }));
 
-      const props = {
-        id: 33339587,
-      };
-
       const { queryByTestId } = render(
         <FeatureFlagProvider features={{}}>
-          <Relationships {...props} />
+          <Relationships person={person} />
         </FeatureFlagProvider>
       );
 
@@ -444,7 +402,7 @@ describe('Relationships component', () => {
         .spyOn(relationshipsAPI, 'useRelationships')
         .mockImplementation(() => ({
           data: mockedRelationshipFactory.build({
-            personId: 33339587,
+            personId: person.id,
             personalRelationships: [
               mockedRelationshipData.build({
                 type: 'siblingOfUnbornChild',
@@ -457,13 +415,9 @@ describe('Relationships component', () => {
           revalidate: jest.fn(),
         }));
 
-      const props = {
-        id: 33339587,
-      };
-
       const { queryByTestId } = render(
         <FeatureFlagProvider features={{}}>
-          <Relationships {...props} />
+          <Relationships person={person} />
         </FeatureFlagProvider>
       );
 
@@ -475,7 +429,7 @@ describe('Relationships component', () => {
         .spyOn(relationshipsAPI, 'useRelationships')
         .mockImplementation(() => ({
           data: mockedRelationshipFactory.build({
-            personId: 33339587,
+            personId: person.id,
             personalRelationships: [
               mockedRelationshipData.build({
                 type: 'siblingOfUnbornChild',
@@ -502,13 +456,9 @@ describe('Relationships component', () => {
           revalidate: jest.fn(),
         }));
 
-      const props = {
-        id: 33339587,
-      };
-
       const { queryByTestId } = render(
         <FeatureFlagProvider features={{}}>
-          <Relationships {...props} />
+          <Relationships person={person} />
         </FeatureFlagProvider>
       );
 
@@ -527,12 +477,10 @@ describe('Relationships component', () => {
         isActive: true,
       },
     };
-    const props = {
-      id: 33339587,
-    };
+
     const { queryByText } = render(
       <FeatureFlagProvider features={features}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
 
@@ -546,7 +494,7 @@ describe('Relationships component', () => {
     });
     jest.spyOn(relationshipsAPI, 'useRelationships').mockImplementation(() => ({
       data: mockedRelationshipFactory.build({
-        personId: 33339587,
+        personId: person.id,
         personalRelationships: [
           mockedRelationshipData.build({
             relationships: [existingRelationship],
@@ -558,12 +506,9 @@ describe('Relationships component', () => {
       revalidate: jest.fn(),
     }));
 
-    const props = {
-      id: 33339587,
-    };
     const { queryByText } = render(
       <FeatureFlagProvider features={{}}>
-        <Relationships {...props} />
+        <Relationships person={person} />
       </FeatureFlagProvider>
     );
 
@@ -571,5 +516,186 @@ describe('Relationships component', () => {
       'href',
       `/people/${existingRelationship.personId}`
     );
+  });
+
+  describe('Remove a relationship', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(relationshipsAPI, 'useRelationships')
+        .mockImplementation(() => ({
+          data: mockedRelationshipFactory.build({
+            personId: person.id,
+            personalRelationships: [
+              mockedRelationshipData.build({
+                relationships: [mockedExistingRelationship.build()],
+              }),
+            ],
+          }),
+          isValidating: false,
+          mutate: jest.fn(),
+          revalidate: jest.fn(),
+        }));
+    });
+
+    it('displays "Remove" if the feature flag is active', async () => {
+      const features: FeatureSet = {
+        'remove-relationship': {
+          isActive: true,
+        },
+      };
+
+      const { queryByText } = render(
+        <FeatureFlagProvider features={features}>
+          <Relationships person={person} />
+        </FeatureFlagProvider>
+      );
+
+      expect(queryByText(/Remove/)).toBeInTheDocument();
+    });
+
+    it('does not display "Remove" if the feature flag is inactive', async () => {
+      const features: FeatureSet = {
+        'remove-relationship': {
+          isActive: false,
+        },
+      };
+
+      const { queryByText } = render(
+        <FeatureFlagProvider features={features}>
+          <Relationships person={person} />
+        </FeatureFlagProvider>
+      );
+
+      expect(queryByText(/Remove/)).not.toBeInTheDocument();
+    });
+
+    it('displays dialog if "Remove" is clicked', async () => {
+      jest
+        .spyOn(relationshipsAPI, 'useRelationships')
+        .mockImplementation(() => ({
+          data: mockedRelationshipFactory.build({
+            personId: person.id,
+            personalRelationships: [
+              mockedRelationshipData.build({
+                relationships: [
+                  mockedExistingRelationship.build({
+                    firstName: 'Foo',
+                    lastName: 'Bar',
+                  }),
+                ],
+              }),
+            ],
+          }),
+          isValidating: false,
+          mutate: jest.fn(),
+          revalidate: jest.fn(),
+        }));
+
+      const features: FeatureSet = {
+        'remove-relationship': {
+          isActive: true,
+        },
+      };
+
+      const { getByText, queryByText } = render(
+        <FeatureFlagProvider features={features}>
+          <Relationships person={person} />
+        </FeatureFlagProvider>
+      );
+
+      fireEvent.click(getByText(/Remove/));
+
+      expect(
+        queryByText(/You are about to remove Foo Bar/)
+      ).toBeInTheDocument();
+    });
+
+    it('hides dialog if cross is clicked', async () => {
+      const features: FeatureSet = {
+        'remove-relationship': {
+          isActive: true,
+        },
+      };
+
+      const { getByText, queryByText } = render(
+        <FeatureFlagProvider features={features}>
+          <Relationships person={person} />
+        </FeatureFlagProvider>
+      );
+
+      fireEvent.click(getByText(/Remove/));
+      fireEvent.click(getByText(/Close/));
+
+      expect(
+        queryByText(/You are about to remove Foo Bar/)
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls removeRelationship with ID of relationship when remove confirmed', async () => {
+      const existingRelationship = mockedExistingRelationship.build();
+
+      jest
+        .spyOn(relationshipsAPI, 'useRelationships')
+        .mockImplementation(() => ({
+          data: mockedRelationshipFactory.build({
+            personId: person.id,
+            personalRelationships: [
+              mockedRelationshipData.build({
+                relationships: [existingRelationship],
+              }),
+            ],
+          }),
+          isValidating: false,
+          mutate: jest.fn(),
+          revalidate: jest.fn(),
+        }));
+      jest.spyOn(relationshipsAPI, 'removeRelationship');
+
+      const features: FeatureSet = {
+        'remove-relationship': {
+          isActive: true,
+        },
+      };
+
+      const { getByText } = render(
+        <FeatureFlagProvider features={features}>
+          <Relationships person={person} />
+        </FeatureFlagProvider>
+      );
+
+      fireEvent.click(getByText(/Remove/));
+      fireEvent.click(getByText(/Yes/));
+
+      expect(relationshipsAPI.removeRelationship).toHaveBeenCalledWith(
+        existingRelationship.id.toString()
+      );
+    });
+
+    it('hides dialog after remove confirmed', async () => {
+      jest
+        .spyOn(relationshipsAPI, 'removeRelationship')
+        .mockImplementation(jest.fn());
+
+      const features: FeatureSet = {
+        'remove-relationship': {
+          isActive: true,
+        },
+      };
+
+      const { getByText, queryByText } = render(
+        <FeatureFlagProvider features={features}>
+          <Relationships person={person} />
+        </FeatureFlagProvider>
+      );
+
+      await waitFor(() => {
+        fireEvent.click(getByText(/Remove/));
+        fireEvent.click(getByText(/Yes/));
+
+        expect(
+          queryByText(/You are about to remove Foo Bar/)
+        ).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/features.ts
+++ b/features.ts
@@ -24,6 +24,10 @@ export const getFeatureFlags = ({
     'person-cases': {
       isActive: environmentName === 'production',
     },
+    // FEATURE-FLAG-EXPIRES [2021-08-15]: remove-relationship
+    'remove-relationship': {
+      isActive: environmentName === 'development',
+    },
 
     /*
       The feature-flags-implementation-proof has been setup to have an expiry date in the far future.

--- a/lib/relationships.spec.ts
+++ b/lib/relationships.spec.ts
@@ -18,6 +18,7 @@ describe('relationships APIs', () => {
       });
 
       const data = await relationshipsAPI.getRelationshipByResident(123);
+
       expect(mockedAxios.get).toHaveBeenCalled();
       expect(mockedAxios.get.mock.calls[0][0]).toEqual(
         `${ENDPOINT_API}/residents/123/relationships`
@@ -54,6 +55,24 @@ describe('relationships APIs', () => {
       } catch (e) {
         expect(e.name).toEqual('ValidationError');
       }
+    });
+  });
+
+  describe('removeRelationship', () => {
+    it("calls the service API's relationships endpoint", async () => {
+      const relationshipId = '123456789';
+      mockedAxios.delete.mockResolvedValue({ data: {} });
+
+      await relationshipsAPI.removeRelationship(relationshipId);
+
+      expect(mockedAxios.delete).toHaveBeenCalled();
+      expect(mockedAxios.delete.mock.calls[0][0]).toEqual(
+        // `${ENDPOINT_API}/relationships/personal/${relationshipId}`
+        `https://virtserver.swaggerhub.com/Hackney/social-care-case-viewer-api/1.0.0/relationships/personal/${relationshipId}`
+      );
+      expect(mockedAxios.delete.mock.calls[0][1]?.headers).toEqual({
+        'x-api-key': AWS_KEY,
+      });
     });
   });
 });

--- a/lib/relationships.ts
+++ b/lib/relationships.ts
@@ -22,3 +22,15 @@ export const addRelationship = async (
     headers: { ...headers, 'Content-Type': 'application/json' },
   });
 };
+
+export const removeRelationship = async (
+  relationshipId: string
+): Promise<void> => {
+  // `${ENDPOINT_API}/relationships/personal/${relationshipId}`,
+  await axios.delete(
+    `https://virtserver.swaggerhub.com/Hackney/social-care-case-viewer-api/1.0.0/relationships/personal/${relationshipId}`,
+    {
+      headers,
+    }
+  );
+};

--- a/pages/api/relationships/[id].ts
+++ b/pages/api/relationships/[id].ts
@@ -1,0 +1,43 @@
+import { StatusCodes } from 'http-status-codes';
+
+import { removeRelationship } from 'lib/relationships';
+import { isAuthorised } from 'utils/auth';
+
+import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
+
+const endpoint: NextApiHandler = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
+  const user = isAuthorised(req);
+  if (!user) {
+    return res.status(StatusCodes.UNAUTHORIZED).end();
+  }
+  if (!user.isAuthorised) {
+    return res.status(StatusCodes.FORBIDDEN).end();
+  }
+  switch (req.method) {
+    case 'DELETE':
+      try {
+        await removeRelationship(req.query.id as string);
+        res.status(StatusCodes.OK).end();
+      } catch (error) {
+        console.error('Relationship get error:', error?.response?.data);
+        error?.response?.status === StatusCodes.NOT_FOUND
+          ? res.status(StatusCodes.NOT_FOUND).json({
+              message: `Relationship not found with ID: ${req.query.id}.`,
+            })
+          : res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+              message: `Unable to remove the relationship with ID: ${req.query.id}.`,
+            });
+      }
+      break;
+
+    default:
+      res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: 'Invalid request method' });
+  }
+};
+
+export default endpoint;

--- a/pages/people/[id]/relationships.tsx
+++ b/pages/people/[id]/relationships.tsx
@@ -2,7 +2,6 @@ import { getResident } from 'lib/residents';
 import Layout from 'components/NewPersonView/Layout';
 import { GetServerSideProps } from 'next';
 import { Resident, User } from 'types';
-import { isAuthorised } from 'utils/auth';
 import { canViewRelationships } from 'lib/permissions';
 import Relationships from 'components/pages/people/relationships/view/Relationships';
 import { useAuth } from 'components/UserContext/UserContext';
@@ -17,7 +16,7 @@ const PersonAllocationsPage = ({ person }: Props): React.ReactElement => {
   return (
     <Layout person={person}>
       {canViewRelationships(user, person) ? (
-        <Relationships id={person.id} />
+        <Relationships person={person} />
       ) : (
         "You don't have permission to see this person's relationships"
       )}

--- a/utils/api/relationships.spec.ts
+++ b/utils/api/relationships.spec.ts
@@ -127,4 +127,18 @@ describe('relationships APIs', () => {
       });
     });
   });
+
+  describe('removeRelationship', () => {
+    it('calls the DELETE /api/relationships endpoint', () => {
+      jest.spyOn(axios, 'delete');
+
+      const relationshipId = '123456789';
+
+      relationshipsAPI.removeRelationship(relationshipId);
+
+      expect(axios.delete).toHaveBeenCalledWith(
+        `/api/relationships/${relationshipId}`
+      );
+    });
+  });
 });

--- a/utils/api/relationships.ts
+++ b/utils/api/relationships.ts
@@ -46,3 +46,11 @@ export const addRelationships = async (
 
   return data;
 };
+
+export const removeRelationship = async (
+  relationshipId: string
+): Promise<Record<string, unknown>> => {
+  const { data } = await axios.delete(`/api/relationships/${relationshipId}`);
+
+  return data;
+};


### PR DESCRIPTION
**What**  

Add `Remove` link for each relationship that opens up a dialog to confirm removal. The endpoint currently points to our SwaggerHub endpoint and is **under a feature flag** which means it's only visible on local dev and staging.

https://user-images.githubusercontent.com/42817036/125938635-7d8b701f-9bc0-411a-9ecb-688d7287bd8b.mov

**Why**  

We want to allow users to be able to remove a relationship.

**Anything else?**

Some follow-up actions include adding a Cypress test that will add and remove a relationship, refactoring some tests and eventually point to the real service API endpoint.