### PR TITLE
fix: datetime validate time correctly

### DIFF
--- a/lib/validators.spec.ts
+++ b/lib/validators.spec.ts
@@ -251,3 +251,143 @@ describe('generateSubmitSchema', () => {
     ).rejects.toThrowError(`You can't approve your own submissions`);
   });
 });
+
+describe('validate datetime fields correctly', () => {
+  it('when isfutureDateValid set to false the time cannot be in the future for current datetime', async () => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() =>
+        new Date('2021-08-17T11:30:00.000Z').valueOf()
+      );
+
+    const schema = generateFlexibleSchema([
+      {
+        question: 'foo',
+        id: 'one',
+        type: 'datetime',
+        isfutureDateValid: false,
+      },
+    ]);
+
+    await expect(
+      schema.validate({
+        one: ['2021-08-17', '11:31'],
+      })
+    ).rejects.toThrowError('Date cannot be in the future');
+  });
+
+  it('when isfutureDateValid set to false the time and date cannot be in the future for current datetime', async () => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() =>
+        new Date('2021-08-17T11:30:00.000Z').valueOf()
+      );
+
+    const schema = generateFlexibleSchema([
+      {
+        question: 'foo',
+        id: 'one',
+        type: 'datetime',
+        isfutureDateValid: false,
+      },
+    ]);
+
+    await expect(
+      schema.validate({
+        one: ['2021-08-18', '11:31'],
+      })
+    ).rejects.toThrowError('Date cannot be in the future');
+  });
+
+  it('when isfutureDateValid set to false the date cannot be in the future for current datetime', async () => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() =>
+        new Date('2021-08-17T11:30:00.000Z').valueOf()
+      );
+
+    const schema = generateFlexibleSchema([
+      {
+        question: 'foo',
+        id: 'one',
+        type: 'datetime',
+        isfutureDateValid: false,
+      },
+    ]);
+
+    await expect(
+      schema.validate({
+        one: ['2021-08-18', '11:30'],
+      })
+    ).rejects.toThrowError('Date cannot be in the future');
+  });
+
+  it('when isfutureDateValid set to false and date and time are in the past validation passes', async () => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() =>
+        new Date('2021-08-17T11:30:00.000Z').valueOf()
+      );
+
+    const schema = generateFlexibleSchema([
+      {
+        question: 'foo',
+        id: 'one',
+        type: 'datetime',
+        isfutureDateValid: false,
+      },
+    ]);
+
+    expect(
+      schema.validate({
+        one: ['2021-08-17', '11:29'],
+      })
+    ).resolves.toMatchObject({ one: ['2021-08-17', '11:29'] });
+  });
+
+  it('when isfutureDateValid set to false and date and time are in the present validation passes', async () => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() =>
+        new Date('2021-08-17T11:30:00.000Z').valueOf()
+      );
+
+    const schema = generateFlexibleSchema([
+      {
+        question: 'foo',
+        id: 'one',
+        type: 'datetime',
+        isfutureDateValid: false,
+      },
+    ]);
+
+    await expect(
+      schema.validate({
+        one: ['2021-08-17', '11:30'],
+      })
+    ).resolves.toMatchObject({ one: ['2021-08-17', '11:30'] });
+  });
+
+  it('when isfutureDateValid set to false the time can be in the future if the date is in the past', async () => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() =>
+        new Date('2021-08-17T11:30:00.000Z').valueOf()
+      );
+
+    const schema = generateFlexibleSchema([
+      {
+        question: 'foo',
+        id: 'one',
+        type: 'datetime',
+        isfutureDateValid: false,
+      },
+    ]);
+
+    await expect(
+      schema.validate({
+        one: ['2021-08-16', '12:30'],
+      })
+    ).resolves.toMatchObject({ one: ['2021-08-16', '12:30'] });
+  });
+});

