### PR TITLE
Fix: Person timeline test failing as tested value is dynamic from the date

### DIFF
--- a/components/NewPersonView/PersonTimeline.spec.tsx
+++ b/components/NewPersonView/PersonTimeline.spec.tsx
@@ -17,6 +17,12 @@ const mockEvents = [
 
 describe('PersonTimeline', () => {
   it('renders a list of clickable submissions', () => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() =>
+        new Date('2021-07-25T00:00:00.000Z').valueOf()
+      );
+
     render(
       <PersonTimeline
         setSize={jest.fn()}


### PR DESCRIPTION
**What**  
The `PersonTimeline.spec.tsx` `renders a list of clickable submissions` test started failing. This is due to the testing an output from the function `safelyFormatDistanceToNow`. Now refers to the current time, the test wasn't mocking out the current time though so this test has started failing, added a mock to Date.now that fixes this.

**Why**  
We want our test to actually work and not block the pipeline :p

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
