### PR TITLE
feat: bring back google form prefilling

### DIFF
--- a/components/AddFormDialog/AddFormDialog.spec.tsx
+++ b/components/AddFormDialog/AddFormDialog.spec.tsx
@@ -70,6 +70,25 @@ describe('AddFormDialog', () => {
     expect(screen.queryByText(ADULT_GFORMS[0].text)).toBeNull();
   });
 
+  it('adds prefill parameters to google forms', () => {
+    render(
+      <AuthProvider user={mockedUser}>
+        <AddFormDialog
+          isOpen={true}
+          onDismiss={jest.fn()}
+          person={mockedResident}
+        />
+      </AuthProvider>
+    );
+    expect(
+      screen
+        .getAllByText('Google form', { exact: false })[0]
+        .parentElement?.querySelector('a')?.href
+    ).toContain(
+      '?entry.323945892=1&entry.91559572=Foo&entry.1999530701=Bar&entry.432615953=Foo&entry.809765129=Bar&entry.1802043044=1&entry.787982027=Foo&entry.926422462=Bar&entry.2022397649=1&entry.529016216=foo@bar.com&entry.360061230=foo@bar.com'
+    );
+  });
+
   it('supports canonical urls', () => {
     render(
       <AuthProvider user={mockedUser}>

--- a/components/AddFormDialog/AddFormDialog.tsx
+++ b/components/AddFormDialog/AddFormDialog.tsx
@@ -11,6 +11,7 @@ import { useAuth } from 'components/UserContext/UserContext';
 import ADULT_GFORMS from 'data/googleForms/adultForms';
 import CHILD_GFORMS from 'data/googleForms/childForms';
 import flexibleForms from 'data/flexibleForms';
+import { populateChildForm } from 'utils/populate';
 
 interface Props {
   isOpen: boolean;
@@ -66,20 +67,20 @@ const AddFormDialog = ({
         .concat(
           gForms.map((f) => ({
             label: f.text,
-            href: f.value,
+            href: `${f.value}${populateChildForm(
+              person.firstName,
+              person.lastName,
+              person.id,
+              user.email,
+              f.value
+            )}`,
             system: false,
             groupRecordable: false,
             approvable: false,
             inPreview: false,
           }))
         ),
-    [
-      gForms,
-      serviceContext,
-      user.hasAdminPermissions,
-      user.hasDevPermissions,
-      person.id,
-    ]
+    [gForms, serviceContext, user, person]
   );
 
   const results = useSearch(

--- a/utils/populate.spec.ts
+++ b/utils/populate.spec.ts
@@ -1,0 +1,23 @@
+import { populateChildForm } from './populate';
+
+describe('populate', () => {
+  it('fills a case note form right', () => {
+    const result = populateChildForm(
+      '1',
+      '2',
+      3,
+      '4',
+      'example.com/1FAIpQLSchNVVlwgQwwMHNdmweNPSZUtvKt0hOXFi9lj8na3F-MknFyw'
+    );
+    expect(result).toBe(
+      '?entry.91559572=1 2&entry.323945892=3&entry.824752118=4'
+    );
+  });
+
+  it('fills other forms right', () => {
+    const result = populateChildForm('1', '2', 3, '4', 'example.com');
+    expect(result).toBe(
+      '?entry.323945892=3&entry.91559572=1&entry.1999530701=2&entry.432615953=1&entry.809765129=2&entry.1802043044=3&entry.787982027=1&entry.926422462=2&entry.2022397649=3&entry.529016216=4&entry.360061230=4'
+    );
+  });
+});

--- a/utils/populate.ts
+++ b/utils/populate.ts
@@ -1,0 +1,16 @@
+const caseNoteFormId =
+  '1FAIpQLSchNVVlwgQwwMHNdmweNPSZUtvKt0hOXFi9lj8na3F-MknFyw';
+
+/** apply autopopulation query parameters to child google form urls */
+export const populateChildForm = (
+  firstName: string,
+  lastName: string,
+  mosaicId: number,
+  userName: string,
+  url?: string
+): string => {
+  const fullName = `${firstName} ${lastName}`;
+  return url?.includes(caseNoteFormId)
+    ? `?entry.91559572=${fullName}&entry.323945892=${mosaicId}&entry.824752118=${userName}`
+    : `?entry.323945892=${mosaicId}&entry.91559572=${firstName}&entry.1999530701=${lastName}&entry.432615953=${firstName}&entry.809765129=${lastName}&entry.1802043044=${mosaicId}&entry.787982027=${firstName}&entry.926422462=${lastName}&entry.2022397649=${mosaicId}&entry.529016216=${userName}&entry.360061230=${userName}`;
+};


### PR DESCRIPTION
apparently this is still needed, so i've brought back the old thought-dead code, added some more tests around it.

we should look to eliminate it at the earliest chance, because it's been the source of bugs before

it comprises:
- a `populateChildForm` method which spits out a query string that google interprets to pre-fill particular form fields
- `<AddFormDialog/>` then calls that function if it is rendering a google form