### PR TITLE
Delete relationships UI fixes

### DIFF
--- a/components/pages/people/relationships/remove/RemoveRelationshipDialog.spec.tsx
+++ b/components/pages/people/relationships/remove/RemoveRelationshipDialog.spec.tsx
@@ -1,6 +1,7 @@
 import RemoveRelationshipDialog from './RemoveRelationshipDialog';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { residentFactory } from 'factories/residents';
+// import { residentFactory } from 'factories/residents';
+import { mockedExistingRelationship } from 'factories/relationships';
 
 describe('RemoveRelationshipDialog', () => {
   it('displays the name of the person as part of the title', () => {
@@ -9,7 +10,10 @@ describe('RemoveRelationshipDialog', () => {
         isOpen={true}
         onDismiss={jest.fn()}
         onFormSubmit={jest.fn()}
-        person={residentFactory.build({ firstName: 'Foo', lastName: 'Bar' })}
+        person={mockedExistingRelationship.build({
+          firstName: 'Foo',
+          lastName: 'Bar',
+        })}
       />
     );
 
@@ -24,7 +28,7 @@ describe('RemoveRelationshipDialog', () => {
         isOpen={true}
         onDismiss={jest.fn()}
         onFormSubmit={onFormSubmit}
-        person={residentFactory.build()}
+        person={mockedExistingRelationship.build()}
       />
     );
 
@@ -41,7 +45,7 @@ describe('RemoveRelationshipDialog', () => {
         isOpen={true}
         onDismiss={onDismiss}
         onFormSubmit={jest.fn()}
-        person={residentFactory.build()}
+        person={mockedExistingRelationship.build()}
       />
     );
 

--- a/components/pages/people/relationships/remove/RemoveRelationshipDialog.tsx
+++ b/components/pages/people/relationships/remove/RemoveRelationshipDialog.tsx
@@ -1,11 +1,11 @@
 import Dialog from 'components/Dialog/Dialog';
-import { Resident } from 'types';
+import { ExistingRelationship } from 'types';
 import style from './RemoveRelationshipDialog.module.scss';
 
 interface Props {
   isOpen: boolean;
   onDismiss: () => void;
-  person: Resident;
+  person?: ExistingRelationship;
   onFormSubmit: () => void;
 }
 
@@ -17,18 +17,17 @@ const RemoveRelationshipDialog = ({
 }: Props): React.ReactElement => {
   return (
     <Dialog
-      title={`You are about to remove ${person.firstName} ${person.lastName}`}
+      title={
+        person
+          ? `You are about to remove ${person.firstName} ${person.lastName}`
+          : ''
+      }
       isOpen={isOpen}
       onDismiss={onDismiss}
+      aria-label="remove_relationship_dialog"
     >
       <p className="lbh-body">
         Are you sure you want to remove this relationship?
-      </p>
-      <p className="lbh-body">
-        <u>
-          This feature is currently under development and does not actually
-          remove a relationship yet. It&apos;s not visible on production.
-        </u>
       </p>
       <div className={style.actions}>
         <button onClick={onFormSubmit} className="govuk-button lbh-button">

--- a/components/pages/people/relationships/view/Relationships.tsx
+++ b/components/pages/people/relationships/view/Relationships.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { ConditionalFeature } from 'lib/feature-flags/feature-flags';
 import Link from 'next/link';
 import style from './Relationships.module.scss';
-import { RelationshipType, Resident } from 'types';
+import { RelationshipType, Resident, ExistingRelationship } from 'types';
 import { RELATIONSHIP_TYPES } from 'data/relationships';
 import RemoveRelationshipDialog from '../remove/RemoveRelationshipDialog';
 
@@ -17,6 +17,8 @@ interface Props {
 const Relationships = ({ person }: Props): React.ReactElement => {
   const [isRemoveRelationshipDialogOpen, setIsRemoveRelationshipDialogOpen] =
     useState<boolean>(false);
+  const [personToRemove, setPersonToRemove] = useState<ExistingRelationship>();
+
   const [relationshipToRemoveId, setRelationshipToRemoveId] = useState('');
 
   const {
@@ -68,12 +70,14 @@ const Relationships = ({ person }: Props): React.ReactElement => {
   return (
     <div>
       <RemoveRelationshipDialog
-        person={person}
+        person={personToRemove}
         isOpen={isRemoveRelationshipDialogOpen}
         onDismiss={() => setIsRemoveRelationshipDialogOpen(false)}
         onFormSubmit={() => {
           removeRelationship(relationshipToRemoveId);
           setIsRemoveRelationshipDialogOpen(false);
+
+          window.location.reload();
         }}
       />
       <div>
@@ -215,6 +219,7 @@ const Relationships = ({ person }: Props): React.ReactElement => {
                               className="lbh-link lbh-link--no-visited-state"
                               href="#"
                               onClick={() => {
+                                setPersonToRemove(person);
                                 setIsRemoveRelationshipDialogOpen(true);
                                 setRelationshipToRemoveId(person.id.toString());
                               }}

--- a/lib/relationships.spec.ts
+++ b/lib/relationships.spec.ts
@@ -67,8 +67,7 @@ describe('relationships APIs', () => {
 
       expect(mockedAxios.delete).toHaveBeenCalled();
       expect(mockedAxios.delete.mock.calls[0][0]).toEqual(
-        // `${ENDPOINT_API}/relationships/personal/${relationshipId}`
-        `https://virtserver.swaggerhub.com/Hackney/social-care-case-viewer-api/1.0.0/relationships/personal/${relationshipId}`
+        `${ENDPOINT_API}/relationships/personal/${relationshipId}`
       );
       expect(mockedAxios.delete.mock.calls[0][1]?.headers).toEqual({
         'x-api-key': AWS_KEY,

--- a/lib/relationships.ts
+++ b/lib/relationships.ts
@@ -26,9 +26,8 @@ export const addRelationship = async (
 export const removeRelationship = async (
   relationshipId: string
 ): Promise<void> => {
-  // `${ENDPOINT_API}/relationships/personal/${relationshipId}`,
   await axios.delete(
-    `https://virtserver.swaggerhub.com/Hackney/social-care-case-viewer-api/1.0.0/relationships/personal/${relationshipId}`,
+    `${ENDPOINT_API}/relationships/personal/${relationshipId}`,
     {
       headers,
     }


### PR DESCRIPTION
**What**  
Changed the Relationship UI to use UseState react hook to update data visualisation,
tidied up the code

**Why**  
UseState lets us re-render the module without refreshing the page

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why?

We now need to update the relationship count in the left hand side
