### PR TITLE
feature(sct-997): pull forms from contentful

### DIFF
--- a/ci-scripts/contentful.js
+++ b/ci-scripts/contentful.js
@@ -58,7 +58,7 @@ const run = async () => {
     }));
 
     fs.writeFileSync(
-      __dirname + '/data/flexibleForms/contentfulForms.ts',
+      'data/flexibleForms/contentfulForms.ts',
       template(JSON.stringify(processedForms, null, 2))
     );
   } catch (e) {

--- a/ci-scripts/contentful.js
+++ b/ci-scripts/contentful.js
@@ -1,0 +1,75 @@
+const axios = require('axios');
+const fs = require('fs');
+require('dotenv').config();
+
+const run = async () => {
+  try {
+    const { data } = await axios.get(
+      `https://cdn.contentful.com/spaces/${process.env.CONTENTFUL_SPACE_ID}/environments/master/entries?content_type=form&include=10`,
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.CONTENTFUL_ACCESS_TOKEN}`,
+        },
+      }
+    );
+
+    const forms = data.items;
+    const linkedEntries = data.includes.Entry;
+
+    const processedForms = forms.map((form) => ({
+      id: form.sys.id,
+      ...form.fields,
+      // don't include the themes key
+      themes: undefined,
+      // flatten out steps so they're no longer nested inside themes
+      steps: form.fields.themes
+        .map((rawTheme) =>
+          linkedEntries.find((entry) => entry.sys.id === rawTheme.sys.id)
+        )
+        .reduce((flatSteps, theme) => {
+          theme.fields.steps.forEach((rawStep) => {
+            const linkedStep = linkedEntries.find(
+              (entry) => entry.sys.id === rawStep.sys.id
+            );
+            flatSteps.push({
+              id: linkedStep.fields.name,
+              ...linkedStep.fields,
+              theme: theme.fields.name,
+              fields: linkedStep.fields.fields.map((rawField) => {
+                const linkedField = linkedEntries.find(
+                  (entry) => entry.sys.id === rawField.sys.id
+                );
+
+                return {
+                  id: linkedField.fields.question,
+                  ...linkedField.fields,
+                  choices:
+                    linkedField.fields.choices &&
+                    linkedField.fields.choices.map((choice) => ({
+                      label: choice,
+                      value: choice,
+                    })),
+                };
+              }),
+            });
+          });
+          return flatSteps;
+        }, []),
+    }));
+
+    fs.writeFileSync(
+      __dirname + '/data/flexibleForms/contentfulForms.ts',
+      template(JSON.stringify(processedForms, null, 2))
+    );
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+const template = (string) => `import { Form } from './forms.types';
+
+const forms: Form[] = ${string};
+
+export default forms`;
+
+run();

--- a/data/flexibleForms/contentfulForms.ts
+++ b/data/flexibleForms/contentfulForms.ts
@@ -4,7 +4,7 @@ const forms: Form[] = [
   {
     id: '21hsfQuDZQjNEvikC9QRzf',
     name: 'Social care assessment (sandbox form)',
-    isViewableByChildrens: true,
+    isViewableByChildrens: false,
     isViewableByAdults: false,
     groupRecordable: true,
     approvable: true,
@@ -13,7 +13,6 @@ const forms: Form[] = [
       {
         id: 'Health and wellbeing',
         name: 'Health and wellbeing',
-        theme: 'About you',
         fields: [
           {
             id: 'Are you taking any prescription medication?',
@@ -48,11 +47,11 @@ const forms: Form[] = [
             ],
           },
         ],
+        theme: 'About you',
       },
       {
         id: 'Test step 1',
         name: 'Test step 1',
-        theme: 'About you',
         fields: [
           {
             id: 'How many needles are in this haystack?',
@@ -85,11 +84,11 @@ const forms: Form[] = [
             error: 'That is not a number of pins',
           },
         ],
+        theme: 'About you',
       },
       {
         id: 'The best step',
         name: 'The best step',
-        theme: 'About you',
         fields: [
           {
             id: 'How many needles are in this haystack?',
@@ -142,6 +141,37 @@ const forms: Form[] = [
             ],
           },
         ],
+        theme: 'About you',
+      },
+      {
+        id: 'Your care history',
+        name: 'Your care history',
+        intro: 'Here we will describe the purpose of the step.',
+        fields: [
+          {
+            id: 'What is your history?',
+            question: 'What is your history?',
+            hint: 'It happened in the past.',
+            type: 'checkboxes',
+            choices: [
+              {
+                label: 'A good history',
+                value: 'A good history',
+              },
+              {
+                label: 'An ok history',
+                value: 'An ok history',
+              },
+              {
+                label: 'A bad history',
+                value: 'A bad history',
+              },
+            ],
+            required: true,
+            error: 'That is not a history',
+          },
+        ],
+        theme: 'Your care',
       },
     ],
   },

--- a/data/flexibleForms/contentfulForms.ts
+++ b/data/flexibleForms/contentfulForms.ts
@@ -1,0 +1,150 @@
+import { Form } from './forms.types';
+
+const forms: Form[] = [
+  {
+    id: '21hsfQuDZQjNEvikC9QRzf',
+    name: 'Social care assessment (sandbox form)',
+    isViewableByChildrens: true,
+    isViewableByAdults: false,
+    groupRecordable: true,
+    approvable: true,
+    panelApprovable: true,
+    steps: [
+      {
+        id: 'Health and wellbeing',
+        name: 'Health and wellbeing',
+        theme: 'About you',
+        fields: [
+          {
+            id: 'Are you taking any prescription medication?',
+            question: 'Are you taking any prescription medication?',
+            type: 'text',
+            hint: 'kkkkkkk',
+            required: true,
+          },
+          {
+            id: 'Which medications?',
+            question: 'Which medications?',
+            type: 'text',
+          },
+          {
+            id: 'What is their favourite colour?',
+            question: 'What is their favourite colour?',
+            type: 'radios',
+            hint: 'All the colours of the rainbow',
+            choices: [
+              {
+                label: 'red',
+                value: 'red',
+              },
+              {
+                label: 'blue',
+                value: 'blue',
+              },
+              {
+                label: 'green',
+                value: 'green',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'Test step 1',
+        name: 'Test step 1',
+        theme: 'About you',
+        fields: [
+          {
+            id: 'How many needles are in this haystack?',
+            question: 'How many needles are in this haystack?',
+            type: 'checkboxes',
+            hint: 'Between zero and infinity',
+            choices: [
+              {
+                label: 'one',
+                value: 'one',
+              },
+              {
+                label: 'two',
+                value: 'two',
+              },
+              {
+                label: 'three',
+                value: 'three',
+              },
+              {
+                label: 'four',
+                value: 'four',
+              },
+              {
+                label: 'five',
+                value: 'five',
+              },
+            ],
+            required: false,
+            error: 'That is not a number of pins',
+          },
+        ],
+      },
+      {
+        id: 'The best step',
+        name: 'The best step',
+        theme: 'About you',
+        fields: [
+          {
+            id: 'How many needles are in this haystack?',
+            question: 'How many needles are in this haystack?',
+            type: 'checkboxes',
+            hint: 'Between zero and infinity',
+            choices: [
+              {
+                label: 'one',
+                value: 'one',
+              },
+              {
+                label: 'two',
+                value: 'two',
+              },
+              {
+                label: 'three',
+                value: 'three',
+              },
+              {
+                label: 'four',
+                value: 'four',
+              },
+              {
+                label: 'five',
+                value: 'five',
+              },
+            ],
+            required: false,
+            error: 'That is not a number of pins',
+          },
+          {
+            id: 'What is their favourite colour?',
+            question: 'What is their favourite colour?',
+            type: 'radios',
+            hint: 'All the colours of the rainbow',
+            choices: [
+              {
+                label: 'red',
+                value: 'red',
+              },
+              {
+                label: 'blue',
+                value: 'blue',
+              },
+              {
+                label: 'green',
+                value: 'green',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export default forms;

--- a/data/flexibleForms/index.ts
+++ b/data/flexibleForms/index.ts
@@ -5,6 +5,7 @@ import sgAdultConcern from './sgAdultConcern';
 import sgAdultManagerDecisionConcern from './sgAdultManagerDecisionConcern';
 import adultCaseNote from './adultCaseNote';
 import childCaseNote from './childCaseNote';
+import contentfulForms from './contentfulForms';
 
 export default [
   foo,
@@ -14,4 +15,5 @@ export default [
   faceOverview,
   sgAdultConcern,
   sgAdultManagerDecisionConcern,
+  ...contentfulForms,
 ];

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "cy:open": "cypress open",
     "build-storybook": "build-storybook",
     "release": "release-it",
-    "delete-draft-github-releases": "node ./ci-scripts/delete-draft-github-releases.js"
+    "delete-draft-github-releases": "node ./ci-scripts/delete-draft-github-releases.js",
+    "contentful:import": "node ./ci-scripts/contentful.js"
   },
   "dependencies": {
     "@reach/dialog": "^0.15.0",


### PR DESCRIPTION
adding new forms is time-consuming and frustrating for non-designers.

[contentful](https://contentful.com) is a saas content management tool that can expose flexible content using an api.

this pr uses contentful as a data source for forms:
1. first, add `CONTENTFUL_SPACE_ID` and `CONTENTFUL_ACCESS_TOKEN` to your `.env` file
2. run `npm run contentful:import`
3. a new file, `data/flexibleForms/contentfulForms.ts` will be generated, which you can then save, commit and use immediately.
4. the imported forms will appear alongside hardcoded ones on `/submissions/new`

it adds a script, `ci-scripts/contentful.js` which fetches raw data from the contentful api, and transforms it to the format we need.

documentation added here: https://github.com/LBHackney-IT/lbh-social-care-frontend/wiki/Pulling-forms-from-Contentful

video demo: https://hackit-lbh.slack.com/archives/C029WLZ9196/p1627405277013900