### PR TITLE
Fix: Update endpoint call to request for in-progress submissions created two weeks from today

### DIFF
--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -23,6 +23,12 @@ const AWS_KEY = process.env.AWS_KEY;
 
 describe('getInProgressSubmissions', () => {
   it('should return a list of in-progress submissions', async () => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() =>
+        new Date('2021-07-25T00:00:00.000Z').valueOf()
+      );
+
     mockedAxios.get.mockResolvedValue({
       data: [
         { submissionId: '123', formAnswers: {} },
@@ -31,7 +37,7 @@ describe('getInProgressSubmissions', () => {
     });
     const data = await getInProgressSubmissions();
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      `${ENDPOINT_API}/submissions?submissionStates=in_progress`,
+      `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=4000&createdAfter=2021-07-11T00:00:00.000Z`,
       { headers: { 'x-api-key': AWS_KEY } }
     );
     expect(data).toEqual([

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -25,8 +25,10 @@ const headersWithKey = {
 export const getInProgressSubmissions = async (
   ageContext?: AgeContext
 ): Promise<Submission[]> => {
+  const dateTwoWeeksAgo = new Date(Date.now());
+  dateTwoWeeksAgo.setDate(dateTwoWeeksAgo.getDate() - 14);
   const { data } = await axios.get(
-    `${ENDPOINT_API}/submissions?submissionStates=in_progress`,
+    `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=4000&createdAfter=${dateTwoWeeksAgo.toISOString()}`,
     {
       headers: headersWithKey,
     }


### PR DESCRIPTION
We seem to be hitting a limit on the size of the response from the API, this should limit the amount to submission created in the last two weeks as a temp fix.