### PR TITLE
fix: canonical submission urls on the dashboard

### DIFF
--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -1,6 +1,7 @@
 import s from './index.module.scss';
 import { Submission } from 'data/flexibleForms/forms.types';
 import Link from 'next/link';
+import { generateSubmissionUrl } from 'lib/submissions';
 
 interface SubProps {
   sub: Submission;
@@ -12,7 +13,7 @@ const Sub = ({ sub }: SubProps): React.ReactElement => {
 
   return (
     <li key={sub.submissionId}>
-      <Link href={`/submissions/${sub.submissionId}`}>
+      <Link href={generateSubmissionUrl(sub)}>
         {sub?.form?.name || sub.formId}
       </Link>{' '}
       <p className="lbh-body-xs">

--- a/components/SubmissionsTable/SubmissionDetailDialog.spec.tsx
+++ b/components/SubmissionsTable/SubmissionDetailDialog.spec.tsx
@@ -11,6 +11,7 @@ describe('SubmissionDetailDialog', () => {
         submission={mockSubmission}
         isOpen={true}
         onDismiss={jest.fn()}
+        url="/foo"
       />
     );
     expect(screen.getAllByRole('heading').length).toBe(2);
@@ -24,6 +25,7 @@ describe('SubmissionDetailDialog', () => {
         submission={mockSubmission}
         isOpen={true}
         onDismiss={jest.fn()}
+        url="/foo"
       />
     );
 
@@ -38,6 +40,7 @@ describe('SubmissionDetailDialog', () => {
         submission={mockSubmission}
         isOpen={true}
         onDismiss={mockHandler}
+        url="/foo"
       />
     );
     fireEvent.click(screen.getByText('Close'));

--- a/components/SubmissionsTable/SubmissionDetailDialog.tsx
+++ b/components/SubmissionsTable/SubmissionDetailDialog.tsx
@@ -14,6 +14,7 @@ interface Props {
   completedSteps?: number;
   totalSteps?: number;
   completion?: number;
+  url: string;
 }
 
 const SubmissionDetailDialog = ({
@@ -24,6 +25,7 @@ const SubmissionDetailDialog = ({
   completedSteps,
   totalSteps,
   completion,
+  url,
 }: Props): React.ReactElement => {
   const lastEdited =
     submission.editHistory[submission.editHistory.length - 1]?.editTime;
@@ -48,7 +50,7 @@ const SubmissionDetailDialog = ({
               </>
             )}
             <br />
-            <Link href={`/submissions/${submission.submissionId}`}>
+            <Link href={url}>
               <a className="lbh-link lbh-link--no-visited-state">Resume</a>
             </Link>{' '}
             <DiscardDialog submissionId={submission.submissionId} />

--- a/components/SubmissionsTable/SubmissionPanel.tsx
+++ b/components/SubmissionsTable/SubmissionPanel.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Submission } from 'data/flexibleForms/forms.types';
 import Link from 'next/link';
 import { format } from 'date-fns';
 import forms from 'data/flexibleForms';
 import s from './index.module.scss';
 import SubmissionDetailDialog from './SubmissionDetailDialog';
+import { generateSubmissionUrl } from 'lib/submissions';
 
 interface Props {
   submission: Submission;
@@ -19,6 +20,8 @@ const SubmissionPanel = ({ submission }: Props): React.ReactElement | null => {
   const totalSteps = form?.steps?.length;
   const completion =
     Math.round((completedSteps / Number(totalSteps)) * 100) || 0;
+
+  const url = useMemo(() => generateSubmissionUrl(submission), [submission]);
 
   return (
     <>
@@ -57,7 +60,7 @@ const SubmissionPanel = ({ submission }: Props): React.ReactElement | null => {
           </div>
         </dl>
 
-        <Link href={`/submissions/${submission.submissionId}`}>
+        <Link href={url}>
           <a className="govuk-button lbh-button">Resume</a>
         </Link>
 
@@ -73,6 +76,7 @@ const SubmissionPanel = ({ submission }: Props): React.ReactElement | null => {
           completedSteps={completedSteps}
           totalSteps={totalSteps}
           completion={completion}
+          url={url}
         />
       </li>
     </>

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -10,8 +10,10 @@ import {
   panelApproveSubmission,
   returnForEdits,
   discardSubmission,
+  generateSubmissionUrl,
 } from './submissions';
 import { mockedLegacyResident } from 'factories/residents';
+import { mockSubmission } from 'factories/submissions';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -239,5 +241,33 @@ describe('returnForEdits', () => {
         },
       }
     );
+  });
+});
+
+describe('generateSubmissionUrl', () => {
+  it('correctly generates a canonical-style url', () => {
+    const result = generateSubmissionUrl({
+      ...mockSubmission,
+      formId: 'adult-case-note',
+    });
+    expect(result).toBe(
+      `/people/${mockSubmission.residents[0].id}/case-note?submissionId=${mockSubmission.submissionId}`
+    );
+  });
+  it('accepts a specific social care id', () => {
+    const result = generateSubmissionUrl(
+      {
+        ...mockSubmission,
+        formId: 'adult-case-note',
+      },
+      12345
+    );
+    expect(result).toBe(
+      `/people/12345/case-note?submissionId=${mockSubmission.submissionId}`
+    );
+  });
+  it('correctly generates a basic url', () => {
+    const result = generateSubmissionUrl(mockSubmission);
+    expect(result).toBe(`/submissions/${mockSubmission.submissionId}`);
   });
 });

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -254,6 +254,7 @@ describe('generateSubmissionUrl', () => {
       `/people/${mockSubmission.residents[0].id}/case-note?submissionId=${mockSubmission.submissionId}`
     );
   });
+
   it('accepts a specific social care id', () => {
     const result = generateSubmissionUrl(
       {
@@ -266,6 +267,7 @@ describe('generateSubmissionUrl', () => {
       `/people/12345/case-note?submissionId=${mockSubmission.submissionId}`
     );
   });
+
   it('correctly generates a basic url', () => {
     const result = generateSubmissionUrl(mockSubmission);
     expect(result).toBe(`/submissions/${mockSubmission.submissionId}`);

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -5,6 +5,7 @@ import {
   FlexibleAnswers,
 } from 'data/flexibleForms/forms.types';
 import { Resident, AgeContext } from 'types';
+import forms from 'data/flexibleForms';
 
 type RawSubmission = Omit<Submission, 'formAnswers'> & {
   formAnswers: {
@@ -213,4 +214,20 @@ export const returnForEdits = async (
     }
   );
   return data;
+};
+
+/** safely generate a submission url, handling weird cases like case notes, which use a different canonical url structure */
+export const generateSubmissionUrl = (
+  submission: Submission,
+  socialCareId?: number
+): string => {
+  const form = forms.find((form) => form.id === submission.formId);
+  if (form?.canonicalUrl) {
+    return `${form.canonicalUrl(
+      // use the passed in social care id, or default to the first resident on the submission
+      socialCareId || submission.residents[0].id
+    )}?submissionId=${submission.submissionId}`;
+  } else {
+    return `/submissions/${submission.submissionId}`;
+  }
 };


### PR DESCRIPTION
not all submissions follow the standard `/submissions/:id` url format any more. case notes, in particular, don't.

at the moment, it's possible to go to a task list version of the case note from the dashboard, which shouldn't be possible, because of this.

this pr adds a `generateSubmissionUrl` method that can handle those exceptions.