### PR TITLE
Fix (SCT-982): Address mismatch on widget v2

### DIFF
--- a/components/PersonWidget/PersonWidget.spec.tsx
+++ b/components/PersonWidget/PersonWidget.spec.tsx
@@ -54,19 +54,21 @@ describe('PersonWidget', () => {
     ).toBeNull();
   });
 
-  it('should return the last address if there are multiple addresses saved on the person', () => {
-    const firstAddress = {
+  it('should return the display address from the addresses list saved on the person', () => {
+    const anotherAddress = {
       addressLines: '100 Example Street',
       postCode: 'E1 8HW',
+      isDisplayAddress: 'N',
     };
 
-    const newAddress = {
+    const displayAddress = {
       addressLines: '123 TestCode Lane',
       postCode: 'SE1 7DT',
+      isDisplayAddress: 'Y',
     };
 
     const resident = residentFactory.build();
-    resident.addresses = [firstAddress, newAddress];
+    resident.addresses = [displayAddress, anotherAddress];
 
     const { getByTestId } = render(<PersonWidget person={resident} />);
 
@@ -84,22 +86,26 @@ describe('PersonWidget', () => {
     );
   });
 
-  it('should not return the last address if the person is later updated to have no address', () => {
-    const lastKnownAddress = {
+  it('should return no address if no display address is set for the person', () => {
+    const oneAddress = {
       addressLines: '100 Example Street',
       postCode: 'E1 8HW',
+      isDisplayAddress: 'N',
+    };
+
+    const anotherAddress = {
+      addressLines: '100 Example Street',
+      postCode: 'E1 8HW',
+      isDisplayAddress: 'N',
     };
 
     const resident = residentFactory.build();
-    resident.addresses = [lastKnownAddress];
+    resident.addresses = [oneAddress, anotherAddress];
     resident.address = undefined;
 
-    const { getByTestId, getByText } = render(
-      <PersonWidget person={resident} />
-    );
-
-    const widgetAddress = screen.queryByTestId('resident-last-address');
-    expect(widgetAddress).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('resident-last-address')
+    ).not.toBeInTheDocument();
   });
 
   it('should call the setOpen callback with the id of the selected resident if the widget is not open', () => {

--- a/components/PersonWidget/PersonWidget.spec.tsx
+++ b/components/PersonWidget/PersonWidget.spec.tsx
@@ -1,5 +1,5 @@
 import PersonWidget from './PersonWidget';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { residentFactory } from 'factories/residents';
 
 describe('PersonWidget', () => {
@@ -68,9 +68,7 @@ describe('PersonWidget', () => {
     const resident = residentFactory.build();
     resident.addresses = [firstAddress, newAddress];
 
-    const { getByTestId, asFragment } = render(
-      <PersonWidget person={resident} />
-    );
+    const { getByTestId } = render(<PersonWidget person={resident} />);
 
     expect(getByTestId('resident-last-address')).toHaveTextContent(
       '123 TestCode Lane'
@@ -84,6 +82,24 @@ describe('PersonWidget', () => {
     expect(getByTestId('resident-last-address')).not.toHaveTextContent(
       'E1 8HW'
     );
+  });
+
+  it('should not return the last address if the person is later updated to have no address', () => {
+    const lastKnownAddress = {
+      addressLines: '100 Example Street',
+      postCode: 'E1 8HW',
+    };
+
+    const resident = residentFactory.build();
+    resident.addresses = [lastKnownAddress];
+    resident.address = undefined;
+
+    const { getByTestId, getByText } = render(
+      <PersonWidget person={resident} />
+    );
+
+    const widgetAddress = screen.queryByTestId('resident-last-address');
+    expect(widgetAddress).not.toBeInTheDocument();
   });
 
   it('should call the setOpen callback with the id of the selected resident if the widget is not open', () => {

--- a/components/PersonWidget/PersonWidget.tsx
+++ b/components/PersonWidget/PersonWidget.tsx
@@ -31,10 +31,14 @@ const PersonWidget = ({
 }: Props): React.ReactElement => {
   const dateOfBirth = prettyDate(person?.dateOfBirth ?? '');
   const displayAddress = person?.address;
-  const lastAddress =
+  const mostRecentAddressAdded =
     'id' in person
       ? person?.addresses?.[person?.addresses.length - 1]
       : person.address;
+
+  const lastAddress =
+    person.address === undefined ? person.address : mostRecentAddressAdded;
+
   if (grouped)
     return (
       <aside className={s.aside}>

--- a/components/PersonWidget/PersonWidget.tsx
+++ b/components/PersonWidget/PersonWidget.tsx
@@ -31,13 +31,10 @@ const PersonWidget = ({
 }: Props): React.ReactElement => {
   const dateOfBirth = prettyDate(person?.dateOfBirth ?? '');
   const displayAddress = person?.address;
-  const mostRecentAddressAdded =
-    'id' in person
+  const lastAddress =
+    person.address !== undefined && 'id' in person
       ? person?.addresses?.[person?.addresses.length - 1]
       : person.address;
-
-  const lastAddress =
-    person.address === undefined ? person.address : mostRecentAddressAdded;
 
   if (grouped)
     return (

--- a/components/PersonWidget/PersonWidget.tsx
+++ b/components/PersonWidget/PersonWidget.tsx
@@ -32,8 +32,8 @@ const PersonWidget = ({
   const dateOfBirth = prettyDate(person?.dateOfBirth ?? '');
   const displayAddress = person?.address;
   const lastAddress =
-    person.address !== undefined && 'id' in person
-      ? person?.addresses?.[person?.addresses.length - 1]
+    'id' in person
+      ? person?.addresses?.find((address) => address.isDisplayAddress === 'Y')
       : person.address;
 
   if (grouped)

--- a/components/PersonWidget/PersonWidget.tsx
+++ b/components/PersonWidget/PersonWidget.tsx
@@ -31,7 +31,7 @@ const PersonWidget = ({
 }: Props): React.ReactElement => {
   const dateOfBirth = prettyDate(person?.dateOfBirth ?? '');
   const displayAddress = person?.address;
-  const lastAddress =
+  const firstDisplayAddressMatch =
     'id' in person
       ? person?.addresses?.find((address) => address.isDisplayAddress === 'Y')
       : person.address;
@@ -70,18 +70,18 @@ const PersonWidget = ({
               {displayAddress?.postcode}
             </p>
           )}
-          {lastAddress && (
+          {firstDisplayAddressMatch && (
             <p
               className={`lbh-body-s ${s.paragraph}`}
               data-testid="resident-last-address"
             >
-              {'address' in lastAddress
-                ? lastAddress.address
-                : lastAddress.addressLines}
+              {'address' in firstDisplayAddressMatch
+                ? firstDisplayAddressMatch.address
+                : firstDisplayAddressMatch.addressLines}
               <br />
-              {'postcode' in lastAddress
-                ? lastAddress.postcode
-                : lastAddress.postCode}
+              {'postcode' in firstDisplayAddressMatch
+                ? firstDisplayAddressMatch.postcode
+                : firstDisplayAddressMatch.postCode}
             </p>
           )}
 
@@ -119,18 +119,18 @@ const PersonWidget = ({
           {displayAddress?.postcode}
         </p>
       )}
-      {lastAddress && (
+      {firstDisplayAddressMatch && (
         <p
           className={`lbh-body-s ${s.paragraph}`}
           data-testid="resident-last-address"
         >
-          {'address' in lastAddress
-            ? lastAddress.address
-            : lastAddress.addressLines}
+          {'address' in firstDisplayAddressMatch
+            ? firstDisplayAddressMatch.address
+            : firstDisplayAddressMatch.addressLines}
           <br />
-          {'postcode' in lastAddress
-            ? lastAddress.postcode
-            : lastAddress.postCode}
+          {'postcode' in firstDisplayAddressMatch
+            ? firstDisplayAddressMatch.postcode
+            : firstDisplayAddressMatch.postCode}
         </p>
       )}
     </aside>

--- a/types.ts
+++ b/types.ts
@@ -174,6 +174,7 @@ export interface Resident {
     addressLines: string;
     postCode: string;
     uprn?: string;
+    isDisplayAddress?: string;
   }[];
   address?: {
     address: string;


### PR DESCRIPTION
After fixing the initial issue in #641, there was still a case where if the person was updated to have no address (i.e they had an address before but were later updated to have no address in the UI), the widget would still display the most recently added address.

From investigating the data we use in the widget, the response is from the GET all residents endpoint and we filter by the person. The data returned is different as this response would also return an array of all the addresses associated with the person. But to determine the current address, the addresses in the list have a flag associated with them that tells us if this is the display address i.e current active address or if it is an old address.

This changes the logic to retrieve the address that has the flag set to true which would return the person's current address in the widget which we would also see in the person details page.

If the person is updated to have no address, then none of the addresses returned would have the flag set to true, which would return no address in the widget as well.