### PR TITLE
feat(SCT-1076): Use query params to filter submissions server side

### DIFF
--- a/components/NewPersonView/PersonTimeline.tsx
+++ b/components/NewPersonView/PersonTimeline.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { formatDistanceToNow } from 'date-fns';
 import { Case } from 'types';
 import s from './index.module.scss';
-import { Submission } from 'data/flexibleForms/forms.types';
+import { InProgressSubmission } from 'data/flexibleForms/forms.types';
 import UnfinishedSubmissionsEvent from './UnfinishedSubmissions';
 import { normaliseDateToISO } from 'utils/date';
 import Event from './Event';
@@ -24,7 +24,7 @@ const safelyFormatDistanceToNow = (rawDate: string): string => {
 
 interface Props {
   events: Case[];
-  unfinishedSubmissions?: Submission[];
+  unfinishedSubmissions?: InProgressSubmission[];
   size: number;
   setSize: (size: number) => void;
   onLastPage: boolean;

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -1,10 +1,10 @@
 import s from './index.module.scss';
-import { Submission } from 'data/flexibleForms/forms.types';
+import { InProgressSubmission } from 'data/flexibleForms/forms.types';
 import Link from 'next/link';
 import { generateSubmissionUrl } from 'lib/submissions';
 
 interface SubProps {
-  sub: Submission;
+  sub: InProgressSubmission;
 }
 
 const Sub = ({ sub }: SubProps): React.ReactElement => {
@@ -30,7 +30,7 @@ const Sub = ({ sub }: SubProps): React.ReactElement => {
 };
 
 interface Props {
-  submissions: Submission[];
+  submissions: InProgressSubmission[];
 }
 
 const UnfinishedSubmissionsEvent = ({

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -52,6 +52,14 @@ describe('getInProgressSubmissions', () => {
       { headers: { 'x-api-key': AWS_KEY } }
     );
   });
+
+  it('only queries for submissions using the requested worker email', async () => {
+    await getInProgressSubmissions(undefined, undefined, 'foo@bar.com');
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=1000&workerEmail=foo@bar.com`,
+      { headers: { 'x-api-key': AWS_KEY } }
+    );
+  });
 });
 
 describe('startSubmission', () => {

--- a/lib/submissions.spec.ts
+++ b/lib/submissions.spec.ts
@@ -12,7 +12,6 @@ import {
   discardSubmission,
   generateSubmissionUrl,
 } from './submissions';
-import { mockedLegacyResident } from 'factories/residents';
 import { mockSubmission } from 'factories/submissions';
 
 jest.mock('axios');
@@ -46,34 +45,12 @@ describe('getInProgressSubmissions', () => {
     ]);
   });
 
-  it('only returns submissions in the requested age context', async () => {
-    mockedAxios.get.mockResolvedValue({
-      data: [
-        {
-          submissionId: '123',
-          formAnswers: {},
-          residents: [mockedLegacyResident],
-        },
-        {
-          submissionId: '456',
-          formAnswers: {},
-          residents: [
-            {
-              ...mockedLegacyResident,
-              ageContext: 'C',
-            },
-          ],
-        },
-      ],
-    });
-    const data = await getInProgressSubmissions('A');
-    expect(data).toEqual([
-      {
-        submissionId: '123',
-        formAnswers: {},
-        residents: [mockedLegacyResident],
-      },
-    ]);
+  it('only queries for submissions using the requested age context', async () => {
+    await getInProgressSubmissions('A');
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=1000&ageContext=A`,
+      { headers: { 'x-api-key': AWS_KEY } }
+    );
   });
 });
 

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -5,7 +5,7 @@ import {
   FlexibleAnswers,
   InProgressSubmission,
 } from 'data/flexibleForms/forms.types';
-import { Resident, AgeContext } from 'types';
+import { AgeContext } from 'types';
 import parse from 'date-fns/parse';
 import { mapFormIdToFormDefinition } from 'data/flexibleForms/mapFormIdsToFormDefinition';
 
@@ -26,19 +26,17 @@ const headersWithKey = {
 export const getInProgressSubmissions = async (
   ageContext?: AgeContext
 ): Promise<InProgressSubmission[]> => {
+  const ageContextQuery =
+    ageContext !== undefined ? `&ageContext=${ageContext}` : '';
+
   const { data } = await axios.get<InProgressSubmission[]>(
-    `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=1000`,
+    `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=1000${ageContextQuery}`,
     {
       headers: headersWithKey,
     }
   );
-  return ageContext
-    ? data.filter((submission) =>
-        submission.residents.some(
-          (resident: Resident) => resident.ageContext === ageContext
-        )
-      )
-    : data;
+
+  return data;
 };
 
 /** create a new submission for the given form, resident and worker  */

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -24,13 +24,16 @@ const headersWithKey = {
 
 /** get a list of all unfinished submissions in the current social care service context  */
 export const getInProgressSubmissions = async (
-  ageContext?: AgeContext
+  ageContext?: AgeContext,
+  personID?: number
 ): Promise<InProgressSubmission[]> => {
   const ageContextQuery =
     ageContext !== undefined ? `&ageContext=${ageContext}` : '';
 
+  const personIdQuery = `&personID=${personID}`;
+
   const { data } = await axios.get<InProgressSubmission[]>(
-    `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=1000${ageContextQuery}`,
+    `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=1000${ageContextQuery}${personIdQuery}`,
     {
       headers: headersWithKey,
     }

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -25,15 +25,19 @@ const headersWithKey = {
 /** get a list of all unfinished submissions in the current social care service context  */
 export const getInProgressSubmissions = async (
   ageContext?: AgeContext,
-  personID?: number
+  personID?: number,
+  workerEmail?: string
 ): Promise<InProgressSubmission[]> => {
   const ageContextQuery =
     ageContext !== undefined ? `&ageContext=${ageContext}` : '';
 
-  const personIdQuery = `&personID=${personID}`;
+  const personIdQuery = personID !== undefined ? `&personID=${personID}` : '';
+
+  const workerEmailQuery =
+    workerEmail !== undefined ? `&workerEmail=${workerEmail}` : '';
 
   const { data } = await axios.get<InProgressSubmission[]>(
-    `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=1000${ageContextQuery}${personIdQuery}`,
+    `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=1000${ageContextQuery}${personIdQuery}${workerEmailQuery}`,
     {
       headers: headersWithKey,
     }

--- a/pages/api/submissions/index.ts
+++ b/pages/api/submissions/index.ts
@@ -22,8 +22,11 @@ const handler = async (
       break;
     case 'GET':
       {
+        const { personID } = req.query;
+
         const submissions = await getInProgressSubmissions(
-          user?.permissionFlag
+          user?.permissionFlag,
+          Number(personID)
         );
         res.json(submissions);
       }

--- a/pages/api/submissions/index.ts
+++ b/pages/api/submissions/index.ts
@@ -1,9 +1,7 @@
-import forms from 'data/flexibleForms';
 import { NextApiRequest, NextApiResponse } from 'next';
 import StatusCodes from 'http-status-codes';
 import { startSubmission, getInProgressSubmissions } from 'lib/submissions';
 import { isAuthorised } from 'utils/auth';
-import { mapFormIdToFormDefinition } from 'data/flexibleForms/mapFormIdsToFormDefinition';
 
 const handler = async (
   req: NextApiRequest,
@@ -23,21 +21,11 @@ const handler = async (
       }
       break;
     case 'GET':
-      if (req.query.includeSubmissions) {
+      {
         const submissions = await getInProgressSubmissions(
           user?.permissionFlag
         );
-        res.json({
-          forms,
-          submissions: submissions.map((sub) => ({
-            ...sub,
-            form: mapFormIdToFormDefinition[sub.formId].form,
-          })),
-        });
-      } else {
-        res.json({
-          forms,
-        });
+        res.json(submissions);
       }
       break;
     default:

--- a/pages/people/[id]/index.tsx
+++ b/pages/people/[id]/index.tsx
@@ -41,7 +41,7 @@ const PersonPage = ({ person }: Props): React.ReactElement => {
           <>
             <ConditionalFeature name="person-timeline">
               <PersonTimeline
-                unfinishedSubmissions={submissionsData?.submissions}
+                unfinishedSubmissions={submissionsData || []}
                 events={events}
                 size={size}
                 setSize={setSize}

--- a/utils/api/submissions.spec.ts
+++ b/utils/api/submissions.spec.ts
@@ -9,7 +9,7 @@ describe('submissions APIs', () => {
       jest.spyOn(SWR, 'default');
       useUnfinishedSubmissions(1);
       expect(SWR.default).toHaveBeenLastCalledWith(
-        '/api/submissions?personId=1'
+        '/api/submissions?personID=1'
       );
     });
   });

--- a/utils/api/submissions.spec.ts
+++ b/utils/api/submissions.spec.ts
@@ -1,40 +1,16 @@
 import { useSubmission, useUnfinishedSubmissions } from './submissions';
 import * as SWR from 'swr';
-import { mockSubmission } from 'factories/submissions';
-import { mockedResident } from 'factories/residents';
 
 jest.mock('swr');
 
 describe('submissions APIs', () => {
   describe('useUnfinishedSubmissions', () => {
-    it('should call swr', () => {
+    it('should call swr and pass the person id as a query filter', () => {
       jest.spyOn(SWR, 'default');
-      useUnfinishedSubmissions();
-      expect(SWR.default).toHaveBeenCalled();
-    });
-
-    it('should filter submissions to the requested resident ', () => {
-      jest.spyOn(SWR, 'default').mockImplementation(
-        () =>
-          ({
-            data: {
-              submissions: [
-                mockSubmission,
-                {
-                  ...mockSubmission,
-                  residents: [
-                    {
-                      ...mockedResident,
-                      id: 2,
-                    },
-                  ],
-                },
-              ],
-            },
-          } as any)
+      useUnfinishedSubmissions(1);
+      expect(SWR.default).toHaveBeenLastCalledWith(
+        '/api/submissions?personId=1'
       );
-      const result = useUnfinishedSubmissions(1);
-      expect(result.data?.submissions.length).toBe(1);
     });
   });
 

--- a/utils/api/submissions.ts
+++ b/utils/api/submissions.ts
@@ -30,7 +30,6 @@ export const useUnfinishedSubmissions = (
   const res: SWRResponse<InProgressSubmission[], ErrorAPI> = useSWR(
     `/api/submissions${personIdQuery}`
   );
-  console.log('🚀 ~ file: submissions.ts ~ line 35 ~ res', res.data?.length);
 
   return res;
 };

--- a/utils/api/submissions.ts
+++ b/utils/api/submissions.ts
@@ -25,11 +25,12 @@ export const useSubmission = (
 export const useUnfinishedSubmissions = (
   socialCareId: number
 ): SWRResponse<InProgressSubmission[], ErrorAPI> => {
-  const personIdQuery = `?personId=${socialCareId}`;
+  const personIdQuery = `?personID=${socialCareId}`;
 
   const res: SWRResponse<InProgressSubmission[], ErrorAPI> = useSWR(
     `/api/submissions${personIdQuery}`
   );
+  console.log('🚀 ~ file: submissions.ts ~ line 35 ~ res', res.data?.length);
 
   return res;
 };

--- a/utils/api/submissions.ts
+++ b/utils/api/submissions.ts
@@ -1,4 +1,8 @@
-import { Form, Submission } from 'data/flexibleForms/forms.types';
+import {
+  Form,
+  InProgressSubmission,
+  Submission,
+} from 'data/flexibleForms/forms.types';
 import useSWR, { SWRResponse } from 'swr';
 import type { ErrorAPI } from 'types';
 
@@ -19,21 +23,13 @@ export const useSubmission = (
 
 /** fetch unfinished submissions in the user's current service context, either for everyone, or by social care id */
 export const useUnfinishedSubmissions = (
-  socialCareId?: number
-): SWRResponse<Data, ErrorAPI> => {
-  const res: SWRResponse<Data, ErrorAPI> = useSWR(
-    `/api/submissions?includeSubmissions=true`
+  socialCareId: number
+): SWRResponse<InProgressSubmission[], ErrorAPI> => {
+  const personIdQuery = `?personId=${socialCareId}`;
+
+  const res: SWRResponse<InProgressSubmission[], ErrorAPI> = useSWR(
+    `/api/submissions${personIdQuery}`
   );
 
-  return {
-    ...res,
-    data: {
-      forms: res?.data?.forms || [],
-      submissions: socialCareId
-        ? res?.data?.submissions.filter((sub) =>
-            sub.residents.some((resident) => resident.id === socialCareId)
-          ) || []
-        : res?.data?.submissions || [],
-    },
-  };
+  return res;
 };


### PR DESCRIPTION
**What**  
A bunch of our API calls were doing filtering by taking the response and then calling `.filter`. Instead we now pass filter values into our query parameters so that the filtering can be done server side.

**Why**  
Benefits include

- cleaner code
- smaller response size when requesting data
- will work better with pagination, how can you filter correctly if you only return a paginated subset of data

**Anything else?**

- Have you added any new third-party libraries? no
- Are any new environment variables or configuration values needed? no
- Anything else in this PR that isn't covered by the what/why? no
