### PR TITLE
feat(SCT-918): timeline improvements

### DIFF
--- a/components/Cases/CaseLink.tsx
+++ b/components/Cases/CaseLink.tsx
@@ -21,10 +21,10 @@ const getWarningNoteDetailsPageName = (form_name: string) => {
   }
 };
 
-const getLink = (
+export const getLink = (
   recordId: string,
   { form_name_overall, ...caseFormData }: CaseFormData
-) => {
+): string | null => {
   const fileName = (form as Record<string, unknown>)[form_name_overall]
     ? form_name_overall
     : null;

--- a/components/Cases/CaseLink.tsx
+++ b/components/Cases/CaseLink.tsx
@@ -1,56 +1,7 @@
 import Link from 'next/link';
 import forms from 'data/flexibleForms';
-import * as form from 'data/forms';
-import {
-  AllocationCaseFormData,
-  CaseFormData,
-  DeallocationCaseFormData,
-  WarningNoteCaseFormData,
-} from 'types';
-
-const getWarningNoteDetailsPageName = (form_name: string) => {
-  switch (form_name) {
-    case 'Warning Note Created':
-      return 'note-created';
-    case 'Warning Note Reviewed':
-      return 'note-reviews';
-    case 'Warning Note Ended':
-      return 'note-end';
-    default:
-      return null;
-  }
-};
-
-export const getLink = (
-  recordId: string,
-  { form_name_overall, ...caseFormData }: CaseFormData
-): string | null => {
-  const fileName = (form as Record<string, unknown>)[form_name_overall]
-    ? form_name_overall
-    : null;
-
-  switch (form_name_overall) {
-    case 'API_Allocation':
-    case 'API_Deallocation':
-      return `/people/${caseFormData.mosaic_id}/allocations/${
-        (caseFormData as AllocationCaseFormData | DeallocationCaseFormData)
-          .allocation_id
-      }?recordId=${recordId}`;
-    case fileName:
-      return `/people/${caseFormData.mosaic_id}/records/${recordId}`;
-    case 'Historical_Case_Note':
-      return `/people/${caseFormData.mosaic_id}/records/${recordId}?is_historical=${caseFormData.is_historical}`;
-    case 'Historical_Visit':
-      return `/people/${caseFormData.mosaic_id}/visits/${recordId}?is_historical=${caseFormData.is_historical}`;
-    case 'API_WarningNote':
-      return `/people/${caseFormData.mosaic_id}/warning-notes/${
-        (caseFormData as WarningNoteCaseFormData).warning_note_id
-      }/view/${getWarningNoteDetailsPageName(caseFormData.form_name)}`;
-    default:
-      return null;
-  }
-};
-
+import { CaseFormData } from 'types';
+import { generateInternalLink } from 'utils/urls';
 interface Props {
   recordId: string;
   externalUrl?: string;
@@ -89,7 +40,7 @@ const CaseLink = ({
       </a>
     );
   }
-  const internalLink = getLink(recordId, caseFormData);
+  const internalLink = generateInternalLink(recordId, caseFormData);
   return internalLink ? (
     <Link href={internalLink}>
       <a className="lbh-link">{children || 'View'}</a>

--- a/components/Cases/CaseLink.tsx
+++ b/components/Cases/CaseLink.tsx
@@ -40,7 +40,12 @@ const CaseLink = ({
       </a>
     );
   }
-  const internalLink = generateInternalLink(recordId, caseFormData);
+  const internalLink = generateInternalLink({
+    recordId,
+    caseFormData,
+    personId,
+    formName,
+  });
   return internalLink ? (
     <Link href={internalLink}>
       <a className="lbh-link">{children || 'View'}</a>

--- a/components/NewPersonView/Event.spec.tsx
+++ b/components/NewPersonView/Event.spec.tsx
@@ -10,8 +10,8 @@ describe('Event', () => {
     expect(screen.getAllByRole('link').length).toBe(1);
 
     expect(screen.getByText('foorm'));
-    expect(screen.getByText('25 Oct 2020 1.49 pm'));
-    expect(screen.getByText('Fname.Lname@hackney.gov.uk'));
+    expect(screen.getByText('25 Oct 2020 1.49 pm', { exact: false }));
+    expect(screen.getByText('Fname.Lname@hackney.gov.uk', { exact: false }));
   });
 
   it('renders the right info for a warning note', () => {
@@ -21,7 +21,7 @@ describe('Event', () => {
     expect(screen.getAllByRole('link').length).toBe(1);
 
     expect(screen.getByText('Warning Note'));
-    expect(screen.getByText('25 Oct 2020 1.49 pm'));
-    expect(screen.getByText('Fname.Lname@hackney.gov.uk'));
+    expect(screen.getByText('25 Oct 2020 1.49 pm', { exact: false }));
+    expect(screen.getByText('Fname.Lname@hackney.gov.uk', { exact: false }));
   });
 });

--- a/components/NewPersonView/Event.spec.tsx
+++ b/components/NewPersonView/Event.spec.tsx
@@ -10,6 +10,7 @@ describe('Event', () => {
     expect(screen.getAllByRole('link').length).toBe(1);
 
     expect(screen.getByText('foorm'));
+    expect(screen.getByText('i am a case title', { exact: false }));
     expect(screen.getByText('25 Oct 2020 1.49 pm', { exact: false }));
     expect(screen.getByText('Fname.Lname@hackney.gov.uk', { exact: false }));
   });
@@ -23,5 +24,41 @@ describe('Event', () => {
     expect(screen.getByText('Warning Note'));
     expect(screen.getByText('25 Oct 2020 1.49 pm', { exact: false }));
     expect(screen.getByText('Fname.Lname@hackney.gov.uk', { exact: false }));
+  });
+
+  it('generates and truncates a snippet for form wizard case notes', () => {
+    render(
+      <Event
+        event={{
+          ...mockedWarningNoteCase,
+          caseFormData: {
+            ...mockedWarningNoteCase.caseFormData,
+            case_note_title: 'my title here',
+            case_note_description:
+              'my description here my description here my description here',
+          },
+        }}
+      />
+    );
+    expect(
+      screen.getByText(
+        'my title here: my description here my description here my...',
+        {
+          exact: false,
+        }
+      )
+    );
+  });
+
+  it('marks google docs', () => {
+    render(
+      <Event
+        event={{
+          ...mockedWarningNoteCase,
+          caseFormUrl: 'google.com/123',
+        }}
+      />
+    );
+    expect(screen.getByText('Google document', { exact: false }));
   });
 });

--- a/components/NewPersonView/Event.tsx
+++ b/components/NewPersonView/Event.tsx
@@ -1,7 +1,7 @@
 import { format } from 'date-fns';
 import { Case } from 'types';
-import CaseLink from 'components/Cases/CaseLink';
 import { normaliseDateToISO } from 'utils/date';
+import EventLink from './EventLink';
 import { isMajorEvent } from './PersonTimeline';
 
 const safelyFormat = (rawDate: string): string => {
@@ -24,8 +24,6 @@ const Event = ({ event }: Props): React.ReactElement => {
     String(event?.dateOfEvent || event?.caseFormTimestamp)
   );
 
-  const displayName = event?.formName || event?.caseFormData?.form_name_overall;
-
   return (
     <li
       className={`lbh-timeline__event ${
@@ -33,15 +31,7 @@ const Event = ({ event }: Props): React.ReactElement => {
       }`}
     >
       <h3 className="lbh-heading-h3">
-        <CaseLink
-          formName={event.formName}
-          externalUrl={event.caseFormUrl}
-          caseFormData={event.caseFormData}
-          recordId={event.recordId}
-          personId={event.personId}
-        >
-          {displayName}
-        </CaseLink>
+        <EventLink event={event} />
       </h3>
 
       <p className="lbh-body govuk-!-margin-top-1">

--- a/components/NewPersonView/Event.tsx
+++ b/components/NewPersonView/Event.tsx
@@ -27,7 +27,10 @@ const Event = ({ event }: Props): React.ReactElement => {
   );
 
   const displaySnippet = event?.caseFormData?.case_note_title
-    ? `${event?.caseFormData?.case_note_title}: ${event?.caseFormData?.case_note_description}`
+    ? `${event?.caseFormData?.case_note_title}${
+        event?.caseFormData?.case_note_description &&
+        `: ${event?.caseFormData?.case_note_description}`
+      }`
     : false;
 
   return (

--- a/components/NewPersonView/Event.tsx
+++ b/components/NewPersonView/Event.tsx
@@ -10,7 +10,7 @@ const safelyFormat = (rawDate: string): string => {
   try {
     return format(
       new Date(rawDate),
-      rawDate.includes('T') ? 'dd MMM yyyy K.mm aaa' : 'dd MMM yyyy'
+      rawDate.includes('T') ? 'd MMM yyyy K.mm aaa' : 'd MMM yyyy'
     );
   } catch (e) {
     return rawDate;
@@ -40,13 +40,14 @@ const Event = ({ event }: Props): React.ReactElement => {
         <EventLink event={event} />
       </h3>
 
-      <p className="lbh-body govuk-!-margin-top-1">
+      <p className="lbh-body-s govuk-!-margin-top-2">
         {safelyFormat(displayDate)}
+        {event.caseFormUrl?.includes('google') && ` · Google document`}
         {event.officerEmail && ` · ${event.officerEmail}`}
       </p>
 
       {displaySnippet && (
-        <p className={`lbh-body-s govuk-!-margin-top-1 ${s.snippet}`}>
+        <p className={`lbh-body-s govuk-!-margin-top-2 ${s.snippet}`}>
           {truncate(displaySnippet, 10)}
         </p>
       )}

--- a/components/NewPersonView/Event.tsx
+++ b/components/NewPersonView/Event.tsx
@@ -1,8 +1,10 @@
 import { format } from 'date-fns';
+import { truncate } from 'lib/utils';
 import { Case } from 'types';
 import { normaliseDateToISO } from 'utils/date';
 import EventLink from './EventLink';
 import { isMajorEvent } from './PersonTimeline';
+import s from './index.module.scss';
 
 const safelyFormat = (rawDate: string): string => {
   try {
@@ -24,6 +26,10 @@ const Event = ({ event }: Props): React.ReactElement => {
     String(event?.dateOfEvent || event?.caseFormTimestamp)
   );
 
+  const displaySnippet = event?.caseFormData?.case_note_title
+    ? `${event?.caseFormData?.case_note_title}: ${event?.caseFormData?.case_note_description}`
+    : false;
+
   return (
     <li
       className={`lbh-timeline__event ${
@@ -36,8 +42,14 @@ const Event = ({ event }: Props): React.ReactElement => {
 
       <p className="lbh-body govuk-!-margin-top-1">
         {safelyFormat(displayDate)}
+        {event.officerEmail && ` · ${event.officerEmail}`}
       </p>
-      <p className="lbh-body govuk-!-margin-top-1">{event.officerEmail}</p>
+
+      {displaySnippet && (
+        <p className={`lbh-body-s govuk-!-margin-top-1 ${s.snippet}`}>
+          {truncate(displaySnippet, 10)}
+        </p>
+      )}
     </li>
   );
 };

--- a/components/NewPersonView/EventLink.spec.tsx
+++ b/components/NewPersonView/EventLink.spec.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { mockedAllocationNote, mockedCaseNote } from 'factories/cases';
+import { Case } from 'types';
+import EventLink from './EventLink';
+
+const mockFlexibleForm = {
+  recordId: 'abcd1234',
+  formName: 'child-case-note',
+  personId: 123,
+} as Case;
+
+const mockGoogleForm = {
+  recordId: 'abcd1234',
+  formName: 'Example form name',
+  personId: 123,
+  caseFormUrl: 'https://docs.google.com/document/whatever',
+} as Case;
+
+describe('EventLink', () => {
+  it('correctly handles a flexible form', () => {
+    render(<EventLink event={mockFlexibleForm} />);
+    expect((screen.getByText('Case note') as HTMLLinkElement).href).toContain(
+      `/people/123/submissions/abcd1234`
+    );
+  });
+
+  it('correctly handles a google/external form', () => {
+    render(<EventLink event={mockGoogleForm} />);
+    expect(
+      (screen.getByText('Example form name') as HTMLLinkElement).href
+    ).toBe('https://docs.google.com/document/whatever');
+  });
+
+  it('correctly handles a legacy case note', () => {
+    render(<EventLink event={mockedCaseNote} />);
+    expect((screen.getByText('foorm') as HTMLLinkElement).href).toContain(
+      `/people/123/records/4`
+    );
+  });
+
+  it('correctly handles an allocation', () => {
+    render(<EventLink event={mockedAllocationNote} />);
+    expect(
+      (screen.getByText('Worker allocated') as HTMLLinkElement).href
+    ).toContain('/people/123/allocations/321?recordId=2');
+  });
+
+  it('correctly handles something unrecognisable', () => {
+    render(
+      <EventLink
+        event={
+          {
+            caseFormData: {},
+          } as unknown as Case
+        }
+      />
+    );
+    expect(screen.getByText('Unknown event'));
+  });
+});

--- a/components/NewPersonView/EventLink.tsx
+++ b/components/NewPersonView/EventLink.tsx
@@ -35,7 +35,7 @@ const EventLink = ({ event }: Props): React.ReactElement => {
     );
 
   // 3. handle legacy forms
-  const legacyUrl = generateLegacyUrl(event.recordId, event.caseFormData);
+  const legacyUrl = generateLegacyUrl(event);
   if (legacyUrl)
     return (
       <Link href={legacyUrl}>

--- a/components/NewPersonView/EventLink.tsx
+++ b/components/NewPersonView/EventLink.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { Case } from 'types';
 import forms from 'data/flexibleForms';
 import { getLink as generateLegacyUrl } from 'components/Cases/CaseLink';
+import s from './index.module.scss';
 
 interface Props {
   event: Case;
@@ -16,7 +17,7 @@ const EventLink = ({ event }: Props): React.ReactElement => {
   if (flexibleForm)
     return (
       <Link href={`/people/${event.personId}/submissions/${event.recordId}`}>
-        <a className="lbh-link">{flexibleForm.name}</a>
+        <a className={`lbh-link ${s.eventLink}`}>{flexibleForm.name}</a>
       </Link>
     );
 
@@ -27,7 +28,7 @@ const EventLink = ({ event }: Props): React.ReactElement => {
         href={event.caseFormUrl}
         target="_blank"
         rel="noreferrer noopener"
-        className="lbh-link"
+        className={`lbh-link ${s.eventLink}`}
       >
         {event.formName}
       </a>
@@ -38,7 +39,7 @@ const EventLink = ({ event }: Props): React.ReactElement => {
   if (legacyUrl)
     return (
       <Link href={legacyUrl}>
-        <a className="lbh-link">{event.formName}</a>
+        <a className={`lbh-link ${s.eventLink}`}>{event.formName}</a>
       </Link>
     );
 

--- a/components/NewPersonView/EventLink.tsx
+++ b/components/NewPersonView/EventLink.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { Case } from 'types';
 import forms from 'data/flexibleForms';
-import { getLink as generateLegacyUrl } from 'components/Cases/CaseLink';
+import { generateInternalLink as generateLegacyUrl } from 'utils/urls';
 import s from './index.module.scss';
 
 interface Props {

--- a/components/NewPersonView/EventLink.tsx
+++ b/components/NewPersonView/EventLink.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link';
+import { Case } from 'types';
+import forms from 'data/flexibleForms';
+import { getLink as generateLegacyUrl } from 'components/Cases/CaseLink';
+
+interface Props {
+  event: Case;
+}
+
+const EventLink = ({ event }: Props): React.ReactElement => {
+  // 1. handle flexible forms
+  const flexibleForm = event.formName
+    ? forms?.find((form) => form.id === event.formName)
+    : false;
+
+  if (flexibleForm)
+    return (
+      <Link href={`/people/${event.personId}/submissions/${event.recordId}`}>
+        <a className="lbh-link">{flexibleForm.name}</a>
+      </Link>
+    );
+
+  // 2. handle external/google forms
+  if (event.caseFormUrl)
+    return (
+      <a
+        href={event.caseFormUrl}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="lbh-link"
+      >
+        {event.formName}
+      </a>
+    );
+
+  // 3. handle legacy forms
+  const legacyUrl = generateLegacyUrl(event.recordId, event.caseFormData);
+  if (legacyUrl)
+    return (
+      <Link href={legacyUrl}>
+        <a className="lbh-link">{event.formName}</a>
+      </Link>
+    );
+
+  // 4. handle anything else
+  return <>{event.formName || 'Unknown event'}</>;
+};
+
+export default EventLink;

--- a/components/NewPersonView/Layout.spec.tsx
+++ b/components/NewPersonView/Layout.spec.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import { AuthProvider } from 'components/UserContext/UserContext';
 import { mockedResident } from 'factories/residents';
-import { mockedOnlyChildUser, mockedUser } from 'factories/users';
+import {
+  mockedOnlyChildUser,
+  mockedUser,
+  mockedOnlyAdultUser,
+} from 'factories/users';
 import * as relationshipsAPI from 'utils/api/relationships';
 import Layout from './Layout';
 import 'next/router';
@@ -114,5 +118,21 @@ describe('Layout', () => {
       </AuthProvider>
     );
     expect(screen.queryByText('Timeline')).toBe(null);
+  });
+
+  it('tells unauthorised users when a resident is restricted', () => {
+    render(
+      <AuthProvider user={mockedOnlyAdultUser}>
+        <Layout
+          person={{
+            ...mockedResident,
+            restricted: 'Y',
+          }}
+        >
+          Foo
+        </Layout>
+      </AuthProvider>
+    );
+    expect(screen.getByText('This person is restricted'));
   });
 });

--- a/components/NewPersonView/Layout.spec.tsx
+++ b/components/NewPersonView/Layout.spec.tsx
@@ -135,4 +135,25 @@ describe('Layout', () => {
     );
     expect(screen.getByText('This person is restricted'));
   });
+
+  it("doesn't bother to tell authorised users when a resident is restricted", () => {
+    render(
+      <AuthProvider
+        user={{
+          ...mockedUser,
+          hasUnrestrictedPermissions: true,
+        }}
+      >
+        <Layout
+          person={{
+            ...mockedResident,
+            restricted: 'Y',
+          }}
+        >
+          Foo
+        </Layout>
+      </AuthProvider>
+    );
+    expect(screen.queryByText('This person is restricted')).toBeNull();
+  });
 });

--- a/components/NewPersonView/Layout.tsx
+++ b/components/NewPersonView/Layout.tsx
@@ -9,9 +9,10 @@ import { useAllocatedWorkers } from 'utils/api/allocatedWorkers';
 import React from 'react';
 import WarningNotes from 'components/WarningNote/WarningNotes';
 import { useAuth } from 'components/UserContext/UserContext';
-import { canManageCases } from 'lib/permissions';
+import { canManageCases, canUserEditPerson } from 'lib/permissions';
 import AddFormDialog from 'components/AddFormDialog/AddFormDialog';
 import { useState } from 'react';
+import Banner from 'components/FlexibleForms/Banner';
 
 interface NavLinkProps {
   href: string;
@@ -113,6 +114,15 @@ const Layout = ({ person, children }: Props): React.ReactElement => {
       />
 
       <WarningNotes id={person.id} />
+
+      {person.restricted === 'Y' && !canManageCases(user, person) && (
+        <Banner
+          title="This person is restricted"
+          className="lbh-page-announcement--info"
+        >
+          Only administrators can see this person&apos;s case history.
+        </Banner>
+      )}
 
       <div
         className={`govuk-grid-row govuk-!-margin-bottom-8 ${s.personHeader}`}

--- a/components/NewPersonView/Layout.tsx
+++ b/components/NewPersonView/Layout.tsx
@@ -9,7 +9,7 @@ import { useAllocatedWorkers } from 'utils/api/allocatedWorkers';
 import React from 'react';
 import WarningNotes from 'components/WarningNote/WarningNotes';
 import { useAuth } from 'components/UserContext/UserContext';
-import { canManageCases, canUserEditPerson } from 'lib/permissions';
+import { canManageCases } from 'lib/permissions';
 import AddFormDialog from 'components/AddFormDialog/AddFormDialog';
 import { useState } from 'react';
 import Banner from 'components/FlexibleForms/Banner';

--- a/components/NewPersonView/PersonTimeline.tsx
+++ b/components/NewPersonView/PersonTimeline.tsx
@@ -49,7 +49,12 @@ const PersonTimeline = ({
     events?.filter((event) =>
       filter === 'case-note' ? isMajorEvent(event) : true
     ),
-    ['formName', 'officerEmail']
+    [
+      'formName',
+      'officerEmail',
+      'caseFormData.case_note_title',
+      'caseFormData.case_note_description',
+    ]
   );
 
   const oldestResult = results?.[results.length - 1];

--- a/components/NewPersonView/index.module.scss
+++ b/components/NewPersonView/index.module.scss
@@ -94,3 +94,7 @@
     border-left: 3px dashed lbh-colour('lbh-text');
   }
 }
+
+.snippet {
+  color: lbh-colour('lbh-secondary-text');
+}

--- a/components/NewPersonView/index.module.scss
+++ b/components/NewPersonView/index.module.scss
@@ -95,6 +95,13 @@
   }
 }
 
+.eventLink {
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 .snippet {
   color: lbh-colour('lbh-secondary-text');
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lbh-social-care",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/utils/date.spec.ts
+++ b/utils/date.spec.ts
@@ -100,8 +100,9 @@ describe('date util', () => {
   });
 
   describe('normaliseDateToISO', () => {
-    it('should work properly', () => {
+    it('should handle all likely date formats', () => {
       expect(normaliseDateToISO('1941-09-22')).toEqual('1941-09-22');
+      expect(normaliseDateToISO('22/09/1941')).toEqual('1941-09-22');
       expect(normaliseDateToISO('22/09/1941 13:49:43')).toEqual(
         '1941-09-22T13:49:43'
       );

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -73,6 +73,9 @@ export const normaliseDateToISO = (str: string): string => {
     return `${year}-${month}-${days}T${hours.padStart(2, '0')}:${minutes}${
       seconds ? `:${seconds}` : ''
     }`;
+  } else if (/[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{4}/.test(str)) {
+    const [days, month, year] = str.trim().split('/');
+    return `${year}-${month}-${days}`;
   } else {
     return str;
   }

--- a/utils/urls.spec.ts
+++ b/utils/urls.spec.ts
@@ -1,7 +1,13 @@
-import { getQueryString, parseQueryString } from './urls';
+import {
+  mockedAllocationNote,
+  mockedCaseNote,
+  mockedWarningNoteCase,
+} from 'factories/cases';
+import { Case } from 'types';
+import { generateInternalLink, getQueryString, parseQueryString } from './urls';
 
 describe('urls', () => {
-  describe('getQueryStrin', () => {
+  describe('getQueryString', () => {
     it('should return empty string on empty object', () => {
       expect(getQueryString({})).toEqual('');
     });
@@ -30,6 +36,45 @@ describe('urls', () => {
         barfoo: 'yo',
         yo: 'true',
       });
+    });
+  });
+
+  describe('generateInternalUrl', () => {
+    it('correctly handles all legacy form-wizard forms', () => {
+      expect(generateInternalLink(mockedCaseNote)).toBe(
+        `/people/123/records/4`
+      );
+      expect(generateInternalLink(mockedAllocationNote)).toBe(
+        `/people/123/allocations/321?recordId=2`
+      );
+      expect(
+        generateInternalLink({
+          ...mockedWarningNoteCase,
+          caseFormData: {
+            ...mockedWarningNoteCase.caseFormData,
+            form_name: 'Warning Note Created',
+          },
+        })
+      ).toBe(`/people/123/warning-notes/456/view/note-created`);
+      expect(
+        generateInternalLink({
+          ...mockedCaseNote,
+          caseFormData: {
+            ...mockedCaseNote.caseFormData,
+            form_name_overall: 'Historical_Case_Note',
+            is_historical: true,
+          },
+        })
+      ).toBe(`/people/123/records/4?is_historical=true`);
+    });
+
+    it('returns nothing for an unrecognised form', () => {
+      const result = generateInternalLink({
+        caseFormData: {
+          form_name_overall: 'ffff',
+        },
+      } as Case);
+      expect(result).toBeNull();
     });
   });
 });

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -1,3 +1,11 @@
+import * as oldForms from 'data/forms';
+import {
+  AllocationCaseFormData,
+  Case,
+  DeallocationCaseFormData,
+  WarningNoteCaseFormData,
+} from 'types';
+
 export const getProtocol = (): string =>
   process.env.NODE_ENV === 'production' ? 'https' : 'http';
 
@@ -19,3 +27,47 @@ export const parseQueryString = (str: string): Record<string, unknown> =>
     const [key, value] = curr.split('=');
     return { ...acc, [key]: value };
   }, {}) || {};
+
+const getWarningNoteDetailsPageName = (form_name: string) => {
+  switch (form_name) {
+    case 'Warning Note Created':
+      return 'note-created';
+    case 'Warning Note Reviewed':
+      return 'note-reviews';
+    case 'Warning Note Ended':
+      return 'note-end';
+    default:
+      return null;
+  }
+};
+
+/** generate the correct link for older form wizard-style records */
+export const generateInternalLink = ({
+  recordId,
+  caseFormData: { form_name_overall, ...caseFormData },
+}: Case): string | null => {
+  const fileName = (oldForms as Record<string, unknown>)[form_name_overall]
+    ? form_name_overall
+    : null;
+
+  switch (form_name_overall) {
+    case 'API_Allocation':
+    case 'API_Deallocation':
+      return `/people/${caseFormData.mosaic_id}/allocations/${
+        (caseFormData as AllocationCaseFormData | DeallocationCaseFormData)
+          .allocation_id
+      }?recordId=${recordId}`;
+    case fileName:
+      return `/people/${caseFormData.mosaic_id}/records/${recordId}`;
+    case 'Historical_Case_Note':
+      return `/people/${caseFormData.mosaic_id}/records/${recordId}?is_historical=${caseFormData.is_historical}`;
+    case 'Historical_Visit':
+      return `/people/${caseFormData.mosaic_id}/visits/${recordId}?is_historical=${caseFormData.is_historical}`;
+    case 'API_WarningNote':
+      return `/people/${caseFormData.mosaic_id}/warning-notes/${
+        (caseFormData as WarningNoteCaseFormData).warning_note_id
+      }/view/${getWarningNoteDetailsPageName(caseFormData.form_name)}`;
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
small improvements to the timeline:
- show a title in all cases, rather than defaulting to "view"
- for **OLDER CASE NOTES ONLY**, show the title or description, if it's available (doing this for newer submissions needs api changes)
- for **OLDER CASE NOTES ONLY**, search case note content as well as name and author
- handle the datetime format returned by google docs
- show a more prominent banner if a person is restricted

<img width="566" alt="Screenshot 2021-07-22 at 11 42 57" src="https://user-images.githubusercontent.com/14189497/126627234-99ce6766-12b0-42e1-871f-0b0372c3155b.png">

<img width="1440" alt="Screenshot 2021-07-22 at 13 05 30" src="https://user-images.githubusercontent.com/14189497/126637260-90c2259e-69f7-4b20-9700-af135367cde4.png">
