### PR TITLE
fix(SCT-1082): further prune in progress submission response

### DIFF
--- a/components/ApprovalWidget/ApprovalWidget.spec.tsx
+++ b/components/ApprovalWidget/ApprovalWidget.spec.tsx
@@ -2,6 +2,7 @@ import ApprovalWidget from './ApprovalWidget';
 import { render, screen } from '@testing-library/react';
 import { mockSubmission } from 'factories/submissions';
 import { mockedUser } from 'factories/users';
+import { SubmissionState } from 'data/flexibleForms/forms.types';
 
 jest.mock('axios');
 
@@ -22,7 +23,7 @@ describe('ApprovalWidget', () => {
         }}
         submission={{
           ...mockSubmission,
-          submissionState: 'Submitted',
+          submissionState: SubmissionState.Submitted,
         }}
       />
     );
@@ -39,7 +40,7 @@ describe('ApprovalWidget', () => {
         user={mockedUser}
         submission={{
           ...mockSubmission,
-          submissionState: 'Submitted',
+          submissionState: SubmissionState.Submitted,
         }}
       />
     );

--- a/components/ApprovalWidget/PanelApprovalWidget.spec.tsx
+++ b/components/ApprovalWidget/PanelApprovalWidget.spec.tsx
@@ -2,6 +2,7 @@ import PanelApprovalWidget from './PanelApprovalWidget';
 import { render, screen } from '@testing-library/react';
 import { mockSubmission } from 'factories/submissions';
 import { mockedUser } from 'factories/users';
+import { SubmissionState } from 'data/flexibleForms/forms.types';
 
 jest.mock('axios');
 
@@ -24,7 +25,7 @@ describe('PanelApprovalWidget', () => {
         }}
         submission={{
           ...mockSubmission,
-          submissionState: 'Approved',
+          submissionState: SubmissionState.Approved,
         }}
       />
     );
