### PR TITLE
Disable "x-powered-by" header

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ module.exports = {
   future: {
     webpack5: true,
   },
+  poweredByHeader: false,
 
   async headers() {
     return [

--- a/zap-baseline.conf
+++ b/zap-baseline.conf
@@ -4,9 +4,9 @@
 # You can add your own messages to each rule by appending them after a tab on each line.
 10017	WARN	(Cross-Domain JavaScript Source File Inclusion)
 10021	WARN	(X-Content-Type-Options Header Missing)
-10037	WARN	(Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s))
 10038	WARN	(Content Security Policy (CSP) Header Not Set)
 10202	WARN	(Absence of Anti-CSRF Tokens)
+10037	FAIL	(Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s))
 10003	FAIL	(Vulnerable JS Library)
 10010	FAIL	(Cookie No HttpOnly Flag)
 10011	FAIL	(Cookie Without Secure Flag)


### PR DESCRIPTION
**What**  
No ticket as a quick enhancement.
Disables next.js "x-powered-by" header raised as a warning by owasp scan
