### PR TITLE
feat(SCT-983): Submit title with form answers

### DIFF
--- a/data/flexibleForms/adultCaseNote.ts
+++ b/data/flexibleForms/adultCaseNote.ts
@@ -11,6 +11,9 @@ const form: Form = {
   dateOfEvent: {
     associatedId: 'Date of event',
   },
+  title: {
+    associatedId: 'Title',
+  },
   steps: [
     {
       id: 'Case note',

--- a/data/flexibleForms/childCaseNote.ts
+++ b/data/flexibleForms/childCaseNote.ts
@@ -11,6 +11,9 @@ const form: Form = {
   dateOfEvent: {
     associatedId: 'Date of event',
   },
+  title: {
+    associatedId: 'Title',
+  },
   steps: [
     {
       id: 'Case note',

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -72,6 +72,9 @@ export interface Form {
   dateOfEvent?: {
     associatedId: string;
   };
+  title?: {
+    associatedId: string;
+  };
 }
 
 export interface RepeaterGroupAnswer {

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -164,6 +164,7 @@ describe('patchSubmissionForStep', () => {
         editedBy: 'foo',
         stepAnswers: JSON.stringify(mockAnswers),
         dateOfEvent: null,
+        title: null,
       },
       { headers: { 'x-api-key': AWS_KEY } }
     );
@@ -196,6 +197,7 @@ describe('patchSubmissionForStep', () => {
         editedBy: 'foo',
         stepAnswers: JSON.stringify(mockAnswers),
         dateOfEvent: '2021-08-03T12:00:00.000Z',
+        title: null,
       },
       { headers: { 'x-api-key': AWS_KEY } }
     );
@@ -228,6 +230,7 @@ describe('patchSubmissionForStep', () => {
         editedBy: 'foo',
         stepAnswers: JSON.stringify(mockAnswers),
         dateOfEvent: '2021-08-02T11:00:00.000Z',
+        title: null,
       },
       { headers: { 'x-api-key': AWS_KEY } }
     );
@@ -260,6 +263,7 @@ describe('patchSubmissionForStep', () => {
         editedBy: 'foo',
         stepAnswers: JSON.stringify(mockAnswers),
         dateOfEvent: null,
+        title: null,
       },
       { headers: { 'x-api-key': AWS_KEY } }
     );
@@ -292,6 +296,7 @@ describe('patchSubmissionForStep', () => {
         editedBy: 'foo',
         stepAnswers: JSON.stringify(mockAnswers),
         dateOfEvent: null,
+        title: null,
       },
       { headers: { 'x-api-key': AWS_KEY } }
     );
@@ -324,6 +329,80 @@ describe('patchSubmissionForStep', () => {
         editedBy: 'foo',
         stepAnswers: JSON.stringify(mockAnswers),
         dateOfEvent: null,
+        title: null,
+      },
+      { headers: { 'x-api-key': AWS_KEY } }
+    );
+    expect(data).toEqual({
+      submissionId: '123',
+      formAnswers: {},
+    });
+  });
+
+  it('should submit be able to submit a valid title', async () => {
+    const titleId = 'titleId';
+    const testTitle = 'testTitle';
+
+    const mockAnswers = {
+      'question one': 'answer one',
+      'question two': 'answer two',
+      [titleId]: testTitle,
+    };
+
+    mockedAxios.patch.mockResolvedValue({
+      data: { submissionId: '123', formAnswers: {} },
+    });
+    const data = await patchSubmissionForStep(
+      '123',
+      '456',
+      'foo',
+      mockAnswers,
+      undefined,
+      titleId
+    );
+    expect(mockedAxios.patch).toHaveBeenCalledWith(
+      `${ENDPOINT_API}/submissions/123/steps/456`,
+      {
+        editedBy: 'foo',
+        stepAnswers: JSON.stringify(mockAnswers),
+        dateOfEvent: null,
+        title: testTitle,
+      },
+      { headers: { 'x-api-key': AWS_KEY } }
+    );
+    expect(data).toEqual({
+      submissionId: '123',
+      formAnswers: {},
+    });
+  });
+
+  it('should submit null title if supplied ID does not match a question', async () => {
+    const titleId = 'titleId';
+    const invalidTitleId = 'invalidTitleId';
+
+    const mockAnswers = {
+      'question one': 'answer one',
+      'question two': 'answer two',
+      titleId,
+    };
+
+    mockedAxios.patch.mockResolvedValue({
+      data: { submissionId: '123', formAnswers: {} },
+    });
+    const data = await patchSubmissionForStep(
+      '123',
+      '456',
+      'foo',
+      mockAnswers,
+      invalidTitleId
+    );
+    expect(mockedAxios.patch).toHaveBeenCalledWith(
+      `${ENDPOINT_API}/submissions/123/steps/456`,
+      {
+        editedBy: 'foo',
+        stepAnswers: JSON.stringify(mockAnswers),
+        dateOfEvent: null,
+        title: null,
       },
       { headers: { 'x-api-key': AWS_KEY } }
     );

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -339,6 +339,43 @@ describe('patchSubmissionForStep', () => {
     });
   });
 
+  it('should submit null as title for empty title string', async () => {
+    const titleId = 'titleId';
+    const testTitle = '';
+
+    const mockAnswers = {
+      'question one': 'answer one',
+      'question two': 'answer two',
+      [titleId]: testTitle,
+    };
+
+    mockedAxios.patch.mockResolvedValue({
+      data: { submissionId: '123', formAnswers: {} },
+    });
+    const data = await patchSubmissionForStep(
+      '123',
+      '456',
+      'foo',
+      mockAnswers,
+      undefined,
+      titleId
+    );
+    expect(mockedAxios.patch).toHaveBeenCalledWith(
+      `${ENDPOINT_API}/submissions/123/steps/456`,
+      {
+        editedBy: 'foo',
+        stepAnswers: JSON.stringify(mockAnswers),
+        dateOfEvent: null,
+        title: null,
+      },
+      { headers: { 'x-api-key': AWS_KEY } }
+    );
+    expect(data).toEqual({
+      submissionId: '123',
+      formAnswers: {},
+    });
+  });
+
   it('should submit be able to submit a valid title', async () => {
     const titleId = 'titleId';
     const testTitle = 'testTitle';

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -133,7 +133,6 @@ export const patchSubmissionForStep = async (
 ): Promise<Submission> => {
   const dateOfEvent = getDateOfEvent(stepAnswers, dateOfEventId);
   const title = getTitle(stepAnswers, titleId);
-  console.log('🚀 ~ file: submissions.ts ~ line 136 ~ title', title);
 
   const { data } = await axios.patch(
     `${ENDPOINT_API}/submissions/${submissionId}/steps/${stepId}`,

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -109,15 +109,31 @@ const getDateOfEvent = (
   }
 };
 
+const getTitle = (
+  stepAnswers: StepAnswers,
+  titleId?: string
+): null | string => {
+  if (!titleId) return null;
+
+  const titleFromForm = stepAnswers[titleId] as string | undefined;
+
+  if (!titleFromForm) return null;
+
+  return titleFromForm;
+};
+
 /** update the answers for a given step on a submission, providing the submission id, step id, editor's name and the answers to update */
 export const patchSubmissionForStep = async (
   submissionId: string,
   stepId: string,
   editedBy: string,
   stepAnswers: StepAnswers,
-  dateOfEventId?: string
+  dateOfEventId?: string,
+  titleId?: string
 ): Promise<Submission> => {
   const dateOfEvent = getDateOfEvent(stepAnswers, dateOfEventId);
+  const title = getTitle(stepAnswers, titleId);
+  console.log('🚀 ~ file: submissions.ts ~ line 136 ~ title', title);
 
   const { data } = await axios.patch(
     `${ENDPOINT_API}/submissions/${submissionId}/steps/${stepId}`,
@@ -125,6 +141,7 @@ export const patchSubmissionForStep = async (
       stepAnswers: JSON.stringify(stepAnswers),
       editedBy,
       dateOfEvent,
+      title,
     },
     {
       headers: headersWithKey,

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -40,6 +40,7 @@ export const getUnfinishedSubmissions = async (
 /** create a new submission for the given form, resident and worker  */
 export const startSubmission = async (
   formId: string,
+  formName: string,
   socialCareId: number,
   createdBy: string
 ): Promise<Submission> => {
@@ -47,6 +48,7 @@ export const startSubmission = async (
     `${ENDPOINT_API}/submissions`,
     {
       formId,
+      formName,
       socialCareId: Number(socialCareId),
       createdBy,
     },
@@ -133,6 +135,11 @@ export const patchSubmissionForStep = async (
 ): Promise<Submission> => {
   const dateOfEvent = getDateOfEvent(stepAnswers, dateOfEventId);
   const title = getTitle(stepAnswers, titleId);
+
+  // 1. all case notes are submitting as child-case-note (even when it's an adult...)
+  // 2. form name, id, title are too heavily coupled
+  // 3. When we update the title, this breaks how the links work
+  // 4. Real data is wrong essentially, adult case notes will have been submitted with the id child-case-note
 
   const { data } = await axios.patch(
     `${ENDPOINT_API}/submissions/${submissionId}/steps/${stepId}`,

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -45,7 +45,6 @@ export const getInProgressSubmissions = async (
 /** create a new submission for the given form, resident and worker  */
 export const startSubmission = async (
   formId: string,
-  formName: string,
   socialCareId: number,
   createdBy: string
 ): Promise<Submission> => {

--- a/pages/api/case-note/[id].ts
+++ b/pages/api/case-note/[id].ts
@@ -27,10 +27,10 @@ const handler = async (
         break;
       case 'PATCH':
         {
-          const { values, dateOfEventId, title } = req.body as {
+          const { values, dateOfEventId, titleId } = req.body as {
             values: FormikValues;
             dateOfEventId?: string;
-            title?: string;
+            titleId?: string;
           };
 
           const submission = await patchSubmissionForStep(
@@ -39,7 +39,7 @@ const handler = async (
             String(user?.email),
             values,
             dateOfEventId,
-            title
+            titleId
           );
           res.json(submission);
         }

--- a/pages/api/case-note/[id].ts
+++ b/pages/api/case-note/[id].ts
@@ -27,9 +27,10 @@ const handler = async (
         break;
       case 'PATCH':
         {
-          const { values, dateOfEventId } = req.body as {
+          const { values, dateOfEventId, title } = req.body as {
             values: FormikValues;
             dateOfEventId?: string;
+            title?: string;
           };
 
           const submission = await patchSubmissionForStep(
@@ -37,7 +38,8 @@ const handler = async (
             'singleStep',
             String(user?.email),
             values,
-            dateOfEventId
+            dateOfEventId,
+            title
           );
           res.json(submission);
         }

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -179,7 +179,6 @@ export const getServerSideProps: GetServerSideProps = async ({
 
     submission = await startSubmission(
       form.id,
-      form.name,
       Number(params?.id),
       String(user?.email)
     );

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -175,7 +175,7 @@ export const getServerSideProps: GetServerSideProps = async ({
     const user = isAuthorised(req);
     const resident = await getResident(Number(params?.id), user as User);
     const form =
-      resident.ageContext === 'A' ? ADULT_CASE_NOTE : CHILD_CASE_NOTE;
+      resident.contextFlag === 'A' ? ADULT_CASE_NOTE : CHILD_CASE_NOTE;
 
     submission = await startSubmission(
       form.id,

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -65,7 +65,7 @@ const CaseNote = ({
         await axios.patch(`/api/case-note/${submissionId}`, {
           values,
           dateOfEventId: form.dateOfEvent?.associatedId,
-          title: form.title?.associatedId,
+          titleId: form.title?.associatedId,
         });
       }
     } catch (e) {

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -179,6 +179,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 
     submission = await startSubmission(
       form.id,
+      form.name,
       Number(params?.id),
       String(user?.email)
     );

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -65,6 +65,7 @@ const CaseNote = ({
         await axios.patch(`/api/case-note/${submissionId}`, {
           values,
           dateOfEventId: form.dateOfEvent?.associatedId,
+          title: form.title?.associatedId,
         });
       }
     } catch (e) {


### PR DESCRIPTION
**What**  
API can now handle title as can EventLink component for displaying. We now just need to ensure when our flexible form has a title field we capture the value and submit it to the API to store the title of the form.

**Why**  
Better display on the person timeline, instead of just saying "Case note" can say "Case note - whatever the title is"

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
