### PR TITLE
fix(SCT-1126): nan percent complete showing in unfinished submissions

### DIFF
--- a/components/Cases/CaseLink.tsx
+++ b/components/Cases/CaseLink.tsx
@@ -22,7 +22,7 @@ const CaseLink = ({
   formType,
 }: Props): React.ReactElement | null => {
   if (formType === 'flexible-form') {
-    const name = mapFormIdToFormDefinition[formName].displayName;
+    const name = mapFormIdToFormDefinition[formName]?.displayName;
 
     return (
       <Link href={`/people/${personId}/submissions/${recordId}`}>

--- a/components/NewPersonView/EventLink.tsx
+++ b/components/NewPersonView/EventLink.tsx
@@ -13,7 +13,7 @@ const EventLink = ({ event }: Props): React.ReactElement => {
 
   if (event.formType === 'flexible-form') {
     const formName =
-      mapFormIdToFormDefinition[event.formName].displayName || 'Form';
+      mapFormIdToFormDefinition[event.formName]?.displayName || 'Form';
     const formTitle = event.title ? ` - ${event.title}` : '';
 
     return (

--- a/components/NewPersonView/UnfinishedSubmissions.spec.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.spec.tsx
@@ -1,5 +1,9 @@
 import { render, screen } from '@testing-library/react';
-import { mockSubmission } from 'factories/submissions';
+import {
+  mockInProgressSubmission,
+  mockInProgressSubmissionFactory,
+  mockSubmission,
+} from 'factories/submissions';
 import UnfinishedSubmissions from './UnfinishedSubmissions';
 
 describe('UnfinishedSubmissions', () => {
@@ -41,5 +45,66 @@ describe('UnfinishedSubmissions', () => {
 
     expect(screen.getByText('and 2 more'));
     expect(screen.getAllByRole('listitem').length).toBe(5);
+  });
+
+  it('displays the percentage of steps completed for a fully complete submission', () => {
+    render(
+      <UnfinishedSubmissions
+        submissions={{
+          items: [mockInProgressSubmission],
+          count: 1,
+        }}
+      />
+    );
+
+    expect(screen.getByText('100% complete ·', { exact: false }));
+  });
+
+  it('displays the percentage of steps completed for an empty submission', () => {
+    render(
+      <UnfinishedSubmissions
+        submissions={{
+          items: [mockInProgressSubmissionFactory.build({ completedSteps: 0 })],
+          count: 1,
+        }}
+      />
+    );
+
+    expect(screen.getByText('0% complete ·', { exact: false }));
+  });
+
+  it('displays the percentage of steps correctly for a partially completed submission', () => {
+    render(
+      <UnfinishedSubmissions
+        submissions={{
+          items: [
+            mockInProgressSubmissionFactory.build({
+              completedSteps: 2,
+              formId: 'face-overview-assessment',
+            }),
+          ],
+          count: 1,
+        }}
+      />
+    );
+
+    expect(screen.getByText('7% complete ·', { exact: false }));
+  });
+
+  it('handles when we can not find the associated form for a submission', () => {
+    render(
+      <UnfinishedSubmissions
+        submissions={{
+          items: [
+            mockInProgressSubmissionFactory.build({
+              formId: 'invalid form id',
+            }),
+          ],
+          count: 1,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Unknown % complete · ', { exact: false }));
   });
 });

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -15,16 +15,15 @@ const Sub = ({ sub }: SubProps): React.ReactElement => {
   const form = mapFormIdToFormDefinition[sub.formId].form;
   const totalSteps = form.steps.length;
 
+  const completedPercentageDisplay = `${Math.round(
+    (completedSteps / Number(totalSteps)) * 100
+  )}% complete · `;
+
   return (
     <li key={sub.submissionId}>
       <Link href={generateSubmissionUrl(sub)}>{form.name || sub.formId}</Link>{' '}
       <p className="lbh-body-xs">
-        {!Number.isNaN(completedSteps) &&
-          !Number.isNaN(totalSteps) &&
-          `${Math.round(
-            (completedSteps / Number(totalSteps)) * 100
-          )}% complete · `}
-
+        {completedPercentageDisplay}
         {sub.createdBy.email}
       </p>
     </li>

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -12,16 +12,16 @@ interface SubProps {
 const Sub = ({ sub }: SubProps): React.ReactElement => {
   const completedSteps = sub.completedSteps;
 
-  const form = mapFormIdToFormDefinition[sub.formId].form;
-  const totalSteps = form.steps.length;
+  const form = mapFormIdToFormDefinition[sub.formId]?.form;
+  const totalSteps = form?.steps.length;
 
-  const completedPercentageDisplay = `${Math.round(
-    (completedSteps / Number(totalSteps)) * 100
-  )}% complete · `;
+  const completedPercentageDisplay = totalSteps
+    ? `${Math.round((completedSteps / Number(totalSteps)) * 100)}% complete · `
+    : 'Unknown % complete · ';
 
   return (
     <li key={sub.submissionId}>
-      <Link href={generateSubmissionUrl(sub)}>{form.name || sub.formId}</Link>{' '}
+      <Link href={generateSubmissionUrl(sub)}>{sub.formId}</Link>{' '}
       <p className="lbh-body-xs">
         {completedPercentageDisplay}
         {sub.createdBy.email}

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -3,6 +3,7 @@ import { InProgressSubmission } from 'data/flexibleForms/forms.types';
 import Link from 'next/link';
 import { generateSubmissionUrl } from 'lib/submissions';
 import { Paginated } from 'types';
+import { mapFormIdToFormDefinition } from 'data/flexibleForms/mapFormIdsToFormDefinition';
 
 interface SubProps {
   sub: InProgressSubmission;
@@ -10,13 +11,13 @@ interface SubProps {
 
 const Sub = ({ sub }: SubProps): React.ReactElement => {
   const completedSteps = sub.completedSteps;
-  const totalSteps = sub.form?.steps?.length;
+
+  const form = mapFormIdToFormDefinition[sub.formId].form;
+  const totalSteps = form.steps.length;
 
   return (
     <li key={sub.submissionId}>
-      <Link href={generateSubmissionUrl(sub)}>
-        {sub?.form?.name || sub.formId}
-      </Link>{' '}
+      <Link href={generateSubmissionUrl(sub)}>{form.name || sub.formId}</Link>{' '}
       <p className="lbh-body-xs">
         {!Number.isNaN(completedSteps) &&
           !Number.isNaN(totalSteps) &&

--- a/components/SubmissionsTable/SubmissionPanel.spec.tsx
+++ b/components/SubmissionsTable/SubmissionPanel.spec.tsx
@@ -15,7 +15,6 @@ describe('SubmissionPanel', () => {
   it('can launch and close the dialog', () => {
     render(<SubmissionPanel submission={mockInProgressSubmission} />);
     fireEvent.click(screen.getByText('Details'));
-    expect(screen.getByText('Unknown form details'));
     expect(screen.getByRole('dialog'));
 
     fireEvent.click(screen.getByText('Close'));

--- a/components/SubmissionsTable/SubmissionPanel.tsx
+++ b/components/SubmissionsTable/SubmissionPanel.tsx
@@ -5,6 +5,7 @@ import { format } from 'date-fns';
 import s from './index.module.scss';
 import SubmissionDetailDialog from './SubmissionDetailDialog';
 import { generateSubmissionUrl } from 'lib/submissions';
+import { mapFormIdToFormDefinition } from 'data/flexibleForms/mapFormIdsToFormDefinition';
 
 interface Props {
   submission: InProgressSubmission;
@@ -13,10 +14,12 @@ interface Props {
 const SubmissionPanel = ({ submission }: Props): React.ReactElement | null => {
   const [open, setOpen] = useState(false);
 
-  const form = submission.form;
+  const form = mapFormIdToFormDefinition[submission.formId]?.form ?? {
+    steps: [],
+  };
   const totalSteps = form?.steps?.length;
   const completion =
-    Math.round((submission.completedSteps / Number(totalSteps)) * 100) || 0;
+    Math.round(submission.completedSteps / Number(totalSteps)) * 100;
 
   const url = useMemo(() => generateSubmissionUrl(submission), [submission]);
 

--- a/components/SubmissionsTable/SubmissionPanel.tsx
+++ b/components/SubmissionsTable/SubmissionPanel.tsx
@@ -14,9 +14,7 @@ interface Props {
 const SubmissionPanel = ({ submission }: Props): React.ReactElement | null => {
   const [open, setOpen] = useState(false);
 
-  const form = mapFormIdToFormDefinition[submission.formId]?.form ?? {
-    steps: [],
-  };
+  const form = mapFormIdToFormDefinition[submission.formId]?.form;
   const totalSteps = form?.steps?.length;
   const completion =
     Math.round(submission.completedSteps / Number(totalSteps)) * 100;

--- a/components/SubmissionsTable/index.tsx
+++ b/components/SubmissionsTable/index.tsx
@@ -7,7 +7,6 @@ import st from 'components/Tabs/Tabs.module.scss';
 import Tab from './Tab';
 import SearchBox from './SearchBox';
 import useSearch from 'hooks/useSearch';
-import { mapFormIdToFormDefinition } from 'data/flexibleForms/mapFormIdsToFormDefinition';
 
 interface Props {
   submissions: InProgressSubmission[];
@@ -27,10 +26,6 @@ export const SubmissionsTable = ({
     () =>
       submissions
         // augment each one with its form
-        .map((submission) => ({
-          ...submission,
-          form: mapFormIdToFormDefinition[submission.formId].form,
-        }))
         .filter((submission) => {
           // hide any restricted records unless the user has permission to see them
           if (

--- a/components/SubmissionsTable/index.tsx
+++ b/components/SubmissionsTable/index.tsx
@@ -7,6 +7,7 @@ import st from 'components/Tabs/Tabs.module.scss';
 import Tab from './Tab';
 import SearchBox from './SearchBox';
 import useSearch from 'hooks/useSearch';
+import { mapFormIdToFormDefinition } from 'data/flexibleForms/mapFormIdsToFormDefinition';
 
 interface Props {
   submissions: InProgressSubmission[];
@@ -26,6 +27,10 @@ export const SubmissionsTable = ({
     () =>
       submissions
         // augment each one with its form
+        .map((submission) => ({
+          ...submission,
+          form: mapFormIdToFormDefinition[submission.formId]?.form,
+        }))
         .filter((submission) => {
           // hide any restricted records unless the user has permission to see them
           if (

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -122,7 +122,6 @@ export enum SubmissionState {
 export interface Submission {
   submissionId: string;
   formId: string;
-  form?: Form;
   createdBy: Worker;
   createdAt: string;
   submittedBy: Worker | null;

--- a/data/flexibleForms/mapFormIdsToFormDefinition.ts
+++ b/data/flexibleForms/mapFormIdsToFormDefinition.ts
@@ -7,7 +7,10 @@ type FormDefinition = {
   id: string;
 };
 
-export const mapFormIdToFormDefinition: Record<string, FormDefinition> = {
+export const mapFormIdToFormDefinition: Record<
+  string,
+  FormDefinition | undefined
+> = {
   'adult-case-note': {
     form: formAsObjects.adultCaseNote,
     displayName: 'Case note',

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -275,7 +275,7 @@ export const generateSubmissionUrl = (
   submission: Submission | InProgressSubmission,
   socialCareId?: number
 ): string => {
-  const form = mapFormIdToFormDefinition[submission.formId].form;
+  const form = mapFormIdToFormDefinition[submission.formId]?.form;
   if (form?.canonicalUrl) {
     return `${form.canonicalUrl(
       // use the passed in social care id, or default to the first resident on the submission

--- a/pages/api/submissions/[id]/index.ts
+++ b/pages/api/submissions/[id]/index.ts
@@ -8,7 +8,6 @@ import {
 } from 'lib/submissions';
 import { isAuthorised } from 'utils/auth';
 import { notifyApprover } from 'lib/notify';
-import { mapFormIdToFormDefinition } from 'data/flexibleForms/mapFormIdsToFormDefinition';
 
 const handler = async (
   req: NextApiRequest,
@@ -56,12 +55,8 @@ const handler = async (
     case 'GET':
       {
         const submission = await getSubmissionById(id as string);
-        const form = mapFormIdToFormDefinition[submission.formId].form;
 
-        res.json({
-          ...submission,
-          form,
-        });
+        res.json(submission);
       }
       break;
     default:


### PR DESCRIPTION
**What**  
Utilise our mapping form id to form object.
Remove form property from our submissions as it is no longer added via mutation at the API level.

**Why**  
We want to show the actual percentage complete or handle errors appropriately when we can not compute % complete.

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
