### PR TITLE
feat(SCT-1100): Display case statuses

### DIFF
--- a/components/CaseStatus/CaseStatusView.spec.tsx
+++ b/components/CaseStatus/CaseStatusView.spec.tsx
@@ -65,7 +65,7 @@ describe('CaseStatusView component', () => {
     expect(queryByText('Child in need')).toBeInTheDocument();
   });
 
-  it('displays only one "CIN" and one "CPP" in case they are multiple', async () => {
+  it('displays only one "CIN", one "CPP" and one "LAC"', async () => {
     jest.spyOn(caseStatusApi, 'GetCaseStatus').mockImplementation(() => ({
       data: mockedPersonCaseStatusFactory.build({
         personId: person.id,
@@ -75,6 +75,9 @@ describe('CaseStatusView component', () => {
           }),
           mockedCaseStatusFactory.build({
             type: 'CPP',
+          }),
+          mockedCaseStatusFactory.build({
+            type: 'LAC',
           }),
         ],
       }),
@@ -87,6 +90,7 @@ describe('CaseStatusView component', () => {
 
     expect(queryByText('Child in need')).toBeInTheDocument();
     expect(queryByText('Child protection services')).toBeInTheDocument();
+    expect(queryByText('Looked after child')).toBeInTheDocument();
   });
 
   it("displays nothing if there's no case status", async () => {

--- a/components/CaseStatus/CaseStatusView.spec.tsx
+++ b/components/CaseStatus/CaseStatusView.spec.tsx
@@ -39,7 +39,54 @@ describe('CaseStatusView component', () => {
 
     const { queryByText } = render(<CaseStatusView person={person} />);
 
-    expect(queryByText('Child in need - N0')).toBeInTheDocument();
+    expect(queryByText('Child in need')).toBeInTheDocument();
+  });
+
+  it('displays only one "CIN" in case they are multiple', async () => {
+    jest.spyOn(caseStatusApi, 'GetCaseStatus').mockImplementation(() => ({
+      data: mockedPersonCaseStatusFactory.build({
+        personId: person.id,
+        caseStatuses: [
+          mockedCaseStatusFactory.build({
+            type: 'CIN',
+          }),
+          mockedCaseStatusFactory.build({
+            type: 'CIN',
+          }),
+        ],
+      }),
+      isValidating: false,
+      mutate: jest.fn(),
+      revalidate: jest.fn(),
+    }));
+
+    const { queryByText } = render(<CaseStatusView person={person} />);
+
+    expect(queryByText('Child in need')).toBeInTheDocument();
+  });
+
+  it('displays only one "CIN" and one "CPP" in case they are multiple', async () => {
+    jest.spyOn(caseStatusApi, 'GetCaseStatus').mockImplementation(() => ({
+      data: mockedPersonCaseStatusFactory.build({
+        personId: person.id,
+        caseStatuses: [
+          mockedCaseStatusFactory.build({
+            type: 'CIN',
+          }),
+          mockedCaseStatusFactory.build({
+            type: 'CPP',
+          }),
+        ],
+      }),
+      isValidating: false,
+      mutate: jest.fn(),
+      revalidate: jest.fn(),
+    }));
+
+    const { queryByText } = render(<CaseStatusView person={person} />);
+
+    expect(queryByText('Child in need')).toBeInTheDocument();
+    expect(queryByText('Child protection services')).toBeInTheDocument();
   });
 
   it("displays nothing if there's no case status", async () => {

--- a/components/CaseStatus/CaseStatusView.tsx
+++ b/components/CaseStatus/CaseStatusView.tsx
@@ -24,7 +24,7 @@ const CaseStatusView = ({ person }: Props): React.ReactElement => {
       {groupByType(caseStatusData.caseStatuses, (data: any) => data.type).map(
         (status) => (
           <span
-            className="govuk-tag lbh-tag govuk-!-margin-right-1 govuk-!-margin-top-2"
+            className="govuk-tag lbh-tag lbh-tag--yellow govuk-!-margin-right-1 govuk-!-margin-top-2"
             key={status}
           >
             {getTypeString(status as keyof typeof valueMapping)}

--- a/components/CaseStatus/CaseStatusView.tsx
+++ b/components/CaseStatus/CaseStatusView.tsx
@@ -52,6 +52,7 @@ const getTypeString = (type: keyof typeof valueMapping): any => {
 };
 const valueMapping = {
   CIN: 'Child in need',
+  CPP: 'Child protection services',
 };
 
 export default CaseStatusView;

--- a/components/CaseStatus/CaseStatusView.tsx
+++ b/components/CaseStatus/CaseStatusView.tsx
@@ -21,22 +21,31 @@ const CaseStatusView = ({ person }: Props): React.ReactElement => {
 
   return (
     <>
-      {caseStatusData && (
-        <section className="govuk-!-margin-top-0">
-          {caseStatusData.caseStatuses.map((status) => (
-            <span
-              className="govuk-tag lbh-tag govuk-!-margin-right-1 govuk-!-margin-top-2"
-              key={status.id}
-            >
-              {getTypeString(status.type as keyof typeof valueMapping)} -{' '}
-              {status.fields.map((val) => val.selectedOption.name).join(',')}
-            </span>
-          ))}
-        </section>
+      {groupByType(caseStatusData.caseStatuses, (data: any) => data.type).map(
+        (status) => (
+          <span
+            className="govuk-tag lbh-tag govuk-!-margin-right-1 govuk-!-margin-top-2"
+            key={status}
+          >
+            {getTypeString(status)}
+          </span>
+        )
       )}
     </>
   );
 };
+
+function groupByType(list: any, keyGetter: any) {
+  const map = [];
+  list.forEach((item: any) => {
+    const key = keyGetter(item);
+    const collection = map.find((elm) => elm === key);
+    if (!collection) {
+      map.push(key);
+    }
+  });
+  return map;
+}
 
 const getTypeString = (type: keyof typeof valueMapping): any => {
   return valueMapping[type];

--- a/components/CaseStatus/CaseStatusView.tsx
+++ b/components/CaseStatus/CaseStatusView.tsx
@@ -27,7 +27,7 @@ const CaseStatusView = ({ person }: Props): React.ReactElement => {
             className="govuk-tag lbh-tag govuk-!-margin-right-1 govuk-!-margin-top-2"
             key={status}
           >
-            {getTypeString(status)}
+            {getTypeString(status as keyof typeof valueMapping)}
           </span>
         )
       )}
@@ -36,7 +36,7 @@ const CaseStatusView = ({ person }: Props): React.ReactElement => {
 };
 
 function groupByType(list: any, keyGetter: any) {
-  const map = [];
+  const map = new Array<string>();
   list.forEach((item: any) => {
     const key = keyGetter(item);
     const collection = map.find((elm) => elm === key);

--- a/components/CaseStatus/CaseStatusView.tsx
+++ b/components/CaseStatus/CaseStatusView.tsx
@@ -53,6 +53,7 @@ const getTypeString = (type: keyof typeof valueMapping): any => {
 const valueMapping = {
   CIN: 'Child in need',
   CPP: 'Child protection services',
+  LAC: 'Looked after child',
 };
 
 export default CaseStatusView;

--- a/components/CaseStatus/CaseStatusView.tsx
+++ b/components/CaseStatus/CaseStatusView.tsx
@@ -1,6 +1,6 @@
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import { GetCaseStatus } from 'utils/api/caseStatus';
-import { Resident } from 'types';
+import { Resident, CaseStatus } from 'types';
 
 interface Props {
   person: Resident;
@@ -21,35 +21,24 @@ const CaseStatusView = ({ person }: Props): React.ReactElement => {
 
   return (
     <>
-      {groupByType(caseStatusData.caseStatuses, (data: any) => data.type).map(
-        (status) => (
-          <span
-            className="govuk-tag lbh-tag lbh-tag--yellow govuk-!-margin-right-1 govuk-!-margin-top-2"
-            key={status}
-          >
-            {getTypeString(status as keyof typeof valueMapping)}
-          </span>
-        )
-      )}
+      {groupByType(caseStatusData.caseStatuses).map((status) => (
+        <span
+          className="govuk-tag lbh-tag lbh-tag--yellow govuk-!-margin-right-1 govuk-!-margin-top-2"
+          key={status}
+        >
+          {valueMapping[status]}
+        </span>
+      ))}
     </>
   );
 };
 
-function groupByType(list: any, keyGetter: any) {
-  const map = new Array<string>();
-  list.forEach((item: any) => {
-    const key = keyGetter(item);
-    const collection = map.find((elm) => elm === key);
-    if (!collection) {
-      map.push(key);
-    }
-  });
-  return map;
+function groupByType(
+  allCasesStatues: CaseStatus[]
+): (keyof typeof valueMapping)[] {
+  return Array.from(new Set(allCasesStatues.map((el) => el.type)));
 }
 
-const getTypeString = (type: keyof typeof valueMapping): any => {
-  return valueMapping[type];
-};
 const valueMapping = {
   CIN: 'Child in need',
   CPP: 'Child protection services',

--- a/factories/caseStatus.ts
+++ b/factories/caseStatus.ts
@@ -18,7 +18,7 @@ export const mockedPersonCaseStatusFactory = Factory.define<PersonCaseStatus>(
 export const mockedCaseStatusFactory = Factory.define<CaseStatus>(
   ({ sequence }) => ({
     id: sequence,
-    type: 'foo',
+    type: 'CIN',
     fields: [mockedStatusField.build()],
     startDate: '2021-01-01T02:00:00Z',
     endDate: '2021-12-01T02:00:00Z',

--- a/types.ts
+++ b/types.ts
@@ -347,7 +347,7 @@ export interface CaseStatusFields {
 
 export interface CaseStatus {
   id: number;
-  type: string;
+  type: 'CIN' | 'CPP' | 'LAC';
   fields: Array<CaseStatusFields>;
   startDate: string;
   endDate: string;


### PR DESCRIPTION
**What**  
This PR tidies up the main UI visualization for Case Status Types.
Style changed a bit as well

**Why**  
Before this, in presence of multiple case status connected to the user, they were displayed all under the user's name, one per subtype.
Now it displays only the main status type. 
A following PR will add the main component which will hold the detailed information


![Screenshot 2021-08-25 at 11 28 46](https://user-images.githubusercontent.com/13645306/130774689-a9d02a45-9c65-40dc-a25b-87030eefe456.png)
