### PR TITLE
Fix: Update API call for in-progress submissions

### DIFF
--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import {
   finishSubmission,
   getSubmissionById,
-  getUnfinishedSubmissions,
+  getInProgressSubmissions,
   patchResidents,
   patchSubmissionForStep,
   startSubmission,
@@ -21,17 +21,17 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 const ENDPOINT_API = process.env.ENDPOINT_API;
 const AWS_KEY = process.env.AWS_KEY;
 
-describe('getUnfinishedSubmissions', () => {
-  it('should return a list of incomplete submissions', async () => {
+describe('getInProgressSubmissions', () => {
+  it('should return a list of in-progress submissions', async () => {
     mockedAxios.get.mockResolvedValue({
       data: [
         { submissionId: '123', formAnswers: {} },
         { submissionId: '456', formAnswers: {} },
       ],
     });
-    const data = await getUnfinishedSubmissions();
+    const data = await getInProgressSubmissions();
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      `${ENDPOINT_API}/submissions`,
+      `${ENDPOINT_API}/submissions?submissionStates=in_progress`,
       { headers: { 'x-api-key': AWS_KEY } }
     );
     expect(data).toEqual([
@@ -60,7 +60,7 @@ describe('getUnfinishedSubmissions', () => {
         },
       ],
     });
-    const data = await getUnfinishedSubmissions('A');
+    const data = await getInProgressSubmissions('A');
     expect(data).toEqual([
       {
         submissionId: '123',

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -22,12 +22,15 @@ const headersWithKey = {
 };
 
 /** get a list of all unfinished submissions in the current social care service context  */
-export const getUnfinishedSubmissions = async (
+export const getInProgressSubmissions = async (
   ageContext?: AgeContext
 ): Promise<Submission[]> => {
-  const { data } = await axios.get(`${ENDPOINT_API}/submissions`, {
-    headers: headersWithKey,
-  });
+  const { data } = await axios.get(
+    `${ENDPOINT_API}/submissions?submissionStates=in_progress`,
+    {
+      headers: headersWithKey,
+    }
+  );
   return ageContext
     ? data.filter((submission: Submission) =>
         submission.residents.some(

--- a/pages/api/submissions/index.ts
+++ b/pages/api/submissions/index.ts
@@ -1,7 +1,7 @@
 import forms from 'data/flexibleForms';
 import { NextApiRequest, NextApiResponse } from 'next';
 import StatusCodes from 'http-status-codes';
-import { startSubmission, getUnfinishedSubmissions } from 'lib/submissions';
+import { startSubmission, getInProgressSubmissions } from 'lib/submissions';
 import { isAuthorised } from 'utils/auth';
 
 const handler = async (
@@ -23,7 +23,7 @@ const handler = async (
       break;
     case 'GET':
       if (req.query.includeSubmissions) {
-        const submissions = await getUnfinishedSubmissions(
+        const submissions = await getInProgressSubmissions(
           user?.permissionFlag
         );
         res.json({

--- a/pages/work-in-progress.tsx
+++ b/pages/work-in-progress.tsx
@@ -2,7 +2,7 @@ import Seo from 'components/Layout/Seo/Seo';
 import SavedForms from 'components/SaveFormData/SaveFormData';
 import DashboardWrapper from 'components/Dashboard/DashboardWrapper';
 import { GetServerSideProps } from 'next';
-import { getUnfinishedSubmissions } from 'lib/submissions';
+import { getInProgressSubmissions } from 'lib/submissions';
 import { Submission } from 'data/flexibleForms/forms.types';
 import SubmissionsTable from 'components/SubmissionsTable';
 import { isAuthorised } from 'utils/auth';
@@ -31,7 +31,7 @@ export default UnfinishedSubmissions;
 
 export const getServerSideProps: GetServerSideProps = async ({ req }) => {
   const user = isAuthorised(req);
-  const submissions = await getUnfinishedSubmissions(user?.permissionFlag);
+  const submissions = await getInProgressSubmissions(user?.permissionFlag);
 
   return {
     props: {


### PR DESCRIPTION
**What**  
To match the changes in the API from PR https://github.com/LBHackney-IT/social-care-case-viewer-api/pull/405

**Why**  
So code relying on getting unfinished submissions continues to work

**Anything else?**

This requires some level of simultaneous deployment with the BE changes!

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
