### PR TITLE
fix: add form data to submissions earlier on, so we can search on it

### DIFF
--- a/components/SubmissionsTable/SubmissionPanel.spec.tsx
+++ b/components/SubmissionsTable/SubmissionPanel.spec.tsx
@@ -15,11 +15,11 @@ describe('SubmissionPanel', () => {
   it('can launch and close the dialog', () => {
     render(<SubmissionPanel submission={mockSubmission} />);
     fireEvent.click(screen.getByText('Details'));
-    expect(screen.getByText('Foo details'));
+    expect(screen.getByText('Unknown form details'));
     expect(screen.getByRole('dialog'));
 
     fireEvent.click(screen.getByText('Close'));
-    expect(screen.queryByText('Foo details')).toBeNull();
+    expect(screen.queryByText('Unknown form details')).toBeNull();
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 });

--- a/components/SubmissionsTable/SubmissionPanel.spec.tsx
+++ b/components/SubmissionsTable/SubmissionPanel.spec.tsx
@@ -15,11 +15,11 @@ describe('SubmissionPanel', () => {
   it('can launch and close the dialog', () => {
     render(<SubmissionPanel submission={mockSubmission} />);
     fireEvent.click(screen.getByText('Details'));
-    expect(screen.getByText('Sandbox form details'));
+    expect(screen.getByText('Unknown form details'));
     expect(screen.getByRole('dialog'));
 
     fireEvent.click(screen.getByText('Close'));
-    expect(screen.queryByText('Sandbox form details')).toBeNull();
+    expect(screen.queryByText('Unknown form details')).toBeNull();
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 });

--- a/components/SubmissionsTable/SubmissionPanel.tsx
+++ b/components/SubmissionsTable/SubmissionPanel.tsx
@@ -7,7 +7,7 @@ import SubmissionDetailDialog from './SubmissionDetailDialog';
 import { generateSubmissionUrl } from 'lib/submissions';
 
 interface Props {
-  submission: SubmissionWithForm;
+  submission: Submission;
 }
 
 const SubmissionPanel = ({ submission }: Props): React.ReactElement | null => {

--- a/components/SubmissionsTable/SubmissionPanel.tsx
+++ b/components/SubmissionsTable/SubmissionPanel.tsx
@@ -1,19 +1,18 @@
 import { useState } from 'react';
-import { Submission } from 'data/flexibleForms/forms.types';
+import { SubmissionWithForm } from 'data/flexibleForms/forms.types';
 import Link from 'next/link';
 import { format } from 'date-fns';
-import forms from 'data/flexibleForms';
 import s from './index.module.scss';
 import SubmissionDetailDialog from './SubmissionDetailDialog';
 
 interface Props {
-  submission: Submission;
+  submission: SubmissionWithForm;
 }
 
 const SubmissionPanel = ({ submission }: Props): React.ReactElement | null => {
   const [open, setOpen] = useState<boolean>(false);
 
-  const form = forms.find((form) => form.id === submission.formId);
+  const form = submission.form;
 
   const completedSteps = Object.keys(submission.formAnswers).length;
   const totalSteps = form?.steps?.length;

--- a/components/SubmissionsTable/index.spec.tsx
+++ b/components/SubmissionsTable/index.spec.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { mockSubmission } from 'factories/submissions';
 import SubmissionsTable from './index';
 import { useAuth } from 'components/UserContext/UserContext';
 import { mockedResident } from 'factories/residents';
+import { Form } from 'data/flexibleForms/forms.types';
 
 jest.mock('components/UserContext/UserContext');
 
@@ -40,6 +41,16 @@ describe('SubmissionsTable', () => {
     expect(screen.getByText('Just mine (0)'));
     expect(screen.getByText('Everyone (0)'));
     expect(screen.getByText('No results to show.'));
+  });
+
+  it('lets you search for a submission by form name', async () => {
+    render(<SubmissionsTable submissions={[mockSubmission]} />);
+
+    fireEvent.change(screen.getByRole('searchbox'), {
+      target: { value: 'Sandbox form' },
+    });
+    expect(screen.getByText('Just mine (1)'));
+    expect(screen.queryAllByRole('listitem').length).toBe(3);
   });
 
   it("correctly renders user's own submissions", () => {

--- a/components/SubmissionsTable/index.tsx
+++ b/components/SubmissionsTable/index.tsx
@@ -7,6 +7,7 @@ import st from 'components/Tabs/Tabs.module.scss';
 import Tab from './Tab';
 import SearchBox from './SearchBox';
 import useSearch from 'hooks/useSearch';
+import forms from 'data/flexibleForms';
 
 interface Props {
   submissions: Submission[];
@@ -22,20 +23,28 @@ export const SubmissionsTable = ({
 
   const searchableSubmissions = useMemo(
     () =>
-      submissions.filter((submission) => {
-        // hide any restricted records unless the user has permission to see them
-        if (
-          !user?.hasUnrestrictedPermissions &&
-          submission.residents.every((resident) => resident.restricted === 'Y')
-        )
-          return false;
+      submissions
+        // augment each one with its form
+        .map((submission) => ({
+          ...submission,
+          form: forms.find((form) => form.id === submission.formId),
+        }))
+        .filter((submission) => {
+          // hide any restricted records unless the user has permission to see them
+          if (
+            !user?.hasUnrestrictedPermissions &&
+            submission.residents.every(
+              (resident) => resident.restricted === 'Y'
+            )
+          )
+            return false;
 
-        // hide discarded submissions
-        if (submission.submissionState === 'Discarded') return false;
+          // hide discarded submissions
+          if (submission.submissionState === 'Discarded') return false;
 
-        // Otherwise, this record is good to show
-        return true;
-      }),
+          // Otherwise, this record is good to show
+          return true;
+        }),
     [submissions, user?.hasUnrestrictedPermissions]
   );
 
@@ -48,7 +57,7 @@ export const SubmissionsTable = ({
       'createdBy.lastName',
       'residents.fullName',
       'residents.id',
-      'formName',
+      'form.name',
     ],
     1
   );

--- a/data/flexibleForms/foo.ts
+++ b/data/flexibleForms/foo.ts
@@ -3,7 +3,7 @@ import { format } from 'date-fns';
 
 const form: Form = {
   id: 'foo',
-  name: 'Foo',
+  name: 'Sandbox form',
   isViewableByAdults: false,
   isViewableByChildrens: false,
   approvable: true,

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -116,6 +116,10 @@ export interface Submission {
   tags?: string[];
 }
 
+export interface SubmissionWithForm extends Submission {
+  form?: Form;
+}
+
 export interface Revision {
   worker: Worker;
   editTime: string;


### PR DESCRIPTION
it's ideal to be able to type in the name of a form on the dashboard and see the submissions that match it.

> the filter field on the submissions page seems to work strangely. for instance, if i type “review” it filters out the review 3c forms (meaning, they no longer show) in “just mine” but i see other people’s in “everyone”

this wasn't possible before because we were just querying what came back from the api, which had only the machine-readable `formId`.

- we now use a memoised function to add the form to each submission, before applying searching logic
- we modify components lower down the tree to use the form that already exists, rather than re-searching for it