### PR TITLE
fix: person view appearance tweaks

### DIFF
--- a/components/NewPersonView/Layout.tsx
+++ b/components/NewPersonView/Layout.tsx
@@ -138,7 +138,7 @@ const Layout = ({ person, children }: Props): React.ReactElement => {
           >
             #{person.id}
             {person.dateOfBirth &&
-              ` · Born ${format(new Date(person.dateOfBirth), 'dd MMM yyyy')}`}
+              ` · Born ${format(new Date(person.dateOfBirth), 'd MMM yyyy')}`}
             {allocations?.allocations &&
               summariseAllocations(allocations.allocations)}
           </p>

--- a/components/PersonView/PersonDetails.tsx
+++ b/components/PersonView/PersonDetails.tsx
@@ -4,6 +4,7 @@ import { useAuth } from 'components/UserContext/UserContext';
 import { canUserEditPerson } from 'lib/permissions';
 import Link from 'next/link';
 import s from 'stylesheets/Section.module.scss';
+import { format } from 'date-fns';
 
 interface Props {
   person: Resident;
@@ -74,7 +75,7 @@ const PersonDetails = ({ person }: Props): React.ReactElement => {
             <div className="govuk-summary-list__row">
               <dt className="govuk-summary-list__key">Date of birth</dt>
               <dd className="govuk-summary-list__value">
-                {new Date(dateOfBirth).toLocaleDateString('en-GB')}
+                {format(new Date(dateOfBirth), 'dd MMM yyyy')}
               </dd>
             </div>
           )}
@@ -82,7 +83,7 @@ const PersonDetails = ({ person }: Props): React.ReactElement => {
             <div className="govuk-summary-list__row">
               <dt className="govuk-summary-list__key">Date of death</dt>
               <dd className="govuk-summary-list__value">
-                {new Date(dateOfDeath).toLocaleDateString('en-GB')}
+                {format(new Date(dateOfDeath), 'dd MMM yyyy')}
               </dd>
             </div>
           )}
@@ -119,6 +120,15 @@ const PersonDetails = ({ person }: Props): React.ReactElement => {
                 {address.address}
                 <br />
                 {address.postcode}
+                <br />
+                <a
+                  className="lbh-link lbh-link--no-visited-state"
+                  target="_blank"
+                  rel="noreferrer"
+                  href={`https://www.google.com/maps/dir//${address.address} ${address.postcode}`}
+                >
+                  Get directions
+                </a>
               </dd>
             </div>
           )}
@@ -129,7 +139,13 @@ const PersonDetails = ({ person }: Props): React.ReactElement => {
                 <ul className="lbh-list">
                   {phoneNumbers.map(({ number, type }) => (
                     <li key={number}>
-                      {number} - {type}
+                      <strong>{type}:</strong>{' '}
+                      <a
+                        href={`tel:${number}`}
+                        className="lbh-link lbh-link--no-visited-state"
+                      >
+                        {number}
+                      </a>
                     </li>
                   ))}
                 </ul>
@@ -139,7 +155,11 @@ const PersonDetails = ({ person }: Props): React.ReactElement => {
           {emailAddress && (
             <div className="govuk-summary-list__row">
               <dt className="govuk-summary-list__key">Email</dt>
-              <dd className="govuk-summary-list__value">{emailAddress}</dd>
+              <dd className="govuk-summary-list__value">
+                {emailAddress}
+                <br />
+                <a href={`mailto:${emailAddress}`}>Send email</a>
+              </dd>
             </div>
           )}
           {preferredMethodOfContact && (
@@ -156,7 +176,7 @@ const PersonDetails = ({ person }: Props): React.ReactElement => {
             <div className="govuk-summary-list__row">
               <dt className="govuk-summary-list__key">Service area</dt>
               <dd className="govuk-summary-list__value">
-                {contextFlag === 'C' ? 'CFS' : 'ASC'}
+                {contextFlag === 'C' ? 'Children' : 'Adults'}
               </dd>
             </div>
           )}

--- a/components/PersonView/PersonDetails.tsx
+++ b/components/PersonView/PersonDetails.tsx
@@ -75,7 +75,7 @@ const PersonDetails = ({ person }: Props): React.ReactElement => {
             <div className="govuk-summary-list__row">
               <dt className="govuk-summary-list__key">Date of birth</dt>
               <dd className="govuk-summary-list__value">
-                {format(new Date(dateOfBirth), 'dd MMM yyyy')}
+                {format(new Date(dateOfBirth), 'd MMM yyyy')}
               </dd>
             </div>
           )}
@@ -83,7 +83,7 @@ const PersonDetails = ({ person }: Props): React.ReactElement => {
             <div className="govuk-summary-list__row">
               <dt className="govuk-summary-list__key">Date of death</dt>
               <dd className="govuk-summary-list__value">
-                {format(new Date(dateOfDeath), 'dd MMM yyyy')}
+                {format(new Date(dateOfDeath), 'd MMM yyyy')}
               </dd>
             </div>
           )}

--- a/components/RevisionTimeline/MiniRevisionTimeline.tsx
+++ b/components/RevisionTimeline/MiniRevisionTimeline.tsx
@@ -20,7 +20,7 @@ const RevisionTimeline = ({ submission }: Props): React.ReactElement | null => {
           <h3 className="lbh-body-xs">Edited by {revision.worker.email}</h3>
 
           <p className="lbh-body-xs">
-            {format(new Date(revision.editTime), 'dd MMM yyyy K.mm aaa')}
+            {format(new Date(revision.editTime), 'd MMM yyyy K.mm aaa')}
           </p>
         </li>
       ))}