@@ -41,7 +42,7 @@ describe('PanelApprovalWidget', () => {
         user={mockedUser}
         submission={{
           ...mockSubmission,
-          submissionState: 'Approved',
+          submissionState: SubmissionState.Approved,
         }}
       />
     );

--- a/components/NewPersonView/PersonTimeline.tsx
+++ b/components/NewPersonView/PersonTimeline.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { formatDistanceToNow } from 'date-fns';
 import { Case } from 'types';
 import s from './index.module.scss';
-import { Submission } from 'data/flexibleForms/forms.types';
+import { InProgressSubmission } from 'data/flexibleForms/forms.types';
 import UnfinishedSubmissionsEvent from './UnfinishedSubmissions';
 import { normaliseDateToISO } from 'utils/date';
 import Event from './Event';
@@ -24,7 +24,7 @@ const safelyFormatDistanceToNow = (rawDate: string): string => {
 
 interface Props {
   events: Case[];
-  unfinishedSubmissions?: Submission[];
+  unfinishedSubmissions?: InProgressSubmission[];
   size: number;
   setSize: (size: number) => void;
   onLastPage: boolean;

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -1,10 +1,10 @@
 import s from './index.module.scss';
-import { Submission } from 'data/flexibleForms/forms.types';
+import { InProgressSubmission } from 'data/flexibleForms/forms.types';
 import Link from 'next/link';
 import { generateSubmissionUrl } from 'lib/submissions';
 
 interface SubProps {
-  sub: Submission;
+  sub: InProgressSubmission;
 }
 
 const Sub = ({ sub }: SubProps): React.ReactElement => {
@@ -30,7 +30,7 @@ const Sub = ({ sub }: SubProps): React.ReactElement => {
 };
 
 interface Props {
-  submissions: Submission[];
+  submissions: InProgressSubmission[];
 }
 
 const UnfinishedSubmissionsEvent = ({

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -8,7 +8,7 @@ interface SubProps {
 }
 
 const Sub = ({ sub }: SubProps): React.ReactElement => {
-  const completedSteps = Object.keys(sub.formAnswers).length;
+  const completedSteps = sub.completedSteps;
   const totalSteps = sub.form?.steps?.length;
 
   return (

--- a/components/RevisionTimeline/MiniRevisionTimeline.tsx
+++ b/components/RevisionTimeline/MiniRevisionTimeline.tsx
@@ -1,3 +1,4 @@
+import Spinner from 'components/Spinner/Spinner';
 import { InProgressSubmission } from 'data/flexibleForms/forms.types';
 import { format } from 'date-fns';
 import { useSubmission } from 'utils/api/submissions';
@@ -20,7 +21,12 @@ const RevisionTimeline = ({
   const revisions = Array.from(submission?.editHistory ?? [])
     .reverse()
     .slice(0, 3);
-
+  if (error) {
+    return <p>Error fetching this sumbission edit history</p>;
+  }
+  if (isValidating) {
+    return <Spinner />;
+  }
   return (
     <ol className={`lbh-timeline ${s.timeline}`}>
       {revisions.map((revision, i) => (

--- a/components/RevisionTimeline/MiniRevisionTimeline.tsx
+++ b/components/RevisionTimeline/MiniRevisionTimeline.tsx
@@ -22,7 +22,7 @@ const RevisionTimeline = ({
     .reverse()
     .slice(0, 3);
   if (error) {
-    return <p>Error fetching this sumbission edit history</p>;
+    return <p>Error fetching submission edit history</p>;
   }
   if (isValidating) {
     return <Spinner />;

--- a/components/RevisionTimeline/MiniRevisionTimeline.tsx
+++ b/components/RevisionTimeline/MiniRevisionTimeline.tsx
@@ -1,10 +1,6 @@
-import axios from 'axios';
-import {
-  InProgressSubmission,
-  Submission,
-} from 'data/flexibleForms/forms.types';
+import { InProgressSubmission } from 'data/flexibleForms/forms.types';
 import { format } from 'date-fns';
-import { useEffect, useState } from 'react';
+import { useSubmission } from 'utils/api/submissions';
 import s from './MiniRevisionTimeline.module.scss';
 
 interface Props {
@@ -14,16 +10,11 @@ interface Props {
 const RevisionTimeline = ({
   inProgressSubmission,
 }: Props): React.ReactElement | null => {
-  const [submission, setSubmission] = useState<Submission>();
-
-  useEffect(() => {
-    (async () => {
-      const { data } = await axios.get<Submission>(
-        `/api/submissions/${inProgressSubmission.submissionId}`
-      );
-      setSubmission(data);
-    })();
-  }, [inProgressSubmission.submissionId]);
+  const {
+    data: submission,
+    error,
+    isValidating,
+  } = useSubmission(inProgressSubmission.submissionId);
 
   // reverse the array so it's in reverse-chronological order and take the three most recent events
   const revisions = Array.from(submission?.editHistory ?? [])

--- a/components/RevisionTimeline/MiniRevisionTimeline.tsx
+++ b/components/RevisionTimeline/MiniRevisionTimeline.tsx
@@ -1,14 +1,34 @@
+import axios from 'axios';
+import {
+  InProgressSubmission,
+  Submission,
+} from 'data/flexibleForms/forms.types';
 import { format } from 'date-fns';
-import { Submission } from 'data/flexibleForms/forms.types';
+import { useEffect, useState } from 'react';
 import s from './MiniRevisionTimeline.module.scss';
 
 interface Props {
-  submission: Submission;
+  inProgressSubmission: InProgressSubmission;
 }
 
-const RevisionTimeline = ({ submission }: Props): React.ReactElement | null => {
+const RevisionTimeline = ({
+  inProgressSubmission,
+}: Props): React.ReactElement | null => {
+  const [submission, setSubmission] = useState<Submission>();
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await axios.get<Submission>(
+        `/api/submissions/${inProgressSubmission.submissionId}`
+      );
+      setSubmission(data);
+    })();
+  }, [inProgressSubmission.submissionId]);
+
   // reverse the array so it's in reverse-chronological order and take the three most recent events
-  const revisions = Array.from(submission.editHistory).reverse().slice(0, 3);
+  const revisions = Array.from(submission?.editHistory ?? [])
+    .reverse()
+    .slice(0, 3);
 
   return (
     <ol className={`lbh-timeline ${s.timeline}`}>

--- a/components/RevisionTimeline/MiniSubmissionTimeline.spec.tsx
+++ b/components/RevisionTimeline/MiniSubmissionTimeline.spec.tsx
@@ -11,6 +11,10 @@ import MiniRevisionTimeline from './MiniRevisionTimeline';
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
+// change mock to SWR
+// test loading state
+// test error handling
+
 describe('MiniRevisionTimeline', () => {
   it('correctly renders edits and creation', async () => {
     mockedAxios.get.mockResolvedValue({

--- a/components/RevisionTimeline/MiniSubmissionTimeline.spec.tsx
+++ b/components/RevisionTimeline/MiniSubmissionTimeline.spec.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import axios from 'axios';
 import { Revision, Submission } from 'data/flexibleForms/forms.types';
 import {
   mockInProgressSubmission,
@@ -7,18 +6,27 @@ import {
 } from 'factories/submissions';
 import { mockedWorker } from 'factories/workers';
 import MiniRevisionTimeline from './MiniRevisionTimeline';
+import * as submissionHooks from 'utils/api/submissions';
+import { SWRResponse } from 'swr';
+import { ErrorAPI } from 'types';
 
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
-
-// change mock to SWR
-// test loading state
-// test error handling
+jest.mock('utils/api/submissions');
+jest.mock('components/Spinner/Spinner', () => () => 'MockedSpinner');
 
 describe('MiniRevisionTimeline', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('correctly renders edits and creation', async () => {
-    mockedAxios.get.mockResolvedValue({
-      data: mockSubmission,
+    jest.spyOn(submissionHooks, 'useSubmission').mockImplementation(() => {
+      const response = {
+        data: mockSubmission,
+        error: undefined,
+        isValidating: false,
+      } as SWRResponse<Submission, ErrorAPI>;
+
+      return response;
     });
 
     render(
@@ -56,8 +64,14 @@ describe('MiniRevisionTimeline', () => {
     ];
     mockSubmissionClone.editHistory.push(...appendedEdits);
 
-    mockedAxios.get.mockResolvedValue({
-      data: mockSubmissionClone,
+    jest.spyOn(submissionHooks, 'useSubmission').mockImplementation(() => {
+      const response = {
+        data: mockSubmissionClone,
+        error: undefined,
+        isValidating: false,
+      } as SWRResponse<Submission, ErrorAPI>;
+
+      return response;
     });
 
     render(
@@ -66,6 +80,54 @@ describe('MiniRevisionTimeline', () => {
 
     await waitFor(() => {
       expect(screen.getAllByRole('listitem').length).toBe(3);
+    });
+  });
+
+  it('shows an error message when useSubmission returns an error', async () => {
+    jest.spyOn(submissionHooks, 'useSubmission').mockImplementation(() => {
+      const response = {
+        data: mockSubmission,
+        error: {} as ErrorAPI,
+        isValidating: false,
+      } as SWRResponse<Submission, ErrorAPI>;
+
+      return response;
+    });
+
+    render(
+      <MiniRevisionTimeline inProgressSubmission={mockInProgressSubmission} />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Error fetching submission edit history', {
+          exact: false,
+        })
+      );
+    });
+  });
+
+  it('shows a loading spinner (mocked) when useSubmission is validating', async () => {
+    jest.spyOn(submissionHooks, 'useSubmission').mockImplementation(() => {
+      const response = {
+        data: mockSubmission,
+        error: undefined,
+        isValidating: true,
+      } as SWRResponse<Submission, ErrorAPI>;
+
+      return response;
+    });
+
+    render(
+      <MiniRevisionTimeline inProgressSubmission={mockInProgressSubmission} />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('MockedSpinner', {
+          exact: false,
+        })
+      );
     });
   });
 });

--- a/components/SubmissionsTable/SubmissionDetailDialog.spec.tsx
+++ b/components/SubmissionsTable/SubmissionDetailDialog.spec.tsx
@@ -14,8 +14,9 @@ describe('SubmissionDetailDialog', () => {
         url="/foo"
       />
     );
+
     expect(screen.getAllByRole('heading').length).toBe(1);
-    expect(screen.getAllByRole('list').length).toBe(3);
+    expect(screen.getAllByRole('list').length).toBe(2);
     expect(screen.getAllByRole('button').length).toBe(2);
   });
 
@@ -30,7 +31,7 @@ describe('SubmissionDetailDialog', () => {
     );
 
     expect(screen.getByText('Editors'));
-    expect(screen.getAllByRole('list').length).toBe(3);
+    expect(screen.getAllByRole('list').length).toBe(2);
   });
 
   it('fires the dismiss handler', () => {

--- a/components/SubmissionsTable/SubmissionDetailDialog.spec.tsx
+++ b/components/SubmissionsTable/SubmissionDetailDialog.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { mockSubmission } from 'factories/submissions';
+import { mockInProgressSubmission } from 'factories/submissions';
 import SubmissionDetailDialog from './SubmissionDetailDialog';
 
 const mockHandler = jest.fn();
@@ -8,7 +8,7 @@ describe('SubmissionDetailDialog', () => {
   it('renders the right basic information and controls', () => {
     render(
       <SubmissionDetailDialog
-        submission={mockSubmission}
+        submission={mockInProgressSubmission}
         isOpen={true}
         onDismiss={jest.fn()}
         url="/foo"
@@ -22,7 +22,7 @@ describe('SubmissionDetailDialog', () => {
   it('correctly shows a list of editors', () => {
     render(
       <SubmissionDetailDialog
-        submission={mockSubmission}
+        submission={mockInProgressSubmission}
         isOpen={true}
         onDismiss={jest.fn()}
         url="/foo"

--- a/components/SubmissionsTable/SubmissionDetailDialog.spec.tsx
+++ b/components/SubmissionsTable/SubmissionDetailDialog.spec.tsx
@@ -14,7 +14,7 @@ describe('SubmissionDetailDialog', () => {
         url="/foo"
       />
     );
-    expect(screen.getAllByRole('heading').length).toBe(2);
+    expect(screen.getAllByRole('heading').length).toBe(1);
     expect(screen.getAllByRole('list').length).toBe(3);
     expect(screen.getAllByRole('button').length).toBe(2);
   });
@@ -31,13 +31,12 @@ describe('SubmissionDetailDialog', () => {
 
     expect(screen.getByText('Editors'));
     expect(screen.getAllByRole('list').length).toBe(3);
-    expect(screen.getAllByText('foo.bar@hackney.gov.uk').length).toBe(2);
   });
 
   it('fires the dismiss handler', () => {
     render(
       <SubmissionDetailDialog
-        submission={mockSubmission}
+        submission={mockInProgressSubmission}
         isOpen={true}
         onDismiss={mockHandler}
         url="/foo"

--- a/components/SubmissionsTable/SubmissionDetailDialog.tsx
+++ b/components/SubmissionsTable/SubmissionDetailDialog.tsx
@@ -27,9 +27,6 @@ const SubmissionDetailDialog = ({
   completion,
   url,
 }: Props): React.ReactElement => {
-  const lastEdited =
-    submission.editHistory[submission.editHistory.length - 1]?.editTime;
-
   const editors = submission.workers.map((worker) => worker.email);
 
   return (
@@ -84,7 +81,7 @@ const SubmissionDetailDialog = ({
         <div className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">Last edited</dt>
           <dd className="govuk-summary-list__value">
-            {format(new Date(lastEdited), 'd MMM yyyy K.mm aaa')}
+            {format(new Date(submission.lastEdited), 'd MMM yyyy K.mm aaa')}
           </dd>
         </div>
 

--- a/components/SubmissionsTable/SubmissionDetailDialog.tsx
+++ b/components/SubmissionsTable/SubmissionDetailDialog.tsx
@@ -101,7 +101,7 @@ const SubmissionDetailDialog = ({
         <div className="govuk-summary-list__row govuk-summary-list__row--no-border">
           <dt className="govuk-summary-list__key">Recent revisions</dt>
           <dd className="govuk-summary-list__value">
-            <MiniRevisionTimeline submission={submission} />
+            <MiniRevisionTimeline inProgressSubmission={submission} />
           </dd>
         </div>
       </dl>

--- a/components/SubmissionsTable/SubmissionDetailDialog.tsx
+++ b/components/SubmissionsTable/SubmissionDetailDialog.tsx
@@ -1,13 +1,13 @@
 import DiscardDialog from './DiscardDialog';
 import MiniRevisionTimeline from 'components/RevisionTimeline/MiniRevisionTimeline';
 import Dialog from 'components/Dialog/Dialog';
-import { Form, Submission } from 'data/flexibleForms/forms.types';
+import { Form, InProgressSubmission } from 'data/flexibleForms/forms.types';
 import { format } from 'date-fns';
 import Link from 'next/link';
 import s from './index.module.scss';
 
 interface Props {
-  submission: Submission;
+  submission: InProgressSubmission;
   isOpen: boolean;
   onDismiss: () => void;
   form?: Form;

--- a/components/SubmissionsTable/SubmissionPanel.spec.tsx
+++ b/components/SubmissionsTable/SubmissionPanel.spec.tsx
@@ -1,10 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { mockSubmission } from 'factories/submissions';
+import { mockInProgressSubmission } from 'factories/submissions';
 import SubmissionPanel from './SubmissionPanel';
 
 describe('SubmissionPanel', () => {
   it('renders the right basic information and controls', () => {
-    render(<SubmissionPanel submission={mockSubmission} />);
+    render(<SubmissionPanel submission={mockInProgressSubmission} />);
     expect(screen.queryAllByText('Started').length).toBe(0);
     expect(screen.queryAllByText('Progress').length).toBe(0);
     expect(screen.getByText('Details'));
@@ -13,7 +13,7 @@ describe('SubmissionPanel', () => {
   });
 
   it('can launch and close the dialog', () => {
-    render(<SubmissionPanel submission={mockSubmission} />);
+    render(<SubmissionPanel submission={mockInProgressSubmission} />);
     fireEvent.click(screen.getByText('Details'));
     expect(screen.getByText('Unknown form details'));
     expect(screen.getByRole('dialog'));

--- a/components/SubmissionsTable/SubmissionPanel.tsx
+++ b/components/SubmissionsTable/SubmissionPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { Submission } from 'data/flexibleForms/forms.types';
+import { InProgressSubmission } from 'data/flexibleForms/forms.types';
 import Link from 'next/link';
 import { format } from 'date-fns';
 import s from './index.module.scss';
@@ -7,18 +7,16 @@ import SubmissionDetailDialog from './SubmissionDetailDialog';
 import { generateSubmissionUrl } from 'lib/submissions';
 
 interface Props {
-  submission: Submission;
+  submission: InProgressSubmission;
 }
 
 const SubmissionPanel = ({ submission }: Props): React.ReactElement | null => {
   const [open, setOpen] = useState<boolean>(false);
 
   const form = submission.form;
-
-  const completedSteps = Object.keys(submission.formAnswers).length;
   const totalSteps = form?.steps?.length;
   const completion =
-    Math.round((completedSteps / Number(totalSteps)) * 100) || 0;
+    Math.round((submission.completedSteps / Number(totalSteps)) * 100) || 0;
 
   const url = useMemo(() => generateSubmissionUrl(submission), [submission]);
 
@@ -72,7 +70,7 @@ const SubmissionPanel = ({ submission }: Props): React.ReactElement | null => {
           onDismiss={() => setOpen(false)}
           submission={submission}
           form={form}
-          completedSteps={completedSteps}
+          completedSteps={submission.completedSteps}
           totalSteps={totalSteps}
           completion={completion}
           url={url}

--- a/components/SubmissionsTable/SubmissionPanel.tsx
+++ b/components/SubmissionsTable/SubmissionPanel.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 const SubmissionPanel = ({ submission }: Props): React.ReactElement | null => {
-  const [open, setOpen] = useState<boolean>(false);
+  const [open, setOpen] = useState(false);
 
   const form = submission.form;
   const totalSteps = form?.steps?.length;

--- a/components/SubmissionsTable/index.tsx
+++ b/components/SubmissionsTable/index.tsx
@@ -86,14 +86,12 @@ export const SubmissionsTable = ({
 
       <ul className={`lbh-list ${s.list}`}>
         {results?.length > 0 ? (
-          results
-            .slice(0, 20)
-            .map((submission) => (
-              <SubmissionRow
-                submission={submission}
-                key={submission.submissionId}
-              />
-            ))
+          results.map((submission) => (
+            <SubmissionRow
+              submission={submission}
+              key={submission.submissionId}
+            />
+          ))
         ) : (
           <p>No results to show.</p>
         )}

--- a/components/SubmissionsTable/index.tsx
+++ b/components/SubmissionsTable/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { Submission } from 'data/flexibleForms/forms.types';
+import { InProgressSubmission } from 'data/flexibleForms/forms.types';
 import SubmissionRow from './SubmissionPanel';
 import { useAuth } from 'components/UserContext/UserContext';
 import s from './index.module.scss';
@@ -7,10 +7,10 @@ import st from 'components/Tabs/Tabs.module.scss';
 import Tab from './Tab';
 import SearchBox from './SearchBox';
 import useSearch from 'hooks/useSearch';
-import forms from 'data/flexibleForms';
+import { mapFormIdToForm } from 'data/flexibleForms/mapFormIdToForm';
 
 interface Props {
-  submissions: Submission[];
+  submissions: InProgressSubmission[];
 }
 
 export const SubmissionsTable = ({
@@ -27,7 +27,7 @@ export const SubmissionsTable = ({
         // augment each one with its form
         .map((submission) => ({
           ...submission,
-          form: forms.find((form) => form.id === submission.formId),
+          form: mapFormIdToForm[submission.formId],
         }))
         .filter((submission) => {
           // hide any restricted records unless the user has permission to see them
@@ -38,9 +38,6 @@ export const SubmissionsTable = ({
             )
           )
             return false;
-
-          // hide discarded submissions
-          if (submission.submissionState === 'Discarded') return false;
 
           // Otherwise, this record is good to show
           return true;

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -111,6 +111,14 @@ export type InProgressSubmission = Omit<
   'formAnswers' | 'editHistory'
 >;
 
+enum SubmissionState {
+  InProgress = 'In progress',
+  Approved = 'Approved',
+  Discarded = 'Discarded',
+  Submitted = 'Submitted',
+  PanelApproved = 'Panel Approved',
+}
+
 export interface Submission {
   submissionId: string;
   formId: string;
@@ -126,12 +134,7 @@ export interface Submission {
   residents: Resident[];
   workers: Worker[];
   editHistory: Revision[];
-  submissionState:
-    | 'In progress'
-    | 'Approved'
-    | 'Discarded'
-    | 'Submitted'
-    | 'Panel Approved';
+  submissionState: SubmissionState;
   formAnswers: FlexibleAnswers;
   tags?: string[];
   lastEdited: string;

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -106,6 +106,11 @@ export interface FlexibleAnswers {
   [key: string]: StepAnswers;
 }
 
+export type InProgressSubmission = Omit<
+  Submission,
+  'formAnswers' | 'editHistory'
+>;
+
 export interface Submission {
   submissionId: string;
   formId: string;
@@ -121,9 +126,16 @@ export interface Submission {
   residents: Resident[];
   workers: Worker[];
   editHistory: Revision[];
-  submissionState: 'In progress' | 'Approved' | 'Discarded' | 'Submitted';
+  submissionState:
+    | 'In progress'
+    | 'Approved'
+    | 'Discarded'
+    | 'Submitted'
+    | 'Panel Approved';
   formAnswers: FlexibleAnswers;
   tags?: string[];
+  lastEdited: string;
+  completedSteps: number;
 }
 
 export interface SubmissionWithForm extends Submission {

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -108,8 +108,22 @@ export interface FlexibleAnswers {
 
 export type InProgressSubmission = Omit<
   Submission,
-  'formAnswers' | 'editHistory'
->;
+  | 'formAnswers'
+  | 'editHistory'
+  | 'workers'
+  | 'submittedBy'
+  | 'createdBy'
+  | 'submittedBy'
+  | 'submittedAt'
+  | 'residents'
+> & {
+  workers: Pick<Worker, 'email'>[];
+  createdBy: Pick<Worker, 'email'>;
+  residents: Pick<
+    Resident,
+    'id' | 'ageContext' | 'firstName' | 'lastName' | 'restricted'
+  >[];
+};
 
 export enum SubmissionState {
   InProgress = 'In progress',

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -111,7 +111,7 @@ export type InProgressSubmission = Omit<
   'formAnswers' | 'editHistory'
 >;
 
-enum SubmissionState {
+export enum SubmissionState {
   InProgress = 'In progress',
   Approved = 'Approved',
   Discarded = 'Discarded',

--- a/data/flexibleForms/index.ts
+++ b/data/flexibleForms/index.ts
@@ -15,3 +15,13 @@ export default [
   sgAdultConcern,
   sgAdultManagerDecisionConcern,
 ];
+
+export const formAsObjects = {
+  foo,
+  review3c,
+  adultCaseNote,
+  childCaseNote,
+  faceOverview,
+  sgAdultConcern,
+  sgAdultManagerDecisionConcern,
+};

--- a/data/flexibleForms/mapFormIdToForm.ts
+++ b/data/flexibleForms/mapFormIdToForm.ts
@@ -1,0 +1,8 @@
+import { formAsObjects } from '.';
+import { Form } from './forms.types';
+
+export const mapFormIdToForm: Record<string, Form> = {
+  'adult-case-note': formAsObjects.adultCaseNote,
+  'child-case-note': formAsObjects.childCaseNote,
+  foo: formAsObjects.foo,
+};

--- a/data/flexibleForms/mapFormIdToForm.ts
+++ b/data/flexibleForms/mapFormIdToForm.ts
@@ -5,4 +5,9 @@ export const mapFormIdToForm: Record<string, Form> = {
   'adult-case-note': formAsObjects.adultCaseNote,
   'child-case-note': formAsObjects.childCaseNote,
   foo: formAsObjects.foo,
+  'review-3c': formAsObjects.review3c,
+  'FACE overview assessment': formAsObjects.faceOverview,
+  'safeguarding-adult-concern-form': formAsObjects.sgAdultConcern,
+  'Safeguarding adult manager decision on concern':
+    formAsObjects.sgAdultManagerDecisionConcern,
 };

--- a/data/flexibleForms/mapFormIdsToDisplayName.ts
+++ b/data/flexibleForms/mapFormIdsToDisplayName.ts
@@ -1,4 +1,10 @@
 export const mapIdToType: Record<string, string> = {
   'adult-case-note': 'Case note',
   'child-case-note': 'Case note',
+  foo: 'Sandbox form',
+  'review-3c': 'Review of Care and Support Plan (3C)',
+  'FACE overview assessment': 'FACE overview assessment',
+  'safeguarding-adult-concern-form': 'Safeguarding Adult Concern Form',
+  'Safeguarding adult manager decision on concern':
+    'Safeguarding adult manager decision on concern',
 };

--- a/factories/submissions.ts
+++ b/factories/submissions.ts
@@ -1,6 +1,7 @@
 import {
   InProgressSubmission,
   Submission,
+  SubmissionState,
 } from 'data/flexibleForms/forms.types';
 import { mockedResident } from 'factories/residents';
 import { mockedWorker } from 'factories/workers';
@@ -24,7 +25,7 @@ export const mockSubmission: Submission = {
       editTime: '2021-06-21T12:00:00.000Z',
     },
   ],
-  submissionState: 'In progress',
+  submissionState: SubmissionState.InProgress,
   formAnswers: {},
   lastEdited: '2021-06-21T12:00:00.000Z',
   completedSteps: 0,
@@ -43,7 +44,7 @@ export const mockInProgressSubmission: InProgressSubmission = {
   panelApprovedBy: null,
   panelApprovedAt: null,
   workers: [mockedWorker],
-  submissionState: 'In progress',
+  submissionState: SubmissionState.InProgress,
   lastEdited: '2021-06-21T12:00:00.000Z',
   completedSteps: 1,
 };

--- a/factories/submissions.ts
+++ b/factories/submissions.ts
@@ -37,8 +37,6 @@ export const mockInProgressSubmission: InProgressSubmission = {
   residents: [mockedResident],
   createdBy: mockedWorker,
   createdAt: '2021-06-21T12:00:00.000Z',
-  submittedBy: mockedWorker,
-  submittedAt: '2021-07-21T12:00:00.000Z',
   approvedBy: null,
   approvedAt: null,
   panelApprovedBy: null,

--- a/factories/submissions.ts
+++ b/factories/submissions.ts
@@ -23,4 +23,6 @@ export const mockSubmission: Submission = {
   ],
   submissionState: 'In progress',
   formAnswers: {},
+  lastEdited: '2021-06-21T12:00:00.000Z',
+  completedSteps: 0,
 };

--- a/factories/submissions.ts
+++ b/factories/submissions.ts
@@ -1,4 +1,7 @@
-import { Submission } from 'data/flexibleForms/forms.types';
+import {
+  InProgressSubmission,
+  Submission,
+} from 'data/flexibleForms/forms.types';
 import { mockedResident } from 'factories/residents';
 import { mockedWorker } from 'factories/workers';
 
@@ -25,4 +28,22 @@ export const mockSubmission: Submission = {
   formAnswers: {},
   lastEdited: '2021-06-21T12:00:00.000Z',
   completedSteps: 0,
+};
+
+export const mockInProgressSubmission: InProgressSubmission = {
+  submissionId: '123',
+  formId: 'foo',
+  residents: [mockedResident],
+  createdBy: mockedWorker,
+  createdAt: '2021-06-21T12:00:00.000Z',
+  submittedBy: mockedWorker,
+  submittedAt: '2021-07-21T12:00:00.000Z',
+  approvedBy: null,
+  approvedAt: null,
+  panelApprovedBy: null,
+  panelApprovedAt: null,
+  workers: [mockedWorker],
+  submissionState: 'In progress',
+  lastEdited: '2021-06-21T12:00:00.000Z',
+  completedSteps: 1,
 };

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -37,7 +37,7 @@ describe('getInProgressSubmissions', () => {
     });
     const data = await getInProgressSubmissions();
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=4000&createdAfter=2021-07-11T00:00:00.000Z`,
+      `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=1000`,
       { headers: { 'x-api-key': AWS_KEY } }
     );
     expect(data).toEqual([

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -6,8 +6,8 @@ import {
   InProgressSubmission,
 } from 'data/flexibleForms/forms.types';
 import { Resident, AgeContext } from 'types';
-import forms from 'data/flexibleForms';
 import parse from 'date-fns/parse';
+import { mapFormIdToForm } from 'data/flexibleForms/mapFormIdToForm';
 
 type RawSubmission = Omit<Submission, 'formAnswers'> & {
   formAnswers: {
@@ -267,10 +267,10 @@ export const returnForEdits = async (
 
 /** safely generate a submission url, handling weird cases like case notes, which use a different canonical url structure */
 export const generateSubmissionUrl = (
-  submission: Submission,
+  submission: Submission | InProgressSubmission,
   socialCareId?: number
 ): string => {
-  const form = forms.find((form) => form.id === submission.formId);
+  const form = mapFormIdToForm[submission.formId];
   if (form?.canonicalUrl) {
     return `${form.canonicalUrl(
       // use the passed in social care id, or default to the first resident on the submission

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -3,6 +3,7 @@ import {
   Submission,
   StepAnswers,
   FlexibleAnswers,
+  InProgressSubmission,
 } from 'data/flexibleForms/forms.types';
 import { Resident, AgeContext } from 'types';
 import forms from 'data/flexibleForms';
@@ -24,17 +25,15 @@ const headersWithKey = {
 /** get a list of all unfinished submissions in the current social care service context  */
 export const getInProgressSubmissions = async (
   ageContext?: AgeContext
-): Promise<Submission[]> => {
-  const dateTwoWeeksAgo = new Date(Date.now());
-  dateTwoWeeksAgo.setDate(dateTwoWeeksAgo.getDate() - 14);
-  const { data } = await axios.get(
-    `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=4000&createdAfter=${dateTwoWeeksAgo.toISOString()}`,
+): Promise<InProgressSubmission[]> => {
+  const { data } = await axios.get<InProgressSubmission[]>(
+    `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=1000`,
     {
       headers: headersWithKey,
     }
   );
   return ageContext
-    ? data.filter((submission: Submission) =>
+    ? data.filter((submission) =>
         submission.residents.some(
           (resident: Resident) => resident.ageContext === ageContext
         )

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -32,10 +32,12 @@ export const getInProgressSubmissions = async (
       headers: headersWithKey,
     }
   );
+
   return ageContext
     ? data.filter((submission) =>
         submission.residents.some(
-          (resident: Resident) => resident.ageContext === ageContext
+          (resident: Pick<Resident, 'ageContext'>) =>
+            resident.ageContext === ageContext
         )
       )
     : data;

--- a/pages/api/submissions/[id]/index.ts
+++ b/pages/api/submissions/[id]/index.ts
@@ -1,5 +1,4 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import forms from 'data/flexibleForms';
 import StatusCodes from 'http-status-codes';
 import {
   getSubmissionById,
@@ -9,6 +8,7 @@ import {
 } from 'lib/submissions';
 import { isAuthorised } from 'utils/auth';
 import { notifyApprover } from 'lib/notify';
+import { mapFormIdToForm } from 'data/flexibleForms/mapFormIdToForm';
 
 const handler = async (
   req: NextApiRequest,
@@ -56,7 +56,7 @@ const handler = async (
     case 'GET':
       {
         const submission = await getSubmissionById(id as string);
-        const form = forms.find((form) => form.id === submission.formId);
+        const form = mapFormIdToForm[submission.formId];
 
         res.json({
           ...submission,

--- a/pages/api/submissions/index.ts
+++ b/pages/api/submissions/index.ts
@@ -3,6 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import StatusCodes from 'http-status-codes';
 import { startSubmission, getInProgressSubmissions } from 'lib/submissions';
 import { isAuthorised } from 'utils/auth';
+import { mapFormIdToForm } from 'data/flexibleForms/mapFormIdToForm';
 
 const handler = async (
   req: NextApiRequest,
@@ -30,7 +31,7 @@ const handler = async (
           forms,
           submissions: submissions.map((sub) => ({
             ...sub,
-            form: forms.find((form) => form.id === sub.formId),
+            form: mapFormIdToForm[sub.formId],
           })),
         });
       } else {

--- a/pages/work-in-progress.tsx
+++ b/pages/work-in-progress.tsx
@@ -3,12 +3,12 @@ import SavedForms from 'components/SaveFormData/SaveFormData';
 import DashboardWrapper from 'components/Dashboard/DashboardWrapper';
 import { GetServerSideProps } from 'next';
 import { getInProgressSubmissions } from 'lib/submissions';
-import { Submission } from 'data/flexibleForms/forms.types';
+import { InProgressSubmission } from 'data/flexibleForms/forms.types';
 import SubmissionsTable from 'components/SubmissionsTable';
 import { isAuthorised } from 'utils/auth';
 
 interface Props {
-  submissions: Submission[];
+  submissions: InProgressSubmission[];
 }
 
 const UnfinishedSubmissions = ({ submissions }: Props): React.ReactElement => (

--- a/utils/api/submissions.spec.ts
+++ b/utils/api/submissions.spec.ts
@@ -1,4 +1,4 @@
-import { useUnfinishedSubmissions } from './submissions';
+import { useSubmission, useUnfinishedSubmissions } from './submissions';
 import * as SWR from 'swr';
 import { mockSubmission } from 'factories/submissions';
 import { mockedResident } from 'factories/residents';
@@ -35,6 +35,14 @@ describe('submissions APIs', () => {
       );
       const result = useUnfinishedSubmissions(1);
       expect(result.data?.submissions.length).toBe(1);
+    });
+  });
+
+  describe('useSubmission', () => {
+    it('should call swr', () => {
+      jest.spyOn(SWR, 'default');
+      useSubmission('foo');
+      expect(SWR.default).toHaveBeenLastCalledWith('/api/submissions/foo');
     });
   });
 });

--- a/utils/api/submissions.ts
+++ b/utils/api/submissions.ts
@@ -7,6 +7,16 @@ export type Data = {
   submissions: Submission[];
 };
 
+export const useSubmission = (
+  submissionId: string
+): SWRResponse<Submission, ErrorAPI> => {
+  const res: SWRResponse<Submission, ErrorAPI> = useSWR(
+    `/api/submissions/${submissionId}`
+  );
+
+  return res;
+};
+
 /** fetch unfinished submissions in the user's current service context, either for everyone, or by social care id */
 export const useUnfinishedSubmissions = (
   socialCareId?: number

--- a/utils/api/submissions.ts
+++ b/utils/api/submissions.ts
@@ -1,10 +1,14 @@
-import { Form, Submission } from 'data/flexibleForms/forms.types';
+import {
+  Form,
+  InProgressSubmission,
+  Submission,
+} from 'data/flexibleForms/forms.types';
 import useSWR, { SWRResponse } from 'swr';
 import type { ErrorAPI } from 'types';
 
 export type Data = {
   forms: Form[];
-  submissions: Submission[];
+  submissions: InProgressSubmission[];
 };
 
 export const useSubmission = (


### PR DESCRIPTION
**What**  

Update our interfaces for getting in progress submissions to be as minimal as absolutely possible. This in turn will allow our API to reduce the amount of information being returned.

**Why**  

These changes ensure everything will still work when the API starts returning less information by updating the relevant interfaces.

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
