### PR TITLE
Fix: Send correct formId for case notes

### DIFF
--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -47,7 +47,7 @@ export const startSubmission = async (
     `${ENDPOINT_API}/submissions`,
     {
       formId,
-      socialCareId: Number(socialCareId),
+      socialCareId: socialCareId,
       createdBy,
     },
     {

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -174,7 +174,7 @@ export const getServerSideProps: GetServerSideProps = async ({
     const user = isAuthorised(req);
     const resident = await getResident(Number(params?.id), user as User);
     const form =
-      resident.ageContext === 'A' ? ADULT_CASE_NOTE : CHILD_CASE_NOTE;
+      resident.contextFlag === 'A' ? ADULT_CASE_NOTE : CHILD_CASE_NOTE;
 
     submission = await startSubmission(
       form.id,


### PR DESCRIPTION
**What**  
We were always sending the formId as `child-case-note` even when the form was actually for an adult so should be `child-case-note`

**Why**  
Bug fix.

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
