### PR TITLE
remove all cases of destructuring process.env

### DIFF
--- a/lib/allocatedWorkers.spec.ts
+++ b/lib/allocatedWorkers.spec.ts
@@ -6,7 +6,8 @@ import * as allocatedWorkersAPI from './allocatedWorkers';
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 describe('allocatedWorkersAPI', () => {
   describe('getResidentAllocatedWorkers', () => {

--- a/lib/allocatedWorkers.ts
+++ b/lib/allocatedWorkers.ts
@@ -5,7 +5,8 @@ import parseISO from 'date-fns/parseISO';
 
 import type { Allocation, AllocationData } from 'types';
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 interface AllocationsParams {
   mosaic_id?: number;

--- a/lib/cases.spec.ts
+++ b/lib/cases.spec.ts
@@ -7,7 +7,8 @@ import * as casesAPI from './cases';
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 describe('sanitiseCaseFormData', () => {
   it('should work properly', () => {

--- a/lib/cases.ts
+++ b/lib/cases.ts
@@ -3,7 +3,8 @@ import axios from 'axios';
 import type { Case, CaseData, HistoricCaseData, User } from 'types';
 import { getAuditingParams } from '../utils/auditing';
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 const headersWithKey = {
   'x-api-key': AWS_KEY,

--- a/lib/postcode.spec.ts
+++ b/lib/postcode.spec.ts
@@ -5,7 +5,8 @@ import * as postcodeAPI from './postcode';
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-const { POSTCODE_LOOKUP_URL, POSTCODE_LOOKUP_APIKEY } = process.env;
+const POSTCODE_LOOKUP_URL = process.env.POSTCODE_LOOKUP_URL;
+const POSTCODE_LOOKUP_APIKEY = process.env.POSTCODE_LOOKUP_APIKEY;
 
 describe('postcode APIs', () => {
   describe('getAddresses', () => {

--- a/lib/postcode.ts
+++ b/lib/postcode.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-const { POSTCODE_LOOKUP_URL, POSTCODE_LOOKUP_APIKEY } = process.env;
+const POSTCODE_LOOKUP_URL = process.env.POSTCODE_LOOKUP_URL;
+const POSTCODE_LOOKUP_APIKEY = process.env.POSTCODE_LOOKUP_APIKEY;
 
 interface Address {
   line1: string;

--- a/lib/relationships.spec.ts
+++ b/lib/relationships.spec.ts
@@ -5,7 +5,9 @@ import {
   mockedAddRelationship,
 } from 'factories/relationships';
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
+
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 jest.mock('axios');
 

--- a/lib/relationships.ts
+++ b/lib/relationships.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import type { RelationshipData } from 'types';
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 const headers = { 'x-api-key': AWS_KEY };
 
 export const getRelationshipByResident = async (

--- a/lib/residents.spec.ts
+++ b/lib/residents.spec.ts
@@ -7,7 +7,8 @@ import * as residentsAPI from './residents';
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 const residentResponse = {
   name: 'foo',

--- a/lib/residents.ts
+++ b/lib/residents.ts
@@ -3,7 +3,8 @@ import axios from 'axios';
 import type { LegacyResident, Resident, ResidentsAPI, User } from 'types';
 import { getAuditingParams } from '../utils/auditing';
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 const headers = { 'x-api-key': AWS_KEY };
 

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -16,7 +16,8 @@ import { mockedLegacyResident } from 'factories/residents';
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 describe('getUnfinishedSubmissions', () => {
   it('should return a list of incomplete submissions', async () => {

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -12,7 +12,8 @@ type RawSubmission = Omit<Submission, 'formAnswers'> & {
   };
 };
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 const headersWithKey = {
   'x-api-key': AWS_KEY,

--- a/lib/teams.spec.ts
+++ b/lib/teams.spec.ts
@@ -5,7 +5,8 @@ import * as teamsAPI from './teams';
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 describe('teams APIs', () => {
   describe('getTeams', () => {

--- a/lib/teams.ts
+++ b/lib/teams.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 const headersWithKey = {
   'x-api-key': AWS_KEY,

--- a/lib/warningNotes.spec.ts
+++ b/lib/warningNotes.spec.ts
@@ -7,7 +7,8 @@ import { warningNoteFactory } from 'factories/warningNotes';
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 describe('warningNotesAPI', () => {
   describe('addWarningNote', () => {

--- a/lib/warningNotes.ts
+++ b/lib/warningNotes.ts
@@ -2,7 +2,8 @@ import axios from 'axios';
 
 import { WarningNote } from 'types';
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 const headers = { 'x-api-key': AWS_KEY };
 

--- a/lib/workers.spec.ts
+++ b/lib/workers.spec.ts
@@ -5,7 +5,8 @@ import * as workersAPI from './workers';
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 describe('workers APIs', () => {
   describe('getWorkers', () => {

--- a/lib/workers.ts
+++ b/lib/workers.ts
@@ -2,7 +2,8 @@ import axios from 'axios';
 
 import { Worker } from 'types';
 
-const { ENDPOINT_API, AWS_KEY } = process.env;
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
 
 const headers = {
   'x-api-key': AWS_KEY,

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -37,7 +37,8 @@ const AdminLoginPage = ({ gssoUrl, returnUrl }: Props): React.ReactElement => (
 );
 
 export const getServerSideProps = async () => {
-  const { GSSO_URL, REDIRECT_URL } = process.env;
+  const GSSO_URL = process.env.GSSO_URL;
+  const REDIRECT_URL = process.env.REDIRECT_URL;
   const protocol = getProtocol();
   return {
     props: {

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -8,7 +8,7 @@ import { getPermissionFlag } from 'utils/user';
 
 export const AUTH_WHITELIST = ['/login', '/access-denied'];
 
-const { GSSO_TOKEN_NAME } = process.env;
+const GSSO_TOKEN_NAME = process.env.GSSO_TOKEN_NAME;
 
 export const deleteSession = (
   res: NonNullable<NextPageContext['res']>
@@ -53,16 +53,16 @@ interface ParsedCookie {
 export const isAuthorised = (
   req: NonNullable<NextPageContext['req']>
 ): User | undefined => {
-  const {
-    HACKNEY_JWT_SECRET,
-    AUTHORISED_DEV_GROUP,
-    AUTHORISED_ADMIN_GROUP,
-    AUTHORISED_ADULT_GROUP,
-    AUTHORISED_CHILD_GROUP,
-    AUTHORISED_ALLOCATORS_GROUP,
-    AUTHORISED_UNRESTRICTED_GROUP,
-    AUTHORISED_AUDITABLE_GROUP,
-  } = process.env;
+  const HACKNEY_JWT_SECRET = process.env.HACKNEY_JWT_SECRET;
+  const AUTHORISED_DEV_GROUP = process.env.AUTHORISED_DEV_GROUP;
+  const AUTHORISED_ADMIN_GROUP = process.env.AUTHORISED_ADMIN_GROUP;
+  const AUTHORISED_ADULT_GROUP = process.env.AUTHORISED_ADULT_GROUP;
+  const AUTHORISED_CHILD_GROUP = process.env.AUTHORISED_CHILD_GROUP;
+  const AUTHORISED_ALLOCATORS_GROUP = process.env.AUTHORISED_ALLOCATORS_GROUP;
+  const AUTHORISED_UNRESTRICTED_GROUP =
+    process.env.AUTHORISED_UNRESTRICTED_GROUP;
+  const AUTHORISED_AUDITABLE_GROUP = process.env.AUTHORISED_AUDITABLE_GROUP;
+
   const cookies = cookie.parse(req.headers.cookie ?? '');
   const parsedToken = cookies[GSSO_TOKEN_NAME]
     ? (jsonwebtoken.verify(


### PR DESCRIPTION
**What**  
Turns out destructuring `process.env` can cause issues due to webpack configuration. I haven't dived too deeply into the why but an easy solution is to access properties directly.

https://github.com/vercel/next.js/issues/15574

**Why**  

To resolve bug from screenshot below.

![Screenshot from 2021-07-27 11-10-33](https://user-images.githubusercontent.com/29123700/127139724-791e1305-5907-4aa4-8cde-a1e94d8d5245.png)


**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
