### PR TITLE
Sct 425/chore remove date search

### DIFF
--- a/components/Search/Search.jsx
+++ b/components/Search/Search.jsx
@@ -103,7 +103,6 @@ const Search = ({
     },
     [pathname, query, replace]
   );
-
   // commented out as the feature is not ready in the BE
   // eslint-disable-next-line no-unused-vars
   const onSort = useCallback(

--- a/components/Search/forms/SearchCasesForm.spec.tsx
+++ b/components/Search/forms/SearchCasesForm.spec.tsx
@@ -42,8 +42,6 @@ describe(`SearchCasesForm`, () => {
       form_name: '',
       exact_name_match: false,
       my_notes_only: false,
-      end_date: null,
-      start_date: null,
       worker_email: '',
     });
   });
@@ -67,8 +65,6 @@ describe(`SearchCasesForm`, () => {
       form_name: '',
       exact_name_match: false,
       my_notes_only: false,
-      end_date: null,
-      start_date: null,
       worker_email: '',
     });
   });

--- a/components/Search/forms/SearchCasesForm.tsx
+++ b/components/Search/forms/SearchCasesForm.tsx
@@ -1,15 +1,7 @@
 import { useMemo } from 'react';
 import { useForm } from 'react-hook-form';
-import isPast from 'date-fns/isPast';
 
-import { convertFormat } from 'utils/date';
-import {
-  TextInput,
-  EmailInput,
-  Checkbox,
-  DateInput,
-  Autocomplete,
-} from 'components/Form';
+import { TextInput, EmailInput, Checkbox, Autocomplete } from 'components/Form';
 import Button from 'components/Button/Button';
 import { useAuth } from 'components/UserContext/UserContext';
 import { getFormsByUserPermission } from 'utils/forms';
@@ -95,7 +87,8 @@ const SearchCasesForm = ({
           />
         </div>
       </div>
-      <div className="govuk-grid-row">
+      {/* There is a big in date input which swaps the date and month fields. This date input may be swapped for a date picker in the future. */}
+      {/* <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-half">
           <DateInput
             label="Date created from"
@@ -132,7 +125,7 @@ const SearchCasesForm = ({
             }}
           />
         </div>
-      </div>
+      </div> */}
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-half">
           <Autocomplete


### PR DESCRIPTION
The date input on search has a bug which reverses the date and month inputs when sent to the back end. 
This input may be replaced with a date picker. The search functionality may have a overhaul in the future. Therefore, we have decided to comment out an not use the date input until we have a clearer way of moving forward with search.