### PR TITLE
fix: only show add case note button to adults

### DIFF
--- a/components/NewPersonView/Layout.tsx
+++ b/components/NewPersonView/Layout.tsx
@@ -89,14 +89,16 @@ const Layout = ({ person, children }: Props): React.ReactElement => {
 
   const secondaryNavigation = [
     {
-      text: 'Add case note',
-      href: `/people/${person.id}/case-note`,
-    },
-    {
       text: 'Add warning note',
       href: `/people/${person.id}/warning-notes/add?id=${person.id}`,
     },
   ];
+
+  if (person.contextFlag === 'A')
+    secondaryNavigation.unshift({
+      text: 'Add case note',
+      href: `/people/${person.id}/case-note`,
+    });
 
   return (
     <>


### PR DESCRIPTION
**What**  
No ticket, small UX bug fix. Hide the add case note secondary nav button for childrens as case note isn't signed off yet.

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
