### PR TITLE
add canonical urls to forms

### DIFF
--- a/components/AddFormDialog/AddFormDialog.spec.tsx
+++ b/components/AddFormDialog/AddFormDialog.spec.tsx
@@ -5,6 +5,7 @@ import { AuthProvider } from 'components/UserContext/UserContext';
 import { mockedUser } from 'factories/users';
 import ADULT_GFORMS from 'data/googleForms/adultForms';
 import CHILD_GFORMS from 'data/googleForms/childForms';
+import flexibleForms from 'data/flexibleForms';
 
 import 'next/router';
 
@@ -60,6 +61,24 @@ describe('AddFormDialog', () => {
     );
     expect(screen.getByText(CHILD_GFORMS[0].text));
     expect(screen.queryByText(ADULT_GFORMS[0].text)).toBeNull();
+  });
+
+  it('supports canonical urls', () => {
+    render(
+      <AuthProvider user={mockedUser}>
+        <AddFormDialog
+          isOpen={true}
+          onDismiss={jest.fn()}
+          person={{ ...mockedResident, contextFlag: 'C' }}
+        />
+      </AuthProvider>
+    );
+    fireEvent.change(screen.getByLabelText('Search for a form'), {
+      target: { value: 'Case note' },
+    });
+    expect((screen.getByText('Case note') as HTMLLinkElement).href).toContain(
+      `/people/1/case-note`
+    );
   });
 
   it('allows searching for a form', () => {

--- a/components/AddFormDialog/AddFormDialog.tsx
+++ b/components/AddFormDialog/AddFormDialog.tsx
@@ -54,7 +54,9 @@ const AddFormDialog = ({
         })
         .map((f) => ({
           label: f.name,
-          href: `/submissions/new?form_id=${f.id}&social_care_id=${person.id}`,
+          href: f.canonicalUrl
+            ? f.canonicalUrl(person.id)
+            : `/submissions/new?form_id=${f.id}&social_care_id=${person.id}`,
           system: true,
           groupRecordable: !!f.groupRecordable,
           approvable: !!f.approvable,

--- a/data/flexibleForms/childCaseNote.ts
+++ b/data/flexibleForms/childCaseNote.ts
@@ -8,6 +8,7 @@ const form: Form = {
   groupRecordable: true,
   isViewableByAdults: false,
   isViewableByChildrens: false,
+  canonicalUrl: (socialCareId) => `/people/${socialCareId}/case-note`,
   steps: [
     {
       id: 'Case note',

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -65,6 +65,8 @@ export interface Form {
   isViewableByChildrens: boolean;
   isViewableByAdults: boolean;
   tags?: string[];
+  /** override the automatically generated /submissions/new... url, for edge case forms */
+  canonicalUrl?: (socialCareId: number) => string;
 }
 
 export interface RepeaterGroupAnswer {


### PR DESCRIPTION
in the `<AddFormDialog/>`, support weird forms (case notes, warning notes) that have their own special routes and aren't at the normal `/submissions/new...` path