### PR TITLE
fix: formats dates correctly in the timeline view

### DIFF
--- a/components/NewPersonView/Event.tsx
+++ b/components/NewPersonView/Event.tsx
@@ -4,6 +4,17 @@ import CaseLink from 'components/Cases/CaseLink';
 import { normaliseDateToISO } from 'utils/date';
 import { isMajorEvent } from './PersonTimeline';
 
+const safelyFormat = (rawDate: string): string => {
+  try {
+    return format(
+      new Date(rawDate),
+      rawDate.includes('T') ? 'dd MMM yyyy K.mm aaa' : 'dd MMM yyyy'
+    );
+  } catch (e) {
+    return rawDate;
+  }
+};
+
 interface Props {
   event: Case;
 }
@@ -34,10 +45,7 @@ const Event = ({ event }: Props): React.ReactElement => {
       </h3>
 
       <p className="lbh-body govuk-!-margin-top-1">
-        {format(
-          new Date(displayDate),
-          displayDate.includes('T') ? 'dd MMM yyyy K.mm aaa' : 'dd MMM yyyy'
-        )}
+        {safelyFormat(displayDate)}
       </p>
       <p className="lbh-body govuk-!-margin-top-1">{event.officerEmail}</p>
     </li>

--- a/components/NewPersonView/PersonTimeline.tsx
+++ b/components/NewPersonView/PersonTimeline.tsx
@@ -17,6 +17,14 @@ export const isMajorEvent = (event: Case): boolean =>
   MAJOR_FORMS.includes(event?.formName) ||
   MAJOR_FORMS.includes(event?.caseFormData?.form_name_overall);
 
+const safelyFormatDistanceToNow = (rawDate: string): string => {
+  try {
+    return formatDistanceToNow(new Date(rawDate));
+  } catch (e) {
+    return rawDate;
+  }
+};
+
 interface Props {
   events: Case[];
   unfinishedSubmissions?: Submission[];
@@ -82,8 +90,7 @@ const PersonTimeline = ({
           {results.length > 0 ? (
             <p className="lbh-body-xs">
               Showing {results?.length} events over{' '}
-              {oldestTimestamp &&
-                formatDistanceToNow(new Date(oldestTimestamp))}
+              {oldestTimestamp && safelyFormatDistanceToNow(oldestTimestamp)}
             </p>
           ) : (
             <p className="lbh-body-xs">No events match your search</p>


### PR DESCRIPTION
the timeline synthesises/integrates many different random date formats. to display these in a standard way, we first need to normalise them to an iso-compatible format.

it turns out that for some people in prod, there are edge case formats that we don't currently handle, which cause errors. 

this workaround safely handles those errors by instead returning the raw timestamp, rather than bugging out.