### PR TITLE
split visit types into two queations

### DIFF
--- a/data/flexibleForms/childCaseNote.ts
+++ b/data/flexibleForms/childCaseNote.ts
@@ -57,12 +57,12 @@ const form: Form = {
           ],
         },
         {
-          id: 'Visit type',
-          question: 'What kind of visit?',
-          type: 'checkboxes',
-          hint: 'Choose all that apply',
+          id: 'Visit occurance',
+          question: 'How did the visit occur?',
+          type: 'radios',
+          hint: 'Choose one',
           required: true,
-          error: 'You must choose a visit type',
+          error: 'You must choose an option',
           condition: {
             id: 'Type',
             value: 'Visit',
@@ -73,13 +73,27 @@ const form: Form = {
               label: 'Face to face visit',
             },
             {
-              value: 'Office',
-              label: 'Office visit',
+              value: 'Virtual',
+              label: 'Virtual visit',
             },
             {
               value: 'Unsuccessful',
               label: 'Unsuccessful visit',
             },
+          ],
+        },
+        {
+          id: 'Visit type',
+          question: 'What kind of visit?',
+          type: 'radios',
+          hint: 'Choose one option',
+          required: true,
+          error: 'You must choose a visit type',
+          condition: {
+            id: 'Type',
+            value: 'Visit',
+          },
+          choices: [
             { label: 'Child in need visit', value: 'Child in need' },
             { label: 'CFS assessment visit', value: 'CFS assessment' },
             {


### PR DESCRIPTION
**What**  
When 'visit' is selected in the CFS case notes, two questions instead of one now display. The lists within these questions hve been changed to radios instead of checkboxes. Office visit has also been renamed to virtual visit.

**Why**  
Request from CFS

<img width="369" alt="Screenshot 2021-07-23 at 15 38 06" src="https://user-images.githubusercontent.com/33314998/126798216-d4e460ef-f508-4651-bc41-e6714810e163.png">
