### PR TITLE
fix: case note submit bug

### DIFF
--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -88,7 +88,7 @@ const CaseNote = ({
               validationSchema={generateFlexibleSchema(fields)}
               onSubmit={handleSubmit}
             >
-              {({ touched, errors, values, isSubmitting, status }) => (
+              {({ touched, errors, values, isSubmitting, status, isValid }) => (
                 <Form>
                   {status && (
                     <Banner
@@ -113,7 +113,7 @@ const CaseNote = ({
                   ))}
 
                   <button
-                    onClick={() => setFinished(true)}
+                    onClick={() => isValid && setFinished(true)}
                     className="govuk-button lbh-button"
                     disabled={isSubmitting}
                   >


### PR DESCRIPTION
fix a tiny edge case where if you click the submit button while the form is invalid, the form would inadvertently set `finished` to true