--- a/lib/validators.spec.ts
+++ b/lib/validators.spec.ts
@@ -1,3 +1,4 @@
+import { ObjectShape, OptionalObjectSchema, TypeOfShape } from 'yup/lib/object';
 import { generateFlexibleSchema, generateSubmitSchema } from './validators';
 
 describe('generateFlexibleSchema', () => {
@@ -253,14 +254,20 @@ describe('generateSubmitSchema', () => {
 });
 
 describe('validate datetime fields correctly', () => {
-  it('when isfutureDateValid set to false the time cannot be in the future for current datetime', async () => {
+  let schema: OptionalObjectSchema<
+    ObjectShape,
+    Record<string, unknown>,
+    TypeOfShape<ObjectShape>
+  >;
+
+  beforeEach(() => {
     jest
       .spyOn(global.Date, 'now')
       .mockImplementationOnce(() =>
         new Date('2021-08-17T11:30:00.000Z').valueOf()
       );
 
-    const schema = generateFlexibleSchema([
+    schema = generateFlexibleSchema([
       {
         question: 'foo',
         id: 'one',
@@ -268,7 +275,9 @@ describe('validate datetime fields correctly', () => {
         isfutureDateValid: false,
       },
     ]);
+  });
 
+  it('when isfutureDateValid set to false the time cannot be in the future for current datetime', async () => {
     await expect(
       schema.validate({
         one: ['2021-08-17', '11:31'],
@@ -277,21 +286,6 @@ describe('validate datetime fields correctly', () => {
   });
 
   it('when isfutureDateValid set to false the time and date cannot be in the future for current datetime', async () => {
-    jest
-      .spyOn(global.Date, 'now')
-      .mockImplementationOnce(() =>
-        new Date('2021-08-17T11:30:00.000Z').valueOf()
-      );
-
-    const schema = generateFlexibleSchema([
-      {
-        question: 'foo',
-        id: 'one',
-        type: 'datetime',
-        isfutureDateValid: false,
-      },
-    ]);
-
     await expect(
       schema.validate({
         one: ['2021-08-18', '11:31'],
@@ -300,21 +294,6 @@ describe('validate datetime fields correctly', () => {
   });
 
   it('when isfutureDateValid set to false the date cannot be in the future for current datetime', async () => {
-    jest
-      .spyOn(global.Date, 'now')
-      .mockImplementationOnce(() =>
-        new Date('2021-08-17T11:30:00.000Z').valueOf()
-      );
-
-    const schema = generateFlexibleSchema([
-      {
-        question: 'foo',
-        id: 'one',
-        type: 'datetime',
-        isfutureDateValid: false,
-      },
-    ]);
-
     await expect(
       schema.validate({
         one: ['2021-08-18', '11:30'],
@@ -323,21 +302,6 @@ describe('validate datetime fields correctly', () => {
   });
 
   it('when isfutureDateValid set to false and date and time are in the past validation passes', async () => {
-    jest
-      .spyOn(global.Date, 'now')
-      .mockImplementationOnce(() =>
-        new Date('2021-08-17T11:30:00.000Z').valueOf()
-      );
-
-    const schema = generateFlexibleSchema([
-      {
-        question: 'foo',
-        id: 'one',
-        type: 'datetime',
-        isfutureDateValid: false,
-      },
-    ]);
-
     expect(
       schema.validate({
         one: ['2021-08-17', '11:29'],
@@ -346,21 +310,6 @@ describe('validate datetime fields correctly', () => {
   });
 
   it('when isfutureDateValid set to false and date and time are in the present validation passes', async () => {
-    jest
-      .spyOn(global.Date, 'now')
-      .mockImplementationOnce(() =>
-        new Date('2021-08-17T11:30:00.000Z').valueOf()
-      );
-
-    const schema = generateFlexibleSchema([
-      {
-        question: 'foo',
-        id: 'one',
-        type: 'datetime',
-        isfutureDateValid: false,
-      },
-    ]);
-
     await expect(
       schema.validate({
         one: ['2021-08-17', '11:30'],
@@ -369,21 +318,6 @@ describe('validate datetime fields correctly', () => {
   });
 
   it('when isfutureDateValid set to false the time can be in the future if the date is in the past', async () => {
-    jest
-      .spyOn(global.Date, 'now')
-      .mockImplementationOnce(() =>
-        new Date('2021-08-17T11:30:00.000Z').valueOf()
-      );
-
-    const schema = generateFlexibleSchema([
-      {
-        question: 'foo',
-        id: 'one',
-        type: 'datetime',
-        isfutureDateValid: false,
-      },
-    ]);
-
     await expect(
       schema.validate({
         one: ['2021-08-16', '12:30'],

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -2,7 +2,6 @@ import * as Yup from 'yup';
 import { Answer, Field } from 'data/flexibleForms/forms.types';
 import { ObjectShape, OptionalObjectSchema, TypeOfShape } from 'yup/lib/object';
 import { getTotalHours } from './utils';
-import { format } from 'date-fns';
 
 export const startSchema = Yup.object().shape({
   socialCareId: Yup.number()
@@ -104,6 +103,9 @@ export const generateFlexibleSchema = (
       shape[field.id] = Yup.object();
     } else if (field.type === 'datetime' && field.isfutureDateValid === false) {
       //for those cases that don't allow dates in the future
+
+      let dateTime: Date;
+
       shape[field.id] = Yup.array().of(
         Yup.string().test(
           'Validate date is present or past',
@@ -115,21 +117,19 @@ export const generateFlexibleSchema = (
             const timeRegex = /[0-9]{2}:[0-9]{2}/;
 
             if (dateRegex.test(dateValue)) {
-              const inputDate = new Date(dateValue);
+              dateTime = new Date(dateValue);
 
-              return inputDate <= new Date();
+              return true;
             }
 
             if (timeRegex.test(dateValue)) {
-              const dateWithInputTime = new Date();
-
               const hours = Number(dateValue.slice(0, 2));
               const minutes = Number(dateValue.slice(3, 5));
 
-              dateWithInputTime.setHours(hours);
-              dateWithInputTime.setMinutes(minutes);
+              dateTime.setHours(hours);
+              dateTime.setMinutes(minutes);
 
-              return dateWithInputTime <= new Date();
+              return dateTime <= new Date(Date.now());
             }
 
             return false;

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -104,37 +104,28 @@ export const generateFlexibleSchema = (
     } else if (field.type === 'datetime' && field.isfutureDateValid === false) {
       //for those cases that don't allow dates in the future
 
-      let dateTime: Date;
+      shape[field.id] = Yup.array().test(
+        'Validate date is present or past',
+        'Date cannot be in the future',
+        (dateValue) => {
+          if (dateValue?.length !== 2) return false;
 
-      shape[field.id] = Yup.array().of(
-        Yup.string().test(
-          'Validate date is present or past',
-          'Date cannot be in the future',
-          (dateValue) => {
-            if (!dateValue) return false;
+          const dateTimeFromForm: [string, string] = Array.from(dateValue) as [
+            string,
+            string
+          ];
 
-            const dateRegex = /[0-9]{4}-[0-9]{2}-[0-9]{2}/;
-            const timeRegex = /[0-9]{2}:[0-9]{2}/;
+          const dateTimeToValidate = new Date(dateTimeFromForm[0]);
+          const timeFromForm = dateTimeFromForm[1];
 
-            if (dateRegex.test(dateValue)) {
-              dateTime = new Date(dateValue);
+          const hours = Number(timeFromForm.slice(0, 2));
+          const minutes = Number(timeFromForm.slice(3, 5));
 
-              return true;
-            }
+          dateTimeToValidate.setHours(hours);
+          dateTimeToValidate.setMinutes(minutes);
 
-            if (timeRegex.test(dateValue)) {
-              const hours = Number(dateValue.slice(0, 2));
-              const minutes = Number(dateValue.slice(3, 5));
-
-              dateTime.setHours(hours);
-              dateTime.setMinutes(minutes);
-
-              return dateTime <= new Date(Date.now());
-            }
-
-            return false;
-          }
-        )
+          return dateTimeToValidate <= new Date(Date.now());
+        }
       );
     } else if (
       field.type === 'checkboxes' ||


### PR DESCRIPTION
**What**  
Update validation for datetimes that must be in the past, can accept a future time if date is past.

**Why**  
To allow for visits/casenotes to record datetimes properly!

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
