### PR TITLE
fix: only ask if children alone after confirming children were seen

### DIFF
--- a/data/flexibleForms/childCaseNote.ts
+++ b/data/flexibleForms/childCaseNote.ts
@@ -68,6 +68,10 @@ const form: Form = {
               id: 'Type',
               value: 'Visit',
             },
+            {
+              id: 'Were the child/children seen',
+              value: 'Yes',
+            },
           ],
           choices: [
             {


### PR DESCRIPTION
Too small to need description. See title.
