### PR TITLE
Fix(SCT-935): dynamically extend form textarea

### DIFF
--- a/components/FlexibleForms/TextField.spec.tsx
+++ b/components/FlexibleForms/TextField.spec.tsx
@@ -83,4 +83,34 @@ describe('TextField', () => {
     );
     expect(screen.getByText('Example error'));
   });
+
+  it('should render a textarea when the as prop is specified', () => {
+    render(
+      <Formik
+        onSubmit={mockSubmit}
+        initialValues={{
+          foo: '',
+        }}
+      >
+        {({ touched, errors }) => (
+          <Form>
+            <TextField
+              touched={touched}
+              errors={errors}
+              name="foo"
+              label="Label text"
+              hint="Hint text"
+              as="textarea"
+              rows={3}
+            />
+          </Form>
+        )}
+      </Formik>
+    );
+
+    expect(
+      screen.getByLabelText('Label text').closest('textarea')
+    ).toBeTruthy();
+    expect(screen.getByLabelText('Label text').closest('input')).toBeNull();
+  });
 });

--- a/components/FlexibleForms/TextField.tsx
+++ b/components/FlexibleForms/TextField.tsx
@@ -37,7 +37,7 @@ const Field = ({
   const textArea = useRef<HTMLTextAreaElement>(null);
 
   const extendTextarea = () => {
-    const textarea = document.getElementById(name);
+    const textarea = textArea.current;
     textarea &&
       (textarea.oninput = () => {
         textarea.style.height = '';
@@ -84,6 +84,7 @@ const Field = ({
         id={name}
         type={type}
         innerRef={textArea}
+        data-testid="text-raw-field"
         className={cx(
           as === 'textarea'
             ? 'govuk-textarea lbh-textarea'
@@ -93,7 +94,7 @@ const Field = ({
         aria-describedby={hint && `${name}-hint`}
         as={as}
         rows={rows}
-        onInput={extendTextarea}
+        onInput={() => as === 'textarea' && extendTextarea()}
       />
     </div>
   );

--- a/components/FlexibleForms/TextField.tsx
+++ b/components/FlexibleForms/TextField.tsx
@@ -7,6 +7,7 @@ import {
   FormikValues,
 } from 'formik';
 import cx from 'classnames';
+import { useRef } from 'react';
 
 interface FieldProps {
   touched: FormikTouched<FormikValues>;
@@ -32,52 +33,70 @@ const Field = ({
   as,
   rows,
   required,
-}: FieldProps): React.ReactElement => (
-  <div
-    className={`govuk-form-group lbh-form-group ${
-      getIn(touched, name) && getIn(errors, name) && 'govuk-form-group--error'
-    }`}
-  >
-    <label htmlFor={name} data-testid={name} className="govuk-label lbh-label">
-      {label}{' '}
-      {required && (
-        <span className="govuk-required">
-          <span aria-hidden="true">*</span>
-          <span className="govuk-visually-hidden">required</span>
+}: FieldProps): React.ReactElement => {
+  const textArea = useRef<HTMLTextAreaElement>(null);
+
+  const extendTextarea = () => {
+    const textarea = document.getElementById(name);
+    textarea &&
+      (textarea.oninput = () => {
+        textarea.style.height = '';
+        textarea.style.height = textarea.scrollHeight + 'px';
+      });
+  };
+  return (
+    <div
+      className={`govuk-form-group lbh-form-group ${
+        getIn(touched, name) && getIn(errors, name) && 'govuk-form-group--error'
+      }`}
+    >
+      <label
+        htmlFor={name}
+        data-testid={name}
+        className="govuk-label lbh-label"
+      >
+        {label}{' '}
+        {required && (
+          <span className="govuk-required">
+            <span aria-hidden="true">*</span>
+            <span className="govuk-visually-hidden">required</span>
+          </span>
+        )}
+      </label>
+
+      {hint && (
+        <span id={`${name}-hint`} className="govuk-hint lbh-hint">
+          {hint}
         </span>
       )}
-    </label>
 
-    {hint && (
-      <span id={`${name}-hint`} className="govuk-hint lbh-hint">
-        {hint}
-      </span>
-    )}
+      <ErrorMessage name={name}>
+        {(msg) => (
+          <p className="govuk-error-message lbh-error-message" role="alert">
+            <span className="govuk-visually-hidden">Error:</span>
+            {msg}
+          </p>
+        )}
+      </ErrorMessage>
 
-    <ErrorMessage name={name}>
-      {(msg) => (
-        <p className="govuk-error-message lbh-error-message" role="alert">
-          <span className="govuk-visually-hidden">Error:</span>
-          {msg}
-        </p>
-      )}
-    </ErrorMessage>
-
-    <RawField
-      name={name}
-      id={name}
-      type={type}
-      className={cx(
-        as === 'textarea'
-          ? 'govuk-textarea lbh-textarea'
-          : 'govuk-input lbh-input',
-        className
-      )}
-      aria-describedby={hint && `${name}-hint`}
-      as={as}
-      rows={rows}
-    />
-  </div>
-);
+      <RawField
+        name={name}
+        id={name}
+        type={type}
+        innerRef={textArea}
+        className={cx(
+          as === 'textarea'
+            ? 'govuk-textarea lbh-textarea'
+            : 'govuk-input lbh-input',
+          className
+        )}
+        aria-describedby={hint && `${name}-hint`}
+        as={as}
+        rows={rows}
+        onInput={extendTextarea}
+      />
+    </div>
+  );
+};
 
 export default Field;


### PR DESCRIPTION
**What**  
This PR allows the textarea component on forms to dynamically extend if a user types a large amount of text or adds paragraphs.

**Why**  
To allow users to see all the information they are inputting into a text area without having to either click and drag the textarea to extend it or content being covered by scrolling.

**Anything else?**
Nothing else needed
