### PR TITLE
fix(sct-919): preserve newlines in flexible answers

### DIFF
--- a/components/FlexibleAnswers/FlexibleAnswers.module.scss
+++ b/components/FlexibleAnswers/FlexibleAnswers.module.scss
@@ -2,6 +2,8 @@
 
 .dd {
   padding-right: 0;
+  // preserve newlines
+  white-space: pre-wrap;
 }
 
 .timetable {


### PR DESCRIPTION
answers that spread onto new lines, with `\n` characters, will now be preserved in the `<FlexibleAnswers/>` component, resulting in a better reading experience.

we use the `white-space: pre-wrap` css property to achieve this:

> Whitespace is preserved by the browser. Text will wrap when necessary, and on line breaks 

<img width="403" alt="Screenshot 2021-07-24 at 18 36 53" src="https://user-images.githubusercontent.com/14189497/126876697-b429b129-b276-43d5-93c9-0cfb89f35640.png">
