### PR TITLE
feat(SCT-961): record date of event from asc form

### DIFF
--- a/data/flexibleForms/adultCaseNote.ts
+++ b/data/flexibleForms/adultCaseNote.ts
@@ -8,6 +8,9 @@ const form: Form = {
   isViewableByAdults: true,
   isViewableByChildrens: false,
   canonicalUrl: (socialCareId) => `/people/${socialCareId}/case-note`,
+  dateOfEvent: {
+    associatedId: 'Date of event',
+  },
   steps: [
     {
       id: 'Case note',

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -69,6 +69,9 @@ export interface Form {
   tags?: string[];
   /** override the automatically generated /submissions/new... url, for edge case forms */
   canonicalUrl?: (socialCareId: number) => string;
+  dateOfEvent?: {
+    associatedId: string;
+  };
 }
 
 export interface RepeaterGroupAnswer {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+process.env.TZ = 'UTC';
+
 module.exports = {
   collectCoverageFrom: [
     'components/**/*.{js,jsx,ts,tsx}',

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -195,7 +195,7 @@ describe('patchSubmissionForStep', () => {
       {
         editedBy: 'foo',
         stepAnswers: JSON.stringify(mockAnswers),
-        dateOfEvent: '2021-08-02T23:00:00.000Z',
+        dateOfEvent: '2021-08-03T00:00:00.000Z',
       },
       { headers: { 'x-api-key': AWS_KEY } }
     );
@@ -227,7 +227,7 @@ describe('patchSubmissionForStep', () => {
       {
         editedBy: 'foo',
         stepAnswers: JSON.stringify(mockAnswers),
-        dateOfEvent: '2021-08-02T10:00:00.000Z',
+        dateOfEvent: '2021-08-02T11:00:00.000Z',
       },
       { headers: { 'x-api-key': AWS_KEY } }
     );

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -172,6 +172,166 @@ describe('patchSubmissionForStep', () => {
       formAnswers: {},
     });
   });
+
+  it('should work with a valid date', async () => {
+    const mockAnswers = {
+      'question one': 'answer one',
+      'question two': 'answer two',
+      'date of event': '2021-08-03',
+    };
+
+    mockedAxios.patch.mockResolvedValue({
+      data: { submissionId: '123', formAnswers: {} },
+    });
+    const data = await patchSubmissionForStep(
+      '123',
+      '456',
+      'foo',
+      mockAnswers,
+      'date of event'
+    );
+    expect(mockedAxios.patch).toHaveBeenCalledWith(
+      `${ENDPOINT_API}/submissions/123/steps/456`,
+      {
+        editedBy: 'foo',
+        stepAnswers: JSON.stringify(mockAnswers),
+        dateOfEvent: '2021-08-02T23:00:00.000Z',
+      },
+      { headers: { 'x-api-key': AWS_KEY } }
+    );
+    expect(data).toEqual({
+      submissionId: '123',
+      formAnswers: {},
+    });
+  });
+
+  it('should work with a valid date time', async () => {
+    const mockAnswers = {
+      'question one': 'answer one',
+      'question two': 'answer two',
+      'date of event': ['2021-08-02', '11:00'],
+    };
+
+    mockedAxios.patch.mockResolvedValue({
+      data: { submissionId: '123', formAnswers: {} },
+    });
+    const data = await patchSubmissionForStep(
+      '123',
+      '456',
+      'foo',
+      mockAnswers,
+      'date of event'
+    );
+    expect(mockedAxios.patch).toHaveBeenCalledWith(
+      `${ENDPOINT_API}/submissions/123/steps/456`,
+      {
+        editedBy: 'foo',
+        stepAnswers: JSON.stringify(mockAnswers),
+        dateOfEvent: '2021-08-02T10:00:00.000Z',
+      },
+      { headers: { 'x-api-key': AWS_KEY } }
+    );
+    expect(data).toEqual({
+      submissionId: '123',
+      formAnswers: {},
+    });
+  });
+
+  it('should submit null dateOfEvent if supplied ID does not match a question', async () => {
+    const mockAnswers = {
+      'question one': 'answer one',
+      'question two': 'answer two',
+      'date of event wrong id': ['2021-08-02', '11:00'],
+    };
+
+    mockedAxios.patch.mockResolvedValue({
+      data: { submissionId: '123', formAnswers: {} },
+    });
+    const data = await patchSubmissionForStep(
+      '123',
+      '456',
+      'foo',
+      mockAnswers,
+      'date of event'
+    );
+    expect(mockedAxios.patch).toHaveBeenCalledWith(
+      `${ENDPOINT_API}/submissions/123/steps/456`,
+      {
+        editedBy: 'foo',
+        stepAnswers: JSON.stringify(mockAnswers),
+        dateOfEvent: null,
+      },
+      { headers: { 'x-api-key': AWS_KEY } }
+    );
+    expect(data).toEqual({
+      submissionId: '123',
+      formAnswers: {},
+    });
+  });
+
+  it('should submit null dateOfEvent if supplied DateTime is invalid', async () => {
+    const mockAnswers = {
+      'question one': 'answer one',
+      'question two': 'answer two',
+      'date of event wrong id': ['2021-08-40', '11:00'],
+    };
+
+    mockedAxios.patch.mockResolvedValue({
+      data: { submissionId: '123', formAnswers: {} },
+    });
+    const data = await patchSubmissionForStep(
+      '123',
+      '456',
+      'foo',
+      mockAnswers,
+      'date of event'
+    );
+    expect(mockedAxios.patch).toHaveBeenCalledWith(
+      `${ENDPOINT_API}/submissions/123/steps/456`,
+      {
+        editedBy: 'foo',
+        stepAnswers: JSON.stringify(mockAnswers),
+        dateOfEvent: null,
+      },
+      { headers: { 'x-api-key': AWS_KEY } }
+    );
+    expect(data).toEqual({
+      submissionId: '123',
+      formAnswers: {},
+    });
+  });
+
+  it('should submit null dateOfEvent if supplied Date is invalid', async () => {
+    const mockAnswers = {
+      'question one': 'answer one',
+      'question two': 'answer two',
+      'date of event wrong id': '2021-08-40',
+    };
+
+    mockedAxios.patch.mockResolvedValue({
+      data: { submissionId: '123', formAnswers: {} },
+    });
+    const data = await patchSubmissionForStep(
+      '123',
+      '456',
+      'foo',
+      mockAnswers,
+      'date of event'
+    );
+    expect(mockedAxios.patch).toHaveBeenCalledWith(
+      `${ENDPOINT_API}/submissions/123/steps/456`,
+      {
+        editedBy: 'foo',
+        stepAnswers: JSON.stringify(mockAnswers),
+        dateOfEvent: null,
+      },
+      { headers: { 'x-api-key': AWS_KEY } }
+    );
+    expect(data).toEqual({
+      submissionId: '123',
+      formAnswers: {},
+    });
+  });
 });
 
 describe('approveSubmission', () => {

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -195,7 +195,7 @@ describe('patchSubmissionForStep', () => {
       {
         editedBy: 'foo',
         stepAnswers: JSON.stringify(mockAnswers),
-        dateOfEvent: '2021-08-03T00:00:00.000Z',
+        dateOfEvent: '2021-08-03T12:00:00.000Z',
       },
       { headers: { 'x-api-key': AWS_KEY } }
     );

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -152,7 +152,6 @@ describe('patchSubmissionForStep', () => {
     const mockAnswers = {
       'question one': 'answer one',
       'question two': 'answer two',
-      Tags: ['foo', 'bar'],
     };
 
     mockedAxios.patch.mockResolvedValue({
@@ -164,7 +163,7 @@ describe('patchSubmissionForStep', () => {
       {
         editedBy: 'foo',
         stepAnswers: JSON.stringify(mockAnswers),
-        tags: ['foo', 'bar'],
+        dateOfEvent: null,
       },
       { headers: { 'x-api-key': AWS_KEY } }
     );

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -96,7 +96,9 @@ const getDateOfEvent = (
 
   try {
     if (typeof dateOfEventFromForm === 'string') {
-      return parse(dateOfEventFromForm, 'yyyy-MM-dd', new Date()).toISOString();
+      const dateMidDay = parse(dateOfEventFromForm, 'yyyy-MM-dd', new Date());
+      dateMidDay.setHours(12);
+      return dateMidDay.toISOString();
     } else {
       const dateConjoined = `${dateOfEventFromForm[0]} ${dateOfEventFromForm[1]}`;
 

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -87,14 +87,23 @@ const getDateOfEvent = (
 ): null | string => {
   if (!dateOfEventId) return null;
 
-  const dateOfEventFromForm = stepAnswers[dateOfEventId] as string | string[];
+  const dateOfEventFromForm = stepAnswers[dateOfEventId] as
+    | string
+    | string[]
+    | undefined;
 
-  if (typeof dateOfEventFromForm === 'string') {
-    return dateOfEventFromForm;
-  } else {
-    const dateConjoined = `${dateOfEventFromForm[0]} ${dateOfEventFromForm[1]}`;
+  if (!dateOfEventFromForm) return null;
 
-    return parse(dateConjoined, 'yyyy-MM-dd HH:ss', new Date()).toString();
+  try {
+    if (typeof dateOfEventFromForm === 'string') {
+      return parse(dateOfEventFromForm, 'yyyy-MM-dd', new Date()).toISOString();
+    } else {
+      const dateConjoined = `${dateOfEventFromForm[0]} ${dateOfEventFromForm[1]}`;
+
+      return parse(dateConjoined, 'yyyy-MM-dd HH:ss', new Date()).toISOString();
+    }
+  } catch {
+    return null;
   }
 };
 

--- a/pages/api/case-note/[id].ts
+++ b/pages/api/case-note/[id].ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import StatusCodes from 'http-status-codes';
 import { finishSubmission, patchSubmissionForStep } from 'lib/submissions';
 import { isAuthorised } from 'utils/auth';
+import { FormikValues } from 'formik';
 
 const handler = async (
   req: NextApiRequest,
@@ -15,21 +16,28 @@ const handler = async (
     switch (req.method) {
       case 'POST':
         {
+          const values = req.body as FormikValues;
           const submission = await finishSubmission(
             String(id),
             String(user?.email),
-            { singleStep: req.body }
+            { singleStep: values }
           );
           res.json(submission);
         }
         break;
       case 'PATCH':
         {
+          const { values, dateOfEventId } = req.body as {
+            values: FormikValues;
+            dateOfEventId?: string;
+          };
+
           const submission = await patchSubmissionForStep(
             String(id),
             'singleStep',
             String(user?.email),
-            req.body
+            values,
+            dateOfEventId
           );
           res.json(submission);
         }

--- a/pages/api/submissions/[id]/steps/[stepId].tsx
+++ b/pages/api/submissions/[id]/steps/[stepId].tsx
@@ -2,8 +2,9 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import forms from 'data/flexibleForms';
 import { isAuthorised } from 'utils/auth';
 import { getSubmissionById, patchSubmissionForStep } from 'lib/submissions';
-import statusCodes, { StatusCodes } from 'http-status-codes';
+import statusCodes from 'http-status-codes';
 import { Submission } from 'data/flexibleForms/forms.types';
+import { FormikValues } from 'formik';
 
 const handler = async (
   req: NextApiRequest,

--- a/pages/api/submissions/[id]/steps/[stepId].tsx
+++ b/pages/api/submissions/[id]/steps/[stepId].tsx
@@ -4,7 +4,6 @@ import { isAuthorised } from 'utils/auth';
 import { getSubmissionById, patchSubmissionForStep } from 'lib/submissions';
 import statusCodes from 'http-status-codes';
 import { Submission } from 'data/flexibleForms/forms.types';
-import { FormikValues } from 'formik';
 
 const handler = async (
   req: NextApiRequest,

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -62,7 +62,10 @@ const CaseNote = ({
         await axios.post(`/api/case-note/${submissionId}`, values);
         router.push(`/people/${params.id}`);
       } else {
-        await axios.patch(`/api/case-note/${submissionId}`, values);
+        await axios.patch(`/api/case-note/${submissionId}`, {
+          values,
+          dateOfEventId: form.dateOfEvent?.associatedId,
+        });
       }
     } catch (e) {
       setStatus(e.toString());

--- a/pages/submissions/[id]/steps/[stepId].tsx
+++ b/pages/submissions/[id]/steps/[stepId].tsx
@@ -3,7 +3,6 @@ import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import PersonWidget from 'components/PersonWidget/PersonWidget';
 import StepForm from 'components/FlexibleForms/StepForm';
-import { useRouter } from 'next/router';
 import s from 'stylesheets/Sidebar.module.scss';
 import Banner from 'components/FlexibleForms/Banner';
 import { Form, Step, Field } from 'data/flexibleForms/forms.types';
@@ -33,8 +32,6 @@ const StepPage = ({
   step,
   form,
 }: Props): React.ReactElement => {
-  const router = useRouter();
-
   const handleSubmit = async (
     values: FormikValues,
     { setStatus }: FormikHelpers<FormikValues>
@@ -45,17 +42,6 @@ const StepPage = ({
         values
       );
       if (data.error) throw data.error;
-    } catch (e) {
-      setStatus(e.toString());
-    }
-  };
-
-  const handleFinish = async (
-    setStatus: (message: string) => void
-  ): Promise<void> => {
-    try {
-      await axios.post(`/api/submissions/${params.id}`);
-      router.push(`/people/${residents[0].id}/submissions/${params.id}`);
     } catch (e) {
       setStatus(e.toString());
     }


### PR DESCRIPTION
**What**  
Allows our flexible forms to identify a field as being the `dateOfEvent`, when patching our answers we then can supply the datetime value from the form.

**Why**  
For our ASC case note form the date of event is currently just when the form was created but the event happened sometime in the past. This then messes up the timeline for the resident for example where the form appears in the timeline when it was created, not when the event occurred.

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
