### PR TITLE
feat: datetime field

### DIFF
--- a/components/FlexibleForms/DateTimeField.module.scss
+++ b/components/FlexibleForms/DateTimeField.module.scss
@@ -1,0 +1,4 @@
+.date {
+  max-width: 13rem;
+  margin-right: 10px;
+}

--- a/components/FlexibleForms/DateTimeField.spec.tsx
+++ b/components/FlexibleForms/DateTimeField.spec.tsx
@@ -1,0 +1,92 @@
+import DateTimeField from './DateTimeField';
+import { Formik, Form } from 'formik';
+import { render, screen } from '@testing-library/react';
+
+const mockSubmit = jest.fn();
+
+describe('TextField', () => {
+  it('renders two text inputs with the right types', () => {
+    render(
+      <Formik
+        onSubmit={mockSubmit}
+        initialValues={{
+          foo: false,
+        }}
+      >
+        {({ touched, errors }) => (
+          <Form>
+            <DateTimeField
+              touched={touched}
+              errors={errors}
+              name="foo"
+              label="Label text"
+              hint="Hint text"
+            />
+          </Form>
+        )}
+      </Formik>
+    );
+
+    expect(screen.getByText('Label text'));
+    expect(screen.getByText('Hint text'));
+    expect((screen.getByLabelText('Date') as HTMLInputElement).type).toBe(
+      'date'
+    );
+    expect((screen.getByLabelText('Time') as HTMLInputElement).type).toBe(
+      'time'
+    );
+  });
+
+  it('accepts an initial value', () => {
+    render(
+      <Formik
+        onSubmit={mockSubmit}
+        initialValues={{
+          foo: ['2021-12-01', '12:00'],
+        }}
+      >
+        {({ touched, errors }) => (
+          <Form>
+            <DateTimeField
+              touched={touched}
+              errors={errors}
+              name="foo"
+              label="Label text"
+              hint="Hint text"
+            />
+          </Form>
+        )}
+      </Formik>
+    );
+    expect(screen.getByDisplayValue('2021-12-01'));
+    expect(screen.getByDisplayValue('12:00'));
+  });
+
+  it('renders errors', () => {
+    render(
+      <Formik
+        onSubmit={mockSubmit}
+        initialValues={{
+          foo: '',
+        }}
+        initialErrors={{
+          foo: 'Example error',
+        }}
+        initialTouched={{
+          foo: true,
+        }}
+      >
+        {({ touched, errors }) => (
+          <DateTimeField
+            touched={touched}
+            errors={errors}
+            name="foo"
+            label="Label text"
+            hint="Hint text"
+          />
+        )}
+      </Formik>
+    );
+    expect(screen.getByText('Example error'));
+  });
+});

--- a/components/FlexibleForms/DateTimeField.spec.tsx
+++ b/components/FlexibleForms/DateTimeField.spec.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 
 const mockSubmit = jest.fn();
 
-describe('TextField', () => {
+describe('DateTimeField', () => {
   it('renders two text inputs with the right types', () => {
     render(
       <Formik

--- a/components/FlexibleForms/DateTimeField.tsx
+++ b/components/FlexibleForms/DateTimeField.tsx
@@ -1,0 +1,79 @@
+import {
+  Field as RawField,
+  ErrorMessage,
+  getIn,
+  FormikErrors,
+  FormikTouched,
+  FormikValues,
+} from 'formik';
+import s from './DateTimeField.module.scss';
+
+interface FieldProps {
+  touched: FormikTouched<FormikValues>;
+  errors: FormikErrors<FormikValues>;
+  name: string;
+  label: string;
+  type?: string;
+  hint?: string;
+  className?: string;
+  as?: string;
+  rows?: number;
+  required?: boolean;
+}
+
+const Field = ({
+  touched,
+  errors,
+  name,
+  label,
+  hint,
+  required,
+}: FieldProps): React.ReactElement => (
+  <div
+    className={`govuk-form-group lbh-form-group ${
+      getIn(touched, name) && getIn(errors, name) && 'govuk-form-group--error'
+    }`}
+  >
+    <label htmlFor={name} data-testid={name} className="govuk-label lbh-label">
+      {label}
+      {required && (
+        <span className="govuk-required">
+          <span aria-hidden="true">*</span>
+          <span className="govuk-visually-hidden">required</span>
+        </span>
+      )}
+    </label>
+
+    {hint && (
+      <span id={`${name}-hint`} className="govuk-hint lbh-hint">
+        {hint}
+      </span>
+    )}
+
+    <ErrorMessage name={name}>
+      {(msg) => (
+        <p className="govuk-error-message lbh-error-message" role="alert">
+          <span className="govuk-visually-hidden">Error:</span>
+          {msg[0] || msg[1]}
+        </p>
+      )}
+    </ErrorMessage>
+
+    <RawField
+      name={`${name}.0`}
+      id={name}
+      className={`govuk-input lbh-input ${s.date}`}
+      aria-describedby={hint && `${name}-hint`}
+      type="date"
+    />
+    <RawField
+      name={`${name}.1`}
+      id={name}
+      className={'govuk-input lbh-input govuk-input--width-5'}
+      aria-describedby={hint && `${name}-hint`}
+      type="time"
+    />
+  </div>
+);
+
+export default Field;

--- a/components/FlexibleForms/DateTimeField.tsx
+++ b/components/FlexibleForms/DateTimeField.tsx
@@ -63,7 +63,6 @@ const DateTimeField = ({
       Date
     </label>
     <RawField
-      data-testId="datetime-box"
       name={`${name}.0`}
       id={`${name}-date`}
       className={`govuk-input lbh-input ${s.date}`}
@@ -75,7 +74,6 @@ const DateTimeField = ({
       Time
     </label>
     <RawField
-      data-testId="datetime-box"
       name={`${name}.1`}
       id={`${name}-time`}
       className={'govuk-input lbh-input govuk-input--width-5'}

--- a/components/FlexibleForms/DateTimeField.tsx
+++ b/components/FlexibleForms/DateTimeField.tsx
@@ -21,7 +21,7 @@ interface FieldProps {
   required?: boolean;
 }
 
-const Field = ({
+const DateTimeField = ({
   touched,
   errors,
   name,
@@ -29,12 +29,12 @@ const Field = ({
   hint,
   required,
 }: FieldProps): React.ReactElement => (
-  <div
+  <fieldset
     className={`govuk-form-group lbh-form-group ${
       getIn(touched, name) && getIn(errors, name) && 'govuk-form-group--error'
     }`}
   >
-    <label htmlFor={name} data-testid={name} className="govuk-label lbh-label">
+    <legend className="govuk-label lbh-label">
       {label}
       {required && (
         <span className="govuk-required">
@@ -42,7 +42,7 @@ const Field = ({
           <span className="govuk-visually-hidden">required</span>
         </span>
       )}
-    </label>
+    </legend>
 
     {hint && (
       <span id={`${name}-hint`} className="govuk-hint lbh-hint">
@@ -54,26 +54,35 @@ const Field = ({
       {(msg) => (
         <p className="govuk-error-message lbh-error-message" role="alert">
           <span className="govuk-visually-hidden">Error:</span>
-          {msg[0] || msg[1]}
+          {Array.isArray(msg) ? msg[0] || msg[1] : msg}
         </p>
       )}
     </ErrorMessage>
 
+    <label htmlFor={`${name}-date`} className="govuk-visually-hidden">
+      Date
+    </label>
     <RawField
+      data-testId="datetime-box"
       name={`${name}.0`}
-      id={name}
+      id={`${name}-date`}
       className={`govuk-input lbh-input ${s.date}`}
       aria-describedby={hint && `${name}-hint`}
       type="date"
     />
+
+    <label htmlFor={`${name}-time`} className="govuk-visually-hidden">
+      Time
+    </label>
     <RawField
+      data-testId="datetime-box"
       name={`${name}.1`}
-      id={name}
+      id={`${name}-time`}
       className={'govuk-input lbh-input govuk-input--width-5'}
       aria-describedby={hint && `${name}-hint`}
       type="time"
     />
-  </div>
+  </fieldset>
 );
 
-export default Field;
+export default DateTimeField;

--- a/components/FlexibleForms/FlexibleFields.spec.tsx
+++ b/components/FlexibleForms/FlexibleFields.spec.tsx
@@ -115,7 +115,9 @@ describe('TextField', () => {
 
     expect(screen.getAllByRole('textbox').length).toBe(5);
 
-    expect(screen.getAllByRole('textbox').length).toBe(7);
+    expect(screen.getAllByLabelText('Date').length).toBe(1);
+    expect(screen.getAllByLabelText('Time').length).toBe(1);
+
     expect(screen.getAllByRole('radio').length).toBe(1);
     expect(screen.getAllByRole('checkbox').length).toBe(1);
     expect(screen.getAllByRole('combobox').length).toBe(2);

--- a/components/FlexibleForms/FlexibleFields.spec.tsx
+++ b/components/FlexibleForms/FlexibleFields.spec.tsx
@@ -35,6 +35,12 @@ describe('TextField', () => {
             errors={{}}
           />
           <FlexibleFields
+            field={{ id: 'foo', question: '', type: 'datetime' }}
+            values={{}}
+            touched={{}}
+            errors={{}}
+          />
+          <FlexibleFields
             field={{
               id: 'foo',
               question: '',
@@ -108,6 +114,8 @@ describe('TextField', () => {
     );
 
     expect(screen.getAllByRole('textbox').length).toBe(5);
+
+    expect(screen.getAllByRole('textbox').length).toBe(7);
     expect(screen.getAllByRole('radio').length).toBe(1);
     expect(screen.getAllByRole('checkbox').length).toBe(1);
     expect(screen.getAllByRole('combobox').length).toBe(2);

--- a/components/FlexibleForms/FlexibleFields.tsx
+++ b/components/FlexibleForms/FlexibleFields.tsx
@@ -5,6 +5,7 @@ import SelectField from './SelectField';
 import RepeaterField from './RepeaterField';
 import RepeaterGroupField from './RepeaterGroupField';
 import ComboboxField from './ComboboxField';
+import DateTimeField from './DateTimeField';
 import { FormikValues, FormikTouched, FormikErrors } from 'formik';
 import { Field } from 'data/flexibleForms/forms.types';
 import TimetableField from './TimetableField';
@@ -59,6 +60,17 @@ const FlexibleField = ({
   if (field.type === 'date')
     return (
       <TextField
+        name={field.id}
+        label={field.question}
+        touched={touched}
+        errors={errors}
+        {...field}
+      />
+    );
+
+  if (field.type === 'datetime')
+    return (
+      <DateTimeField
         name={field.id}
         label={field.question}
         touched={touched}

--- a/components/FlexibleForms/StepForm.tsx
+++ b/components/FlexibleForms/StepForm.tsx
@@ -108,7 +108,6 @@ const StepFormInner = ({
           await submitForm();
           if (isValid) {
             setSaved(true);
-
             setGoBackToTaskList(true);
           }
         }}

--- a/data/flexibleForms/foo.ts
+++ b/data/flexibleForms/foo.ts
@@ -1,4 +1,5 @@
 import { Form } from './forms.types';
+import { format } from 'date-fns';
 
 const form: Form = {
   id: 'foo',
@@ -13,13 +14,20 @@ const form: Form = {
       theme: 'About you',
       fields: [
         {
-          id: 'Primary address tenure type',
-          question: 'Topics',
-          hint: 'Add as many as you need',
-
-          type: 'tags',
+          id: 'Date of event',
+          question: 'When did this happen?',
+          type: 'datetime',
           required: true,
-          itemName: 'topic',
+          default: [
+            format(new Date(), 'yyyy-MM-dd'),
+            format(new Date(), 'HH:00'),
+          ],
+        },
+        {
+          id: 'Test',
+          question: 'Example question',
+          type: 'repeater',
+          required: true,
         },
       ],
     },

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -71,7 +71,7 @@ export interface Form {
 }
 
 export interface RepeaterGroupAnswer {
-  [key: string]: string | string[];
+  [key: string]: string | [string, string];
 }
 
 export interface TimetableAnswer {

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -12,6 +12,7 @@ export interface Field {
     | 'text'
     | 'textarea'
     | 'date'
+    | 'datetime'
     | 'radios'
     | 'checkboxes'
     | 'select'
@@ -27,8 +28,8 @@ export interface Field {
   className?: string;
   /** on conditional fields, required value is only respected when all conditions are met */
   required?: boolean;
-  /** give an initial, default value for string-type fields */
-  default?: string;
+  /** give an initial, default value for datetime and string-type fields */
+  default?: string | string[];
   /** for select, radio, checkboxes, tags and combobox fields */
   choices?: Choice[];
   /** checkbox, file and repeater fields don't support prefilling */

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -29,7 +29,7 @@ export interface Field {
   /** on conditional fields, required value is only respected when all conditions are met */
   required?: boolean;
   /** give an initial, default value for datetime and string-type fields */
-  default?: string | string[];
+  default?: string | [string, string];
   /** for select, radio, checkboxes, tags and combobox fields */
   choices?: Choice[];
   /** checkbox, file and repeater fields don't support prefilling */
@@ -71,7 +71,7 @@ export interface Form {
 }
 
 export interface RepeaterGroupAnswer {
-  [key: string]: string | [string, string];
+  [key: string]: string | string[];
 }
 
 export interface TimetableAnswer {

--- a/lib/utils.spec.ts
+++ b/lib/utils.spec.ts
@@ -113,10 +113,15 @@ describe('generateInitialValues', () => {
           subfields: [
             {
               id: 'eight',
-              question: 'repeater group',
+              question: '',
               type: 'text',
             },
           ],
+        },
+        {
+          id: 'nine',
+          question: '',
+          type: 'datetime',
         },
       ],
       undefined
@@ -134,6 +139,7 @@ describe('generateInitialValues', () => {
           eight: '',
         },
       ],
+      nine: [],
     });
   });
 
@@ -193,7 +199,7 @@ describe('generateInitialValues', () => {
     expect(result).toMatchObject({ one: [] });
   });
 
-  it('applies a default value to a string-type field', () => {
+  it('applies a default value to a string-type or a datetime field', () => {
     const result = generateInitialValues([
       {
         id: 'foo',
@@ -201,8 +207,14 @@ describe('generateInitialValues', () => {
         type: 'text',
         default: 'bar',
       },
+      {
+        id: 'one',
+        question: '',
+        type: 'datetime',
+        default: 'two',
+      },
     ]);
-    expect(result).toMatchObject({ foo: 'bar' });
+    expect(result).toMatchObject({ foo: 'bar', one: 'two' });
   });
 });
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -88,6 +88,8 @@ export const generateInitialValues = (
     } else if (field.type === 'timetable') {
       initialValues[field.id] = generateInitialTimetableValues();
       initialValues[`${field.id} total hours`] = '';
+    } else if (field.type === 'datetime') {
+      initialValues[field.id] = field.default || [];
     } else if (initiallyArray.has(field.type)) {
       initialValues[field.id] = [];
     } else if (initiallyNull.has(field.type)) {

--- a/lib/validators.spec.ts
+++ b/lib/validators.spec.ts
@@ -41,6 +41,11 @@ describe('generateFlexibleSchema', () => {
         id: 'seven',
         type: 'timetable',
       },
+      {
+        question: 'foo',
+        id: 'eight',
+        type: 'datetime',
+      },
     ]);
 
     const result = await schema.validate({
@@ -51,6 +56,7 @@ describe('generateFlexibleSchema', () => {
       five: 'value',
       six: 'value',
       seven: {},
+      eight: [],
     });
 
     expect(result).toBeTruthy();
@@ -109,6 +115,21 @@ describe('generateFlexibleSchema', () => {
             Morning: '0',
           },
         },
+      })
+    ).rejects.toThrow();
+
+    const schema4 = generateFlexibleSchema([
+      {
+        id: 'one',
+        question: 'foo',
+        type: 'datetime',
+        required: true,
+      },
+    ]);
+
+    await expect(
+      schema4.validate({
+        one: ['test'],
       })
     ).rejects.toThrow();
   });

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -61,10 +61,13 @@ export const generateFlexibleSchema = (
       shape[field.id] = Yup.object();
     } else if (
       field.type === 'checkboxes' ||
+      field.type === 'datetime' ||
       field.type === 'repeater' ||
       field.type === 'tags'
     ) {
-      shape[field.id] = Yup.array().of(Yup.string());
+      shape[field.id] = Yup.array().of(
+        Yup.string().required(getErrorMessage(field))
+      );
     } else {
       shape[field.id] = Yup.string();
     }
@@ -76,6 +79,11 @@ export const generateFlexibleSchema = (
           'total',
           getErrorMessage(field),
           (value) => getTotalHours(value) !== 0
+        );
+      } else if (field.type === 'datetime') {
+        shape[field.id] = (shape[field.id] as Yup.NumberSchema).min(
+          2,
+          getErrorMessage(field)
         );
       } else if (
         field.type === 'checkboxes' ||

--- a/stylesheets/all.scss
+++ b/stylesheets/all.scss
@@ -150,7 +150,8 @@ html {
 }
 
 // fix vertical padding on date input
-input[type='date'] {
+input[type='date'],
+input[type='time'] {
   padding: 0 5px;
 }
 


### PR DESCRIPTION
this adds support for a combined date and time field to the flexible form builder.

it does this by:
- adding a `<DateTimeField/>` component, and rendering it in `<FlexibleField/>`
- augmenting the `generateFlexibleSchema` and `generateInitialValues` functions to support the new field
- supplementing the `default` attribute on a field to support an array of strings, so a default date and time can be specified like:

```
        {
          id: 'Date of event',
          question: 'When did this happen?',
          type: 'datetime',
          required: true,
          default: [
            format(new Date(), 'yyyy-MM-dd'),
            format(new Date(), 'HH:00'),
          ],
        },
```

<img width="361" alt="Screenshot 2021-07-21 at 15 02 52" src="https://user-images.githubusercontent.com/14189497/126502062-4ad1dce2-11fe-4001-b771-5a49b5b6f069.png">
