### PR TITLE
feat: decide feature flag status on client side

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -43,6 +43,7 @@ const CustomApp = ({
 
   useEffect(() => {
     const environmentName = [
+      'localhost:3000',
       'dev.hackney.gov.uk:3000',
       'social-care-service-staging.hackney.gov.uk',
     ].includes(window.location.host)

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,6 +16,8 @@ import 'stylesheets/all.scss';
 import 'stylesheets/header.scss';
 import { FeatureFlagProvider } from '../lib/feature-flags/feature-flags';
 import { getFeatureFlags } from 'features';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 interface Props {
   user?: Partial<User>;
@@ -33,10 +35,26 @@ const CustomApp = ({
   pageProps,
 }: ExtendedAppProps): JSX.Element | null => {
   const [user] = useState(pageProps.user);
+  const [features, setFeatures] = useState(
+    getFeatureFlags({
+      environmentName: pageProps.environmentName,
+    })
+  );
 
-  const features = getFeatureFlags({
-    environmentName: pageProps.environmentName,
-  });
+  useEffect(() => {
+    const environmentName = [
+      'dev.hackney.gov.uk:3000',
+      'social-care-service-staging.hackney.gov.uk',
+    ].includes(window.location.host)
+      ? 'development'
+      : 'production';
+
+    const featureSet = getFeatureFlags({
+      environmentName,
+    });
+
+    setFeatures(featureSet);
+  }, []);
 
   return (
     <FeatureFlagProvider features={features}>


### PR DESCRIPTION
**What**  
We used to only decide the feature flag set on the server side, and trust that it was correct on the client. This re-computes the status of the flags on the client side, and, for now, uses a different value to determine the status of the flag.