### PR TITLE
fix: Remove weird hardcoded form answers

### DIFF
--- a/pages/api/submissions/[id]/index.ts
+++ b/pages/api/submissions/[id]/index.ts
@@ -22,12 +22,7 @@ const handler = async (
         const user = isAuthorised(req);
         const submission = await finishSubmission(
           id as string,
-          user?.email ?? '',
-          {
-            foo: {
-              bar: 'booooo',
-            },
-          }
+          user?.email ?? ''
         );
         if (req.body.approverEmail)
           await notifyApprover(


### PR DESCRIPTION
**What**  
Seems some hardcoded form answers for finishing a submission was left in by mistake!

**Why**  
Because it's a bug, definitely shouldn't be left in

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
