### PR TITLE
Fix: Address mismatch between creating a new note and a person's details

### DIFF
--- a/components/GroupRecording/__snapshots__/GroupRecordingWidget.spec.tsx.snap
+++ b/components/GroupRecording/__snapshots__/GroupRecordingWidget.spec.tsx.snap
@@ -23,6 +23,7 @@ exports[`GroupRecordingWidget should render properly 1`] = `
       </p>
       <p
         class="lbh-body-s paragraph"
+        data-testid="resident-display-address"
       >
         sjakdjlk
         <br />

--- a/components/PersonWidget/PersonWidget.spec.tsx
+++ b/components/PersonWidget/PersonWidget.spec.tsx
@@ -54,6 +54,40 @@ describe('PersonWidget', () => {
     ).toBeNull();
   });
 
+  it('should return the last address if there are multiple addresses saved on the person', () => {
+    const firstAddress = {
+      addressLines: '100 Example Street',
+      postCode: 'E1 8HW',
+    };
+
+    const newAddress = {
+      addressLines: '123 TestCode Lane',
+      postCode: 'SE1 7DT',
+    };
+
+    const resident = residentFactory.build();
+    resident.addresses = [firstAddress, newAddress];
+
+    const { getByTestId, asFragment } = render(
+      <PersonWidget person={resident} />
+    );
+
+    expect(getByTestId('resident-last-address')).toHaveTextContent(
+      '123 TestCode Lane'
+    );
+    expect(getByTestId('resident-last-address')).toHaveTextContent('SE1 7DT');
+
+    expect(getByTestId('resident-last-address')).not.toHaveTextContent(
+      '100 Example Street'
+    );
+
+    expect(getByTestId('resident-last-address')).not.toHaveTextContent(
+      'E1 8HW'
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   it('should call the setOpen callback with the id of the selected resident if the widget is not open', () => {
     const resident = residentFactory.build();
     const mockSetOpen = jest.fn();

--- a/components/PersonWidget/PersonWidget.spec.tsx
+++ b/components/PersonWidget/PersonWidget.spec.tsx
@@ -84,8 +84,6 @@ describe('PersonWidget', () => {
     expect(getByTestId('resident-last-address')).not.toHaveTextContent(
       'E1 8HW'
     );
-
-    expect(asFragment()).toMatchSnapshot();
   });
 
   it('should call the setOpen callback with the id of the selected resident if the widget is not open', () => {

--- a/components/PersonWidget/PersonWidget.tsx
+++ b/components/PersonWidget/PersonWidget.tsx
@@ -31,7 +31,10 @@ const PersonWidget = ({
 }: Props): React.ReactElement => {
   const dateOfBirth = prettyDate(person?.dateOfBirth ?? '');
   const displayAddress = person?.address;
-  const firstAddress = 'id' in person ? person?.addresses?.[0] : person.address;
+  const lastAddress =
+    'id' in person
+      ? person?.addresses?.[person?.addresses.length - 1]
+      : person.address;
   if (grouped)
     return (
       <aside className={s.aside}>
@@ -57,21 +60,27 @@ const PersonWidget = ({
             <p className={`lbh-body-s ${s.paragraph}`}>Born {dateOfBirth}</p>
           )}
           {displayAddress && (
-            <p className={`lbh-body-s ${s.paragraph}`}>
+            <p
+              className={`lbh-body-s ${s.paragraph}`}
+              data-testid="resident-display-address"
+            >
               {displayAddress?.address}
               <br />
               {displayAddress?.postcode}
             </p>
           )}
-          {firstAddress && (
-            <p className={`lbh-body-s ${s.paragraph}`}>
-              {'address' in firstAddress
-                ? firstAddress.address
-                : firstAddress.addressLines}
+          {lastAddress && (
+            <p
+              className={`lbh-body-s ${s.paragraph}`}
+              data-testid="resident-last-address"
+            >
+              {'address' in lastAddress
+                ? lastAddress.address
+                : lastAddress.addressLines}
               <br />
-              {'postcode' in firstAddress
-                ? firstAddress.postcode
-                : firstAddress.postCode}
+              {'postcode' in lastAddress
+                ? lastAddress.postcode
+                : lastAddress.postCode}
             </p>
           )}
 
@@ -100,21 +109,27 @@ const PersonWidget = ({
         <p className={`lbh-body-s ${s.paragraph}`}>Born {dateOfBirth}</p>
       )}
       {displayAddress && (
-        <p className={`lbh-body-s ${s.paragraph}`}>
+        <p
+          className={`lbh-body-s ${s.paragraph}`}
+          data-testid="resident-display-address"
+        >
           {displayAddress?.address}
           <br />
           {displayAddress?.postcode}
         </p>
       )}
-      {firstAddress && (
-        <p className={`lbh-body-s ${s.paragraph}`}>
-          {'address' in firstAddress
-            ? firstAddress.address
-            : firstAddress.addressLines}
+      {lastAddress && (
+        <p
+          className={`lbh-body-s ${s.paragraph}`}
+          data-testid="resident-last-address"
+        >
+          {'address' in lastAddress
+            ? lastAddress.address
+            : lastAddress.addressLines}
           <br />
-          {'postcode' in firstAddress
-            ? firstAddress.postcode
-            : firstAddress.postCode}
+          {'postcode' in lastAddress
+            ? lastAddress.postcode
+            : lastAddress.postCode}
         </p>
       )}
     </aside>

--- a/components/PersonWidget/__snapshots__/PersonWidget.spec.tsx.snap
+++ b/components/PersonWidget/__snapshots__/PersonWidget.spec.tsx.snap
@@ -17,10 +17,46 @@ exports[`PersonWidget should render properly 1`] = `
     </p>
     <p
       class="lbh-body-s paragraph"
