### PR TITLE
feat(SCT-471): add headings to relationships table

### DIFF
--- a/components/pages/people/relationships/view/Relationships.tsx
+++ b/components/pages/people/relationships/view/Relationships.tsx
@@ -100,7 +100,7 @@ const Relationships = ({ person }: Props): React.ReactElement => {
         <hr className="govuk-divider" />
         {personalRelationships && personalRelationships.length > 0 ? (
           <table className="govuk-table lbh-table">
-            <thead className="govuk-table__head govuk-visually-hidden">
+            <thead className="govuk-table__head">
               <tr className="govuk-table__row">
                 <th scope="col" className="govuk-table__header">
                   Relationship type
@@ -109,13 +109,13 @@ const Relationships = ({ person }: Props): React.ReactElement => {
                   Name
                 </th>
                 <th scope="col" className="govuk-table__header">
-                  Main carer
+                  Role
                 </th>
                 <th scope="col" className="govuk-table__header">
                   Gender
                 </th>
                 <th scope="col" className="govuk-table__header">
-                  Context of relationship
+                  Context
                 </th>
                 <th scope="col" className="govuk-table__header">
                   Action
@@ -141,8 +141,9 @@ const Relationships = ({ person }: Props): React.ReactElement => {
                           <th
                             data-testid={`${relationship.type}`}
                             scope="row"
-                            className="govuk-table__header govuk-!-width-one-quarter"
+                            className="govuk-table__header"
                             rowSpan={relationship.relationships.length}
+                            style={{ width: '15%' }}
                           >
                             {RELATIONSHIP_TYPES[relationship.type]}
                           </th>

--- a/utils/api/relationships.spec.ts
+++ b/utils/api/relationships.spec.ts
@@ -69,13 +69,31 @@ describe('relationships APIs', () => {
       });
 
       describe('and it has main carer', () => {
-        it('adds isMainCarer as "Y" to request', () => {
+        it('adds isMainCarer as "Y" to request if an array', () => {
           const formData = {
             personId: 123,
             otherPersonId: 456,
             createdBy: 'test@hackney.gov.uk',
             type: 'parent',
             additionalOptions: ['isMainCarer'],
+          };
+          jest.spyOn(axios, 'post');
+
+          relationshipsAPI.addRelationships(formData);
+
+          expect(axios.post).toHaveBeenCalledWith(
+            '/api/relationships',
+            expect.objectContaining({ isMainCarer: 'Y' })
+          );
+        });
+
+        it('adds isMainCarer as "Y" to request if a string', () => {
+          const formData = {
+            personId: 123,
+            otherPersonId: 456,
+            createdBy: 'test@hackney.gov.uk',
+            type: 'acquaintance',
+            additionalOptions: 'isMainCarer',
           };
           jest.spyOn(axios, 'post');
 

--- a/utils/api/relationships.ts
+++ b/utils/api/relationships.ts
@@ -12,7 +12,7 @@ interface addRelationshipFormData {
   otherPersonId: number;
   createdBy: string;
   type: string;
-  additionalOptions?: string[] | boolean;
+  additionalOptions?: string | string[] | boolean;
   isMainCarer?: string;
   details?: string;
 }
@@ -20,8 +20,9 @@ interface addRelationshipFormData {
 export const addRelationships = async (
   formData: addRelationshipFormData
 ): Promise<Record<string, unknown>> => {
-  if (formData.additionalOptions && Array.isArray(formData.additionalOptions)) {
+  if (formData.additionalOptions) {
     if (
+      Array.isArray(formData.additionalOptions) &&
       formData.type === 'parent' &&
       formData.additionalOptions?.includes('isParentOfUnbornChild')
     ) {
@@ -29,13 +30,18 @@ export const addRelationships = async (
     }
 
     if (
+      Array.isArray(formData.additionalOptions) &&
       formData.type === 'sibling' &&
       formData.additionalOptions?.includes('isSiblingOfUnbornChild')
     ) {
       formData.type = 'siblingOfUnbornChild';
     }
 
-    if (formData.additionalOptions?.includes('isMainCarer')) {
+    if (
+      (Array.isArray(formData.additionalOptions) &&
+        formData.additionalOptions?.includes('isMainCarer')) ||
+      formData.additionalOptions == 'isMainCarer'
+    ) {
       formData.isMainCarer = 'Y';
     }
 


### PR DESCRIPTION
**What**  

- Add headings to relationships table.
- Fix bug where if you selected a relationship type with a single checkbox option e.g. Aunt / uncle, friend and selected main carer, it didn't send it as part of the request so main carer never showed up when you went to view the relationship

Before | After
--|--
![image](https://user-images.githubusercontent.com/42817036/126514931-10171638-7d11-426a-9171-6c72a6efd083.png)|![image](https://user-images.githubusercontent.com/42817036/126514718-0d52290a-56d2-41c4-8fb0-e55278c140c7.png)


**Why**  

This was part of feedback received about relationships.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
