### PR TITLE
feat(SCT-914): add resident ID to GET Case Note by ID request

### DIFF
--- a/components/AllocatedWorkers/AllocationRecap/AllocationRecap.spec.tsx
+++ b/components/AllocatedWorkers/AllocationRecap/AllocationRecap.spec.tsx
@@ -37,7 +37,7 @@ describe(`AllocationRecap`, () => {
       123,
       321
     );
-    expect(caseAPI.useCase).toHaveBeenCalledWith('r_123');
+    expect(caseAPI.useCase).toHaveBeenCalledWith('r_123', 123);
     expect(asFragment()).toMatchSnapshot();
   });
 
@@ -53,7 +53,7 @@ describe(`AllocationRecap`, () => {
       123,
       321
     );
-    expect(caseAPI.useCase).toHaveBeenCalledWith('r_123');
+    expect(caseAPI.useCase).toHaveBeenCalledWith('r_123', 123);
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/components/AllocatedWorkers/AllocationRecap/AllocationRecap.tsx
+++ b/components/AllocatedWorkers/AllocationRecap/AllocationRecap.tsx
@@ -38,7 +38,10 @@ const AllocationRecap = ({
     personId,
     allocationId
   );
-  const { data: { caseFormData } = {}, error: recordError } = useCase(recordId);
+  const { data: { caseFormData } = {}, error: recordError } = useCase(
+    recordId,
+    personId
+  );
   if (recordError || allocationError) {
     return <ErrorMessage />;
   }

--- a/components/Cases/CaseRecap/CaseNote.tsx
+++ b/components/Cases/CaseRecap/CaseNote.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const CaseNote = ({ personId, recordId }: Props): React.ReactElement => {
-  const { data: record, error: recordError } = useCase(recordId);
+  const { data: record, error: recordError } = useCase(recordId, personId);
 
   const recordData = record?.caseFormData?.form_name_overall;
 

--- a/pages/api/cases/[caseId].ts
+++ b/pages/api/cases/[caseId].ts
@@ -16,7 +16,7 @@ const endpoint: NextApiHandler = async (
   if (!user.isAuthorised) {
     return res.status(StatusCodes.FORBIDDEN).end();
   }
-  const { caseId, ...params } = req.query;
+  const { caseId, residentId, ...params } = req.query;
   switch (req.method) {
     case 'GET':
       try {
@@ -24,6 +24,7 @@ const endpoint: NextApiHandler = async (
           caseId as string,
           {
             ...params,
+            residentId: Number(residentId),
             context_flag: user.permissionFlag,
           },
           user

--- a/utils/api/cases.spec.ts
+++ b/utils/api/cases.spec.ts
@@ -44,8 +44,8 @@ describe('cases APIs', () => {
   describe('useCase', () => {
     it('should work properly', () => {
       jest.spyOn(SWR, 'default');
-      casesAPI.useCase('123');
-      expect(SWR.default).toHaveBeenCalledWith('/api/cases/123');
+      casesAPI.useCase('123', 456);
+      expect(SWR.default).toHaveBeenCalledWith('/api/cases/123?residentId=456');
     });
   });
 

--- a/utils/api/cases.ts
+++ b/utils/api/cases.ts
@@ -25,8 +25,11 @@ export const useCasesByResident = (
   // @ts-ignore
   useSWRInfinite(getInfiniteKey(`/api/residents/${id}/cases`, 'cases', params));
 
-export const useCase = (caseId: string): SWRResponse<Case, ErrorAPI> =>
-  useSWR(`/api/cases/${caseId}`);
+export const useCase = (
+  caseId: string,
+  residentId: number
+): SWRResponse<Case, ErrorAPI> =>
+  useSWR(`/api/cases/${caseId}?residentId=${residentId}`);
 
 export const useHistoricCaseNote = (
   caseId: string


### PR DESCRIPTION
**What**  
When we audit a GET case note by ID request, we also need to provide the resident ID. This adds it as a param to the request. 

**Why**  
[SCT-914](https://hackney.atlassian.net/browse/SCT-914)
