### PR TITLE
Fix: Parse datetime correctly from FlexibleForms

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-process.env.TZ = 'UTC';
+process.env.TZ = 'BST';
 
 module.exports = {
   collectCoverageFrom: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-process.env.TZ = 'BST';
+process.env.TZ = 'UTC';
 
 module.exports = {
   collectCoverageFrom: [

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -209,7 +209,7 @@ describe('patchSubmissionForStep', () => {
     const mockAnswers = {
       'question one': 'answer one',
       'question two': 'answer two',
-      'date of event': ['2021-08-02', '11:00'],
+      'date of event': ['2021-02-02', '10:30'],
     };
 
     mockedAxios.patch.mockResolvedValue({
@@ -227,7 +227,7 @@ describe('patchSubmissionForStep', () => {
       {
         editedBy: 'foo',
         stepAnswers: JSON.stringify(mockAnswers),
-        dateOfEvent: '2021-08-02T11:00:00.000Z',
+        dateOfEvent: '2021-02-02T10:30:00.000Z',
       },
       { headers: { 'x-api-key': AWS_KEY } }
     );
@@ -241,7 +241,7 @@ describe('patchSubmissionForStep', () => {
     const mockAnswers = {
       'question one': 'answer one',
       'question two': 'answer two',
-      'date of event wrong id': ['2021-08-02', '11:00'],
+      'date of event wrong id': ['2021-08-02', '10:30'],
     };
 
     mockedAxios.patch.mockResolvedValue({
@@ -273,7 +273,7 @@ describe('patchSubmissionForStep', () => {
     const mockAnswers = {
       'question one': 'answer one',
       'question two': 'answer two',
-      'date of event wrong id': ['2021-08-40', '11:00'],
+      'date of event wrong id': ['2021-08-40', '10:30'],
     };
 
     mockedAxios.patch.mockResolvedValue({

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -102,7 +102,7 @@ const getDateOfEvent = (
     } else {
       const dateConjoined = `${dateOfEventFromForm[0]} ${dateOfEventFromForm[1]}`;
 
-      return parse(dateConjoined, 'yyyy-MM-dd HH:ss', new Date()).toISOString();
+      return parse(dateConjoined, 'yyyy-MM-dd HH:mm', new Date()).toISOString();
     }
   } catch {
     return null;


### PR DESCRIPTION
**What**  
We were mistakenly sending the minutes from the input datetime as seconds, this fixes that

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
