### PR TITLE
Fix(SCT-983): Title handling

### DIFF
--- a/components/NewPersonView/EventLink.spec.tsx
+++ b/components/NewPersonView/EventLink.spec.tsx
@@ -7,6 +7,8 @@ const mockFlexibleForm = {
   recordId: 'abcd1234',
   formName: 'child-case-note',
   personId: 123,
+  formType: 'flexible-form',
+  title: 'Test title',
 } as Case;
 
 const mockGoogleForm = {
@@ -19,9 +21,9 @@ const mockGoogleForm = {
 describe('EventLink', () => {
   it('correctly handles a flexible form', () => {
     render(<EventLink event={mockFlexibleForm} />);
-    expect((screen.getByText('Case note') as HTMLLinkElement).href).toContain(
-      `/people/123/submissions/abcd1234`
-    );
+    expect(
+      (screen.getByText('Case note - Test title') as HTMLLinkElement).href
+    ).toContain(`/people/123/submissions/abcd1234`);
   });
 
   it('correctly handles a google/external form', () => {

--- a/components/NewPersonView/EventLink.tsx
+++ b/components/NewPersonView/EventLink.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
 import { Case } from 'types';
-import forms from 'data/flexibleForms';
 import { generateInternalLink as generateLegacyUrl } from 'utils/urls';
 import s from './index.module.scss';
 
@@ -8,18 +7,27 @@ interface Props {
   event: Case;
 }
 
+const mapIdToType: Record<string, string> = {
+  'adult-case-note': 'Case note',
+  'child-case-note': 'Case note',
+};
+
 const EventLink = ({ event }: Props): React.ReactElement => {
   // 1. handle flexible forms
-  const flexibleForm = event.formName
-    ? forms?.find((form) => form.id === event.formName)
-    : false;
 
-  if (flexibleForm)
+  if (event.formType === 'flexible-form') {
+    const formName = mapIdToType[event.formName];
+    const formTitle = event.title ? ` - ${event.title}` : '';
+
     return (
       <Link href={`/people/${event.personId}/submissions/${event.recordId}`}>
-        <a className={`lbh-link ${s.eventLink}`}>{flexibleForm.name}</a>
+        <a className={`lbh-link ${s.eventLink}`}>
+          {formName}
+          {formTitle}
+        </a>
       </Link>
     );
+  }
 
   // 2. handle external/google forms
   if (event.caseFormUrl)

--- a/types.ts
+++ b/types.ts
@@ -105,6 +105,8 @@ export interface Case {
   caseFormTimestamp?: string;
   dateOfEvent?: string;
   caseFormData: CaseFormData;
+  formType?: string;
+  title?: string;
 }
 
 export interface CaseData {


### PR DESCRIPTION
**What**  
Frontend is now using the form name for the Casenote title and correctly mapping the form id.


**Why**  


**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
