### PR TITLE
feat: adds CI script for validating a PR title conforms to conventional commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,14 @@ jobs:
           root: *workspace_root
           paths: .
 
+  validate-pr-title:
+    executor: node-executor
+    steps:
+      - *attach_workspace
+      - run:
+          name: Run PR title validator
+          command: yarn validate-pr-title
+
   unit-tests:
     executor: node-executor
     steps:
@@ -104,12 +112,12 @@ jobs:
           # 3: Any other failure
           # Link to above:https://github.com/zaproxy/zaproxy/blob/main/docker/zap-baseline.py#L31-L35
           command: |
-              (
-                docker run -t owasp/zap2docker-stable zap-baseline.py \
-                -u https://raw.githubusercontent.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}/zap-baseline.conf \
-                -t http://$(ip -f inet -o addr show docker0 | awk '{print $4}' | cut -d '/' -f 1):3000 || \
-                if [[ $? == 0 || $? == 2 ]]; then exit 0; else exit 1; fi;
-              )
+            (
+              docker run -t owasp/zap2docker-stable zap-baseline.py \
+              -u https://raw.githubusercontent.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}/zap-baseline.conf \
+              -t http://$(ip -f inet -o addr show docker0 | awk '{print $4}' | cut -d '/' -f 1):3000 || \
+              if [[ $? == 0 || $? == 2 ]]; then exit 0; else exit 1; fi;
+            )
 
   build-deploy-staging:
     executor: aws-cli/default
@@ -207,6 +215,9 @@ workflows:
       - unit-tests:
           requires:
             - install-dependencies
+      - validate-pr-title:
+          requires:
+            - unit-tests
       - build:
           requires:
             - unit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ workflows:
             - install-dependencies
       - validate-pr-title:
           requires:
-            - unit-tests
+            - install-dependencies
       - build:
           requires:
             - unit-tests

--- a/ci-scripts/validate-pr-title.js
+++ b/ci-scripts/validate-pr-title.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+const fetch = require('cross-fetch');
+
+const fetchPullRequestTitle = (prUrl) => {
+  const { CIRCLE_PROJECT_USERNAME, CIRCLE_PROJECT_REPONAME, GITHUB_TOKEN } =
+    process.env;
+
+  const prNumber = prUrl.split('/').reverse()[0];
+
+  return fetch(
+    `https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${prNumber}`,
+    {
+      headers: {
+        Authorization: `token ${GITHUB_TOKEN}`,
+      },
+    }
+  )
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText);
+      }
+
+      return res.json();
+    })
+    .then(({ title }) => title);
+};
+
+const validatePrTitle = async ({
+  pullRequestUrl,
+  projectUsername,
+  projectRepoName,
+  gitHubToken,
+}) => {
+  if (!pullRequestUrl || !projectUsername || !projectRepoName || !gitHubToken) {
+    throw new Error('Please provide the required config');
+  }
+
+  const title = await fetchPullRequestTitle(pullRequestUrl);
+
+  console.log(`Verifying PR title: "${title}"`);
+
+  const regex =
+    /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|test)\(?(.*?)\)?: (.*?)$/g;
+
+  const result = regex.exec(title);
+
+  if (!result) {
+    throw new Error(
+      `The PR type provided is not valid, must be one of ${[
+        'build',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'test',
+      ].join(', ')}`
+    );
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  const [_, __, ___, description] = result;
+
+  if (!description) {
+    throw new Error('No description provided');
+  }
+};
+
+if (require.main === module) {
+  const {
+    CIRCLE_PROJECT_USERNAME,
+    CIRCLE_PROJECT_REPONAME,
+    GITHUB_TOKEN,
+    CIRCLE_PULL_REQUEST,
+  } = process.env;
+
+  validatePrTitle({
+    gitHubToken: GITHUB_TOKEN,
+    pullRequestUrl: CIRCLE_PULL_REQUEST,
+    projectRepoName: CIRCLE_PROJECT_REPONAME,
+    projectUsername: CIRCLE_PROJECT_USERNAME,
+  })
+    .then(() => {
+      console.log('Done!');
+      process.exit();
+    })
+    .catch((e) => {
+      console.error('Failed to parse PR title.', e.message);
+      process.exit(1);
+    });
+}
+
+module.exports = {
+  validatePrTitle,
+};

--- a/ci-scripts/validate-pr-title.js
+++ b/ci-scripts/validate-pr-title.js
@@ -1,17 +1,19 @@
 #!/usr/bin/env node
 const fetch = require('cross-fetch');
 
-const fetchPullRequestTitle = (prUrl) => {
-  const { CIRCLE_PROJECT_USERNAME, CIRCLE_PROJECT_REPONAME, GITHUB_TOKEN } =
-    process.env;
-
-  const prNumber = prUrl.split('/').reverse()[0];
+const fetchPullRequestTitle = ({
+  pullRequestUrl,
+  projectUsername,
+  projectRepoName,
+  gitHubToken,
+}) => {
+  const prNumber = pullRequestUrl.split('/').reverse()[0];
 
   return fetch(
-    `https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${prNumber}`,
+    `https://api.github.com/repos/${projectUsername}/${projectRepoName}/pulls/${prNumber}`,
     {
       headers: {
-        Authorization: `token ${GITHUB_TOKEN}`,
+        Authorization: `token ${gitHubToken}`,
       },
     }
   )
@@ -35,7 +37,12 @@ const validatePrTitle = async ({
     throw new Error('Please provide the required config');
   }
 
-  const title = await fetchPullRequestTitle(pullRequestUrl);
+  const title = await fetchPullRequestTitle({
+    pullRequestUrl,
+    projectUsername,
+    projectRepoName,
+    gitHubToken,
+  });
 
   console.log(`Verifying PR title: "${title}"`);
 

--- a/ci-scripts/validate-pr-title.spec.js
+++ b/ci-scripts/validate-pr-title.spec.js
@@ -1,0 +1,100 @@
+import fetch from 'cross-fetch';
+import { validatePrTitle } from './validate-pr-title';
+
+jest.mock('cross-fetch');
+
+const defaultConfig = {
+  gitHubToken: 'github-token',
+  pullRequestUrl: 'pull-request',
+  projectRepoName: 'project-reponame',
+  projectUsername: 'project-username',
+};
+
+describe('#validatePrTitle()', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should throw an error if the projectUsername config value is not provided', async () => {
+    await expect(
+      validatePrTitle({
+        ...defaultConfig,
+        projectUsername: undefined,
+      })
+    ).rejects.toThrow('Please provide the required config');
+  });
+
+  it('should throw an error if the projectRepoName config value is not provided', async () => {
+    await expect(
+      validatePrTitle({
+        ...defaultConfig,
+        projectRepoName: undefined,
+      })
+    ).rejects.toThrow('Please provide the required config');
+  });
+
+  it('should throw an error if the pullRequestUrl config value is not provided', async () => {
+    await expect(
+      validatePrTitle({
+        ...defaultConfig,
+        pullRequestUrl: undefined,
+      })
+    ).rejects.toThrow('Please provide the required config');
+  });
+
+  it('should throw an error if the gitHubToken config value is not provided', async () => {
+    await expect(
+      validatePrTitle({
+        ...defaultConfig,
+        gitHubToken: undefined,
+      })
+    ).rejects.toThrow('Please provide the required config');
+  });
+
+  it('should throw an error if the HTTP request to GitHub fails', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Some error',
+      json: () => {},
+    });
+
+    await expect(validatePrTitle(defaultConfig)).rejects.toThrow(/Some error/);
+  });
+
+  it('should throw an error if an invalid type is provided in the PR title', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => ({
+        title: 'not a valid title',
+      }),
+    });
+
+    await expect(validatePrTitle(defaultConfig)).rejects.toThrow(
+      /The PR type provided is not valid/
+    );
+  });
+
+  it('should throw an error if no description is provided in the PR title', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => ({
+        title: 'fix(ABC-123): ',
+      }),
+    });
+
+    await expect(validatePrTitle(defaultConfig)).rejects.toThrow(
+      'No description provided'
+    );
+  });
+
+  it('should resolve, returning nothing, if a valid PR title is provided', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => ({
+        title: 'fix(ABC-123): some description',
+      }),
+    });
+
+    await expect(validatePrTitle(defaultConfig)).resolves.toBeUndefined();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "cy:open": "cypress open",
     "build-storybook": "build-storybook",
     "release": "release-it",
-    "delete-draft-github-releases": "node ./ci-scripts/delete-draft-github-releases.js"
+    "delete-draft-github-releases": "node ./ci-scripts/delete-draft-github-releases.js",
+    "validate-pr-title": "node ./ci-scripts/validate-pr-title.js"
   },
   "dependencies": {
     "@reach/dialog": "^0.15.0",


### PR DESCRIPTION
**What**  
To help us keep release notes accurate and complete, it helps when our PR titles and the associated merge commit follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) pattern. This PR introduces a CI script for validating PR titles, and failing if they do not match the pattern.
