### PR TITLE
chore: fix the go back button behaviour

### DIFF
--- a/components/Layout/BackButton/BackButton.spec.tsx
+++ b/components/Layout/BackButton/BackButton.spec.tsx
@@ -17,4 +17,11 @@ describe('BackButton', () => {
     fireEvent.click(button);
     expect(history.back).toHaveBeenCalled();
   });
+
+  it('should not use the history back if an explicit url is given', () => {
+    const { getByText } = render(<BackButton href={'/foo'} />);
+    const button = getByText('Go back');
+    fireEvent.click(button);
+    expect(history.back).not.toHaveBeenCalled();
+  });
 });

--- a/components/Layout/BackButton/BackButton.tsx
+++ b/components/Layout/BackButton/BackButton.tsx
@@ -1,11 +1,9 @@
-import Router from 'next/router';
-
-const BackButton = (): React.ReactElement => (
+const BackButton = ({ href }: { href?: string }): React.ReactElement => (
   <div className="lbh-container">
     <a
       className="govuk-back-link lbh-back-link lbh-link--no-visited-state"
-      href="#"
-      onClick={() => window.history.back()}
+      href={href ?? '#'}
+      onClick={href ? undefined : () => window.history.back()}
     >
       Go back
     </a>

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -7,7 +7,7 @@ import Footer from './Footer/Footer';
 
 export interface Props {
   children: React.ReactChild;
-  goBackButton: boolean;
+  goBackButton: string | boolean;
   noLayout: boolean;
 }
 
@@ -25,7 +25,11 @@ const Layout = ({
       <SkipLink />
       <Header serviceName="Social Care" />
       <PhaseBanner phase="beta" feedbackLink={feedbackLink} />
-      {goBackButton && <BackButton />}
+      {goBackButton && (
+        <BackButton
+          href={typeof goBackButton === 'string' ? goBackButton : undefined}
+        />
+      )}
 
       <div className="govuk-width-container">
         <main className="govuk-main-wrapper" id="content" role="main">

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -4,19 +4,13 @@ import SkipLink from './SkipLink/SkipLink';
 import PhaseBanner from './PhaseBanner/PhaseBanner';
 import BackButton from './BackButton/BackButton';
 import Footer from './Footer/Footer';
-
+import { useBreadcrumb } from 'contexts/breadcrumbContext';
 export interface Props {
   children: React.ReactChild;
-  goBackButton: string | boolean;
-  noLayout: boolean;
 }
 
-const Layout = ({
-  children,
-  goBackButton = false,
-  noLayout = false,
-}: Props): React.ReactElement => {
-  if (noLayout) return <>{children}</>;
+const Layout = ({ children }: Props): React.ReactElement => {
+  const { goBackUrl } = useBreadcrumb();
 
   const feedbackLink = process.env.NEXT_PUBLIC_FEEDBACK_LINK || '';
   return (
@@ -25,11 +19,7 @@ const Layout = ({
       <SkipLink />
       <Header serviceName="Social Care" />
       <PhaseBanner phase="beta" feedbackLink={feedbackLink} />
-      {goBackButton && (
-        <BackButton
-          href={typeof goBackButton === 'string' ? goBackButton : undefined}
-        />
-      )}
+      {goBackUrl && <BackButton href={goBackUrl} />}
 
       <div className="govuk-width-container">
         <main className="govuk-main-wrapper" id="content" role="main">

--- a/contexts/breadcrumbContext.tsx
+++ b/contexts/breadcrumbContext.tsx
@@ -1,0 +1,31 @@
+import React, { useContext, createContext, useState } from 'react';
+
+interface ContextType {
+  goBackUrl: string | false;
+  //   setGoBackUrl: (newVal: string | false) => void;
+}
+
+const BreadcrumbContext = createContext<ContextType>({
+  goBackUrl: false,
+  //   setGoBackUrl: () => null,
+});
+
+export const BreadcrumbProvider = ({
+  children,
+}: {
+  children: React.ReactChild;
+}): React.ReactElement => {
+  //   const [goBackUrl, setGoBackUrl] = useState<string | false>(false);
+
+  let goBackUrl;
+
+  return (
+    <BreadcrumbContext.Provider value={{ goBackUrl }}>
+      {children}
+    </BreadcrumbContext.Provider>
+  );
+};
+
+export const useBreadcrumb = (): ContextType => useContext(BreadcrumbContext);
+
+export default BreadcrumbContext;

--- a/contexts/breadcrumbContext.tsx
+++ b/contexts/breadcrumbContext.tsx
@@ -1,13 +1,11 @@
-import React, { useContext, createContext, useState } from 'react';
+import React, { useContext, createContext } from 'react';
 
 interface ContextType {
   goBackUrl: string | false;
-  //   setGoBackUrl: (newVal: string | false) => void;
 }
 
 const BreadcrumbContext = createContext<ContextType>({
   goBackUrl: false,
-  //   setGoBackUrl: () => null,
 });
 
 export const BreadcrumbProvider = ({
@@ -26,6 +24,7 @@ export const BreadcrumbProvider = ({
   );
 };
 
-export const useBreadcrumb = (): ContextType => useContext(BreadcrumbContext);
+export const useBreadcrumb = (goBackUrl: string): ContextType =>
+  useContext(BreadcrumbContext);
 
 export default BreadcrumbContext;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,7 +23,7 @@ interface Props {
 
 interface ExtendedAppProps extends AppProps<Props> {
   Component: NextComponentType & {
-    goBackButton: boolean;
+    goBackButton: string | boolean;
     noLayout: boolean;
   };
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,13 +9,14 @@ import GoogleAnalytics from 'components/GoogleAnalytics/GoogleAnalytics';
 import { AuthProvider } from 'components/UserContext/UserContext';
 import { ErrorBoundary } from 'components/ErrorBoundary/ErrorBoundary';
 import { isAuthorised, shouldRedirect } from 'utils/auth';
+import { FeatureFlagProvider } from '../lib/feature-flags/feature-flags';
+import { getFeatureFlags } from 'features';
+import { BreadcrumbProvider } from 'contexts/breadcrumbContext';
 
 import type { User } from 'types';
 
 import 'stylesheets/all.scss';
 import 'stylesheets/header.scss';
-import { FeatureFlagProvider } from '../lib/feature-flags/feature-flags';
-import { getFeatureFlags } from 'features';
 
 interface Props {
   user?: Partial<User>;
@@ -51,14 +52,17 @@ const CustomApp = ({
       >
         <AuthProvider user={user}>
           <GoogleAnalytics>
-            <Layout
-              goBackButton={Component.goBackButton}
-              noLayout={Component.noLayout}
-            >
-              <ErrorBoundary>
+            <BreadcrumbProvider>
+              {Component.noLayout ? (
                 <Component {...pageProps} />
-              </ErrorBoundary>
-            </Layout>
+              ) : (
+                <Layout>
+                  <ErrorBoundary>
+                    <Component {...pageProps} />
+                  </ErrorBoundary>
+                </Layout>
+              )}
+            </BreadcrumbProvider>
           </GoogleAnalytics>
         </AuthProvider>
       </SWRConfig>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,17 +1,22 @@
 import Seo from 'components/Layout/Seo/Seo';
 import MyAllocatedCases from 'components/AllocatedCases/MyAllocatedCases';
 import DashboardWrapper from 'components/Dashboard/DashboardWrapper';
+import { useBreadcrumb } from 'contexts/breadcrumbContext';
 
-const MyCasesPage = (): React.ReactElement => (
-  <div>
-    <Seo title="My Work Space" />
-    <DashboardWrapper>
-      <>
-        <p className="govuk-body">People you are working with</p>
-        <MyAllocatedCases />
-      </>
-    </DashboardWrapper>
-  </div>
-);
+const MyCasesPage = (): React.ReactElement => {
+  useBreadcrumb('example');
+
+  return (
+    <div>
+      <Seo title="My Work Space" />
+      <DashboardWrapper>
+        <>
+          <p className="govuk-body">People you are working with</p>
+          <MyAllocatedCases />
+        </>
+      </DashboardWrapper>
+    </div>
+  );
+};
 
 export default MyCasesPage;


### PR DESCRIPTION
>i think the “go back” button needs some reconsideration soon. it is just a browser back button right now, but seems like it should behave a little differently (more like a breadcrumb)

> the back button works for me maybe one third of the time

>i know the “go back” pattern is a gds classic but it is more than a little problematic for a case management system

>we can improve the behaviour by hardcoding the link to go back to


remaining problem: how can we get dynamic information at the **top level** of a page component file?

eg. at the moment we say whether a page should show the back button by putting in `PersonPage.goBackButton = true`. how can we instead include specific information like the id of a person to go back to?