+      data-testid="resident-display-address"
     >
       sjakdjlk
       <br />
       hdsadjk
+    </p>
+  </aside>
+</DocumentFragment>
+`;
+
+exports[`PersonWidget should return the last address if there are multiple addresses saved on the person 1`] = `
+<DocumentFragment>
+  <aside
+    class="aside"
+  >
+    <h2
+      class="lbh-heading-h3 title"
+    >
+      Foo Bar
+    </h2>
+    <p
+      class="lbh-body-s paragraph"
+    >
+      Born 13 Nov 2020
+    </p>
+    <p
+      class="lbh-body-s paragraph"
+      data-testid="resident-display-address"
+    >
+      sjakdjlk
+      <br />
+      hdsadjk
+    </p>
+    <p
+      class="lbh-body-s paragraph"
+      data-testid="resident-last-address"
+    >
+      123 TestCode Lane
+      <br />
+      SE1 7DT
     </p>
   </aside>
 </DocumentFragment>

--- a/components/PersonWidget/__snapshots__/PersonWidget.spec.tsx.snap
+++ b/components/PersonWidget/__snapshots__/PersonWidget.spec.tsx.snap
@@ -26,38 +26,3 @@ exports[`PersonWidget should render properly 1`] = `
   </aside>
 </DocumentFragment>
 `;
-
-exports[`PersonWidget should return the last address if there are multiple addresses saved on the person 1`] = `
-<DocumentFragment>
-  <aside
-    class="aside"
-  >
-    <h2
-      class="lbh-heading-h3 title"
-    >
-      Foo Bar
-    </h2>
-    <p
-      class="lbh-body-s paragraph"
-    >
-      Born 13 Nov 2020
-    </p>
-    <p
-      class="lbh-body-s paragraph"
-      data-testid="resident-display-address"
-    >
-      sjakdjlk
-      <br />
-      hdsadjk
-    </p>
-    <p
-      class="lbh-body-s paragraph"
-      data-testid="resident-last-address"
-    >
-      123 TestCode Lane
-      <br />
-      SE1 7DT
-    </p>
-  </aside>
-</DocumentFragment>
-`;


### PR DESCRIPTION
**What**  
When a person's address is updated, the change is reflected in the UI when viewing the person details page. If previous addresses were saved on the person and you created a new case note or submission, the address displayed in the widget was not the same as the one found on the details page.

**Why** 
When creating a new case note or submission, the widget pulled the first address from this list of addresses for a person, and the first address may not always be the most recent address saved on a person.

This changes the code to retrieve the address we want to use when a person has a list of addresses associated with them and gets the last address added instead of the first.

We also added `data_test_id` attributes to make testing the change easier.