--- a/components/RevisionTimeline/RevisionTimeline.tsx
+++ b/components/RevisionTimeline/RevisionTimeline.tsx
@@ -29,7 +29,7 @@ const RevisionTimeline = ({ submission }: Props): React.ReactElement | null => {
             <p className="lbh-body-xs">
               {format(
                 new Date(submission.panelApprovedAt),
-                'dd MMM yyyy K.mm aaa'
+                'd MMM yyyy K.mm aaa'
               )}
             </p>
           </li>
@@ -48,7 +48,7 @@ const RevisionTimeline = ({ submission }: Props): React.ReactElement | null => {
               Approved by {submission.approvedBy?.email}
             </h3>
             <p className="lbh-body-xs">
-              {format(new Date(submission.approvedAt), 'dd MMM yyyy K.mm aaa')}
+              {format(new Date(submission.approvedAt), 'd MMM yyyy K.mm aaa')}
             </p>
           </li>
         )}
@@ -62,7 +62,7 @@ const RevisionTimeline = ({ submission }: Props): React.ReactElement | null => {
             <h3 className="lbh-body">Edited by {revision.worker.email}</h3>
 
             <p className="lbh-body-xs">
-              {format(new Date(revision.editTime), 'dd MMM yyyy K.mm aaa')}
+              {format(new Date(revision.editTime), 'd MMM yyyy K.mm aaa')}
             </p>
           </li>
         ))}
@@ -70,7 +70,7 @@ const RevisionTimeline = ({ submission }: Props): React.ReactElement | null => {
         <li className="lbh-timeline__event">
           <h3 className="lbh-body">Started by {submission.createdBy.email}</h3>
           <p className="lbh-body-xs">
-            {format(new Date(submission.createdAt), 'dd MMM yyyy K.mm aaa')}
+            {format(new Date(submission.createdAt), 'd MMM yyyy K.mm aaa')}
           </p>
         </li>
       </ol>

--- a/components/SubmissionsTable/SubmissionRow.tsx
+++ b/components/SubmissionsTable/SubmissionRow.tsx
@@ -60,7 +60,7 @@ const SubmissionRow = ({
           </dd>
           <br />
           <dt>Last edited</dt>{' '}
-          <dd>{format(new Date(submission.createdAt), 'dd MMM yyyy')}</dd>
+          <dd>{format(new Date(submission.createdAt), 'd MMM yyyy')}</dd>
         </dl>
 
         <button
@@ -92,13 +92,13 @@ const SubmissionRow = ({
           <dl>
             <div>
               <dt className="lbh-body-s">Last edited</dt>
-              <dd>{format(new Date(lastEdited), 'dd MMM yyyy K.mm aaa')}</dd>
+              <dd>{format(new Date(lastEdited), 'd MMM yyyy K.mm aaa')}</dd>
             </div>
 
             <div>
               <dt className="lbh-body-s">Started</dt>
               <dd>
-                {format(new Date(submission.createdAt), 'dd MMM yyyy K.mm aaa')}
+                {format(new Date(submission.createdAt), 'd MMM yyyy K.mm aaa')}
               </dd>
             </div>
 

--- a/components/pages/people/relationships/view/Relationships.tsx
+++ b/components/pages/people/relationships/view/Relationships.tsx
@@ -10,6 +10,7 @@ import { RelationshipType, Resident, ExistingRelationship } from 'types';
 import { RELATIONSHIP_TYPES } from 'data/relationships';
 import RemoveRelationshipDialog from '../remove/RemoveRelationshipDialog';
 import Router from 'next/router';
+import s from 'stylesheets/Section.module.scss';
 
 interface Props {
   person: Resident;
@@ -71,7 +72,7 @@ const Relationships = ({ person }: Props): React.ReactElement => {
   combineOfUnbornChildForType('sibling');
 
   return (
-    <div>
+    <>
       <RemoveRelationshipDialog
         person={relationshipToRemove}
         isOpen={isRemoveRelationshipDialogOpen}
@@ -84,26 +85,26 @@ const Relationships = ({ person }: Props): React.ReactElement => {
           }
         }}
       />
-      <div>
-        <div className="lbh-table-header">
-          <h3 className="govuk-fieldset__legend--m govuk-custom-text-color">
-            RELATIONSHIPS
-          </h3>
+
+      <section className="govuk-!-margin-bottom-8">
+        <div className={s.heading}>
+          <h2>Relationships</h2>
+
           <ConditionalFeature name="add-relationships">
-            <Button
-              label="Add a new relationship"
-              route={`/people/${person.id}/relationships/add`}
-            />
+            <Link href={`/people/${person.id}/relationships/add`}>
+              <a className="lbh-link lbh-link--no-visited-state">
+                Add a relationship
+              </a>
+            </Link>
           </ConditionalFeature>
         </div>
 
-        <hr className="govuk-divider" />
         {personalRelationships && personalRelationships.length > 0 ? (
           <table className="govuk-table lbh-table">
             <thead className="govuk-table__head">
               <tr className="govuk-table__row">
                 <th scope="col" className="govuk-table__header">
-                  Relationship type
+                  Type
                 </th>
                 <th scope="col" className="govuk-table__header">
                   Name
@@ -244,9 +245,9 @@ const Relationships = ({ person }: Props): React.ReactElement => {
         ) : (
           <p className="lbh-body">No relationships found for this person</p>
         )}
-      </div>
+      </section>
       {error && <ErrorMessage />}
-    </div>
+    </>
   );
 };
 

--- a/components/pages/people/relationships/view/Relationships.tsx
+++ b/components/pages/people/relationships/view/Relationships.tsx
@@ -1,7 +1,6 @@
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import Spinner from 'components/Spinner/Spinner';
 import { removeRelationship, useRelationships } from 'utils/api/relationships';
-import Button from 'components/Button/Button';
 import { useState } from 'react';
 import { ConditionalFeature } from 'lib/feature-flags/feature-flags';
 import Link from 'next/link';
@@ -93,7 +92,7 @@ const Relationships = ({ person }: Props): React.ReactElement => {
           <ConditionalFeature name="add-relationships">
             <Link href={`/people/${person.id}/relationships/add`}>
               <a className="lbh-link lbh-link--no-visited-state">
-                Add a relationship
+                Add a new relationship
               </a>
             </Link>
           </ConditionalFeature>

--- a/stylesheets/Section.module.scss
+++ b/stylesheets/Section.module.scss
@@ -5,10 +5,14 @@
   padding-bottom: 15px;
   margin-bottom: 10px;
 
+  a {
+  }
+
   a,
   button {
     display: block;
     margin-top: 1rem;
+    @include lbh-body-m;
   }
 
   @include govuk-media-query(400px) {

--- a/stylesheets/all.scss
+++ b/stylesheets/all.scss
@@ -206,3 +206,8 @@ input[type='time'] {
 .lbh-timeline__event {
   padding-bottom: 25px;
 }
+
+// fix ugly line breaks on person details
+.govuk-summary-list__value br {
+  margin: 0;
+}


### PR DESCRIPTION
minor appearance improvements to the person view, including:

- consistent header to relationships tab
- larger "edit" and "add" links
- new clickable phone numbers and "get directions" links to make personal details more useful
- consistently display dates as elsewhere in the app
- change dates app-wide to eliminate leading zeros (04 Jul 1776 -> 4 Jul 1776)

<img width="1440" alt="Screenshot 2021-07-22 at 16 21 50" src="https://user-images.githubusercontent.com/14189497/126665055-dc96aa75-895e-4a30-8931-9b90c4541739.png">

<img width="846" alt="Screenshot 2021-07-22 at 16 21 57" src="https://user-images.githubusercontent.com/14189497/126665047-a309488d-db70-4111-9b5c-3e010686f6a3.png">
