### PR TITLE
fix(SCT-946): reload after approval, panel approval or reject

### DIFF
--- a/components/ApprovalWidget/ApproveDialog.spec.tsx
+++ b/components/ApprovalWidget/ApproveDialog.spec.tsx
@@ -2,8 +2,16 @@ import ApproveDialog from './ApproveDialog';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { mockSubmission } from 'factories/submissions';
 import axios from 'axios';
+import { useRouter } from 'next/router';
 
 jest.mock('axios');
+
+const mockHandler = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    reload: mockHandler,
+  }),
+}));
 
 beforeEach(() => jest.resetAllMocks());
 
@@ -20,7 +28,7 @@ describe('ApproveDialog', () => {
     expect(screen.getByText('Yes, approve'));
   });
 
-  it('makes a request to the right api route', async () => {
+  it('makes a request to the right api route, then reloads the page', async () => {
     render(
       <ApproveDialog
         isOpen={true}
@@ -32,6 +40,7 @@ describe('ApproveDialog', () => {
     await waitFor(() => {
       expect(axios.post).toBeCalledTimes(1);
       expect(axios.post).toBeCalledWith('/api/submissions/123/approvals');
+      expect(useRouter().reload).toBeCalledTimes(1);
     });
   });
 

--- a/components/ApprovalWidget/ApproveDialog.tsx
+++ b/components/ApprovalWidget/ApproveDialog.tsx
@@ -3,6 +3,7 @@ import Dialog from 'components/Dialog/Dialog';
 import axios from 'axios';
 import { Submission } from 'data/flexibleForms/forms.types';
 import Banner from 'components/FlexibleForms/Banner';
+import { useRouter } from 'next/router';
 
 interface Props {
   isOpen: boolean;
@@ -18,12 +19,15 @@ const ApproveDialog = ({
   const [loading, setLoading] = useState<boolean>(false);
   const [status, setStatus] = useState<string | false>(false);
 
+  const router = useRouter();
+
   const handleApprove = async () => {
     try {
       setLoading(true);
       await axios.post(`/api/submissions/${submission.submissionId}/approvals`);
       setLoading(false);
       setOpen(false);
+      router.reload();
     } catch (e) {
       setStatus(e.toString());
     }

--- a/components/ApprovalWidget/PanelApproveDialog.spec.tsx
+++ b/components/ApprovalWidget/PanelApproveDialog.spec.tsx
@@ -2,8 +2,16 @@ import PanelApproveDialog from './PanelApproveDialog';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { mockSubmission } from 'factories/submissions';
 import axios from 'axios';
+import { useRouter } from 'next/router';
 
 jest.mock('axios');
+
+const mockHandler = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    reload: mockHandler,
+  }),
+}));
 
 beforeEach(() => jest.resetAllMocks());
 
@@ -34,7 +42,7 @@ describe('PanelApproveDialog', () => {
     });
   });
 
-  it('makes a request to the right api route', async () => {
+  it('makes a request to the right api route, then reloads the page', async () => {
     render(
       <PanelApproveDialog
         isOpen={true}
@@ -47,6 +55,7 @@ describe('PanelApproveDialog', () => {
     await waitFor(() => {
       expect(axios.post).toBeCalledTimes(1);
       expect(axios.post).toBeCalledWith('/api/submissions/123/panel-approvals');
+      expect(useRouter().reload).toBeCalledTimes(1);
     });
   });
 

--- a/components/ApprovalWidget/PanelApproveDialog.tsx
+++ b/components/ApprovalWidget/PanelApproveDialog.tsx
@@ -4,6 +4,7 @@ import { Submission } from 'data/flexibleForms/forms.types';
 import Banner from 'components/FlexibleForms/Banner';
 import { Form, Formik, Field, ErrorMessage, FormikHelpers } from 'formik';
 import { panelApproveSchema } from 'lib/validators';
+import { useRouter } from 'next/router';
 
 interface Props {
   isOpen: boolean;
@@ -20,6 +21,8 @@ const PanelApproveDialog = ({
   isOpen,
   setOpen,
 }: Props): React.ReactElement => {
+  const router = useRouter();
+
   const handleSubmit = async (
     values: FormValues,
     { setStatus }: FormikHelpers<FormValues>
@@ -29,6 +32,7 @@ const PanelApproveDialog = ({
         `/api/submissions/${submission.submissionId}/panel-approvals`
       );
       setOpen(false);
+      router.reload();
     } catch (e) {
       setStatus(e.toString());
     }

--- a/components/ApprovalWidget/RejectDialog.spec.tsx
+++ b/components/ApprovalWidget/RejectDialog.spec.tsx
@@ -2,8 +2,16 @@ import RejectDialog from './RejectDialog';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { mockSubmission } from 'factories/submissions';
 import axios from 'axios';
+import { useRouter } from 'next/router';
 
 jest.mock('axios');
+
+const mockHandler = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    reload: mockHandler,
+  }),
+}));
 
 beforeEach(() => jest.resetAllMocks());
 
@@ -21,7 +29,7 @@ describe('RejectDialog', () => {
     expect(screen.getByText('Submit'));
   });
 
-  it('makes a request to the right api route', async () => {
+  it('makes a request to the right api route, then reloads the page', async () => {
     render(
       <RejectDialog
         isOpen={true}
@@ -41,6 +49,7 @@ describe('RejectDialog', () => {
       expect(axios.delete).toBeCalledWith('/api/submissions/123/approvals', {
         data: { rejectionReason: 'This is a test reason' },
       });
+      expect(useRouter().reload).toBeCalledTimes(1);
     });
   });
 

--- a/components/ApprovalWidget/RejectDialog.tsx
+++ b/components/ApprovalWidget/RejectDialog.tsx
@@ -5,6 +5,7 @@ import { Formik, Form, FormikHelpers } from 'formik';
 import TextField from 'components/FlexibleForms/TextField';
 import Banner from 'components/FlexibleForms/Banner';
 import { rejectionSchema } from 'lib/validators';
+import { useRouter } from 'next/router';
 
 interface Props {
   isOpen: boolean;
@@ -21,6 +22,8 @@ const RejectDialog = ({
   isOpen,
   setOpen,
 }: Props): React.ReactElement => {
+  const router = useRouter();
+
   const handleReject = async (
     values: FormValues,
     { setStatus }: FormikHelpers<FormValues>
@@ -33,6 +36,7 @@ const RejectDialog = ({
         }
       );
       setOpen(false);
+      router.reload();
     } catch (e) {
       setStatus(e.toString);
     }


### PR DESCRIPTION
https://hackney.atlassian.net/browse/SCT-946

improves user experience by refreshing the page after a submission changes state, making sure that the ui reflects the latest state (eg. approved, in progress, submitted)