### PR TITLE
fix(SCT-1134): Test and improve unfinished submissions

### DIFF
--- a/components/NewPersonView/PersonHistory.spec.tsx
+++ b/components/NewPersonView/PersonHistory.spec.tsx
@@ -2,14 +2,11 @@ import { render, screen } from '@testing-library/react';
 import { mockedResident } from 'factories/residents';
 import PersonHistory from './PersonHistory';
 import * as caseHooks from 'utils/api/cases';
-import * as submissionHooks from 'utils/api/submissions';
-import { SWRInfiniteResponse, SWRResponse } from 'swr';
-import { CaseData, ErrorAPI, Paginated } from 'types';
-import { InProgressSubmission } from 'data/flexibleForms/forms.types';
+import { SWRInfiniteResponse } from 'swr';
+import { CaseData } from 'types';
 import { mockedCaseNote } from 'factories/cases';
 
 jest.mock('utils/api/cases');
-jest.mock('utils/api/submissions');
 jest.mock('components/Spinner/Spinner', () => () => 'MockedSpinner');
 
 describe('PersonHistory', () => {
@@ -30,19 +27,7 @@ describe('PersonHistory', () => {
       return response;
     });
 
-    jest
-      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
-      .mockImplementation(() => {
-        const response = {} as SWRResponse<
-          Paginated<InProgressSubmission>,
-          ErrorAPI
-        >;
-
-        return response;
-      });
-
     render(<PersonHistory personId={mockedResident.id} />);
-
     expect(screen.getByText('i am a case title'));
   });
 
@@ -59,19 +44,7 @@ describe('PersonHistory', () => {
       return response;
     });
 
-    jest
-      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
-      .mockImplementation(() => {
-        const response = {} as SWRResponse<
-          Paginated<InProgressSubmission>,
-          ErrorAPI
-        >;
-
-        return response;
-      });
-
     render(<PersonHistory personId={mockedResident.id} />);
-
     expect(screen.getByText('No events to show'));
   });
 
@@ -84,19 +57,7 @@ describe('PersonHistory', () => {
       return response;
     });
 
-    jest
-      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
-      .mockImplementation(() => {
-        const response = {} as SWRResponse<
-          Paginated<InProgressSubmission>,
-          ErrorAPI
-        >;
-
-        return response;
-      });
-
     render(<PersonHistory personId={mockedResident.id} />);
-
     expect(screen.getByText('MockedSpinner'));
   });
 
@@ -113,19 +74,7 @@ describe('PersonHistory', () => {
       return response;
     });
 
-    jest
-      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
-      .mockImplementation(() => {
-        const response = {} as SWRResponse<
-          Paginated<InProgressSubmission>,
-          ErrorAPI
-        >;
-
-        return response;
-      });
-
     render(<PersonHistory personId={mockedResident.id} />);
-
     expect(screen.getByText(errorMessage));
   });
 });

--- a/components/NewPersonView/PersonHistory.tsx
+++ b/components/NewPersonView/PersonHistory.tsx
@@ -3,7 +3,6 @@ import Spinner from 'components/Spinner/Spinner';
 import React from 'react';
 import { Case } from 'types';
 import { useCasesByResident } from 'utils/api/cases';
-import { useUnfinishedSubmissions } from 'utils/api/submissions';
 import PersonTimeline from './PersonTimeline';
 
 interface Props {
@@ -18,7 +17,6 @@ const PersonHistory = ({ personId }: Props): React.ReactElement => {
     error: casesError,
     isValidating,
   } = useCasesByResident(personId);
-  const { data: submissionsData } = useUnfinishedSubmissions(personId);
 
   if (isValidating && casesData === undefined) {
     return <Spinner />;
@@ -41,7 +39,7 @@ const PersonHistory = ({ personId }: Props): React.ReactElement => {
 
   return (
     <PersonTimeline
-      unfinishedSubmissions={submissionsData || { items: [], count: 0 }}
+      personId={personId}
       events={events}
       size={size}
       setSize={setSize}

--- a/components/NewPersonView/PersonTimeline.spec.tsx
+++ b/components/NewPersonView/PersonTimeline.spec.tsx
@@ -5,7 +5,6 @@ import {
   mockedNote,
   mockedWarningNoteCase,
 } from 'factories/cases';
-import { mockSubmission } from 'factories/submissions';
 import PersonTimeline from './PersonTimeline';
 
 const mockEvents = [
@@ -29,11 +28,11 @@ describe('PersonTimeline', () => {
         onLastPage={false}
         size={1}
         events={mockEvents}
-        unfinishedSubmissions={{ items: [], count: 0 }}
+        personId={1}
       />
     );
 
-    expect(screen.getAllByRole('listitem').length).toBe(4);
+    expect(screen.getAllByRole('listitem').length).toBe(5);
     expect(screen.getAllByRole('link').length).toBe(4);
     expect(screen.getByText('Showing 4 events over 9 months'));
     expect(screen.getByText('Load older events'));
@@ -46,7 +45,7 @@ describe('PersonTimeline', () => {
         onLastPage={false}
         size={1}
         events={[]}
-        unfinishedSubmissions={{ items: [], count: 0 }}
+        personId={1}
       />
     );
     expect(screen.getByText('No events match your search'));
@@ -59,7 +58,7 @@ describe('PersonTimeline', () => {
         onLastPage={true}
         size={1}
         events={mockEvents}
-        unfinishedSubmissions={{ items: [], count: 0 }}
+        personId={1}
       />
     );
     expect(screen.queryByText('Load older events')).toBeNull();
@@ -73,24 +72,10 @@ describe('PersonTimeline', () => {
         onLastPage={false}
         size={1}
         events={mockEvents}
-        unfinishedSubmissions={{ items: [], count: 0 }}
+        personId={1}
       />
     );
     fireEvent.click(screen.getByText('Load older events'));
     expect(mockHandler).toBeCalledWith(2);
-  });
-
-  it('can show unfinished submissions', () => {
-    render(
-      <PersonTimeline
-        setSize={jest.fn()}
-        onLastPage={false}
-        size={1}
-        events={mockEvents}
-        unfinishedSubmissions={{ items: [mockSubmission], count: 0 }}
-      />
-    );
-    expect(screen.getByText('Unfinished submissions'));
-    expect(screen.getAllByRole('listitem').length).toBe(6);
   });
 });

--- a/components/NewPersonView/PersonTimeline.tsx
+++ b/components/NewPersonView/PersonTimeline.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { formatDistanceToNow } from 'date-fns';
-import { Case, Paginated } from 'types';
+import { Case } from 'types';
 import s from './index.module.scss';
-import { InProgressSubmission } from 'data/flexibleForms/forms.types';
 import UnfinishedSubmissionsEvent from './UnfinishedSubmissions';
 import { normaliseDateToISO } from 'utils/date';
 import Event from './Event';
@@ -24,18 +23,18 @@ const safelyFormatDistanceToNow = (rawDate: string): string => {
 
 interface Props {
   events: Case[];
-  unfinishedSubmissions: Paginated<InProgressSubmission>;
   size: number;
   setSize: (size: number) => void;
   onLastPage: boolean;
+  personId: number;
 }
 
 const PersonTimeline = ({
   events,
-  unfinishedSubmissions,
   size,
   setSize,
   onLastPage,
+  personId,
 }: Props): React.ReactElement => {
   const oldestResult = events?.[events.length - 1];
   const oldestTimestamp = normaliseDateToISO(
@@ -51,9 +50,7 @@ const PersonTimeline = ({
               [s.timelineContinues]: !onLastPage,
             })}
           >
-            {unfinishedSubmissions.items.length > 0 && (
-              <UnfinishedSubmissionsEvent submissions={unfinishedSubmissions} />
-            )}
+            <UnfinishedSubmissionsEvent personId={personId} />
 
             {events?.map((event) => (
               <Event event={event} key={event.recordId} />

--- a/components/NewPersonView/UnfinishedSubmissions.spec.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.spec.tsx
@@ -17,7 +17,23 @@ describe('UnfinishedSubmissions', () => {
     jest.resetAllMocks();
   });
 
-  // test we call the useUnfinishedSubmissions with the personId
+  it('calls useUnfinishedSubmissions with the provided PersonId', () => {
+    const mockPersonId = 1;
+
+    const mock = jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          data: {},
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
+
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={mockPersonId} />);
+
+    expect(mock).toHaveBeenCalledWith(mockPersonId);
+  });
 
   it('renders a list of clickable submissions', () => {
     jest

--- a/components/NewPersonView/UnfinishedSubmissions.spec.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.spec.tsx
@@ -2,24 +2,42 @@ import { render, screen } from '@testing-library/react';
 import {
   mockInProgressSubmission,
   mockInProgressSubmissionFactory,
-  mockSubmission,
 } from 'factories/submissions';
 import UnfinishedSubmissions from './UnfinishedSubmissions';
+import * as submissionHooks from 'utils/api/submissions';
+import { InProgressSubmission } from 'data/flexibleForms/forms.types';
+import { SWRResponse } from 'swr';
+import { Paginated, ErrorAPI } from 'types';
+
+jest.mock('utils/api/submissions');
+jest.mock('components/Spinner/Spinner', () => () => 'MockedSpinner');
 
 describe('UnfinishedSubmissions', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // test we call the useUnfinishedSubmissions with the personId
+
   it('renders a list of clickable submissions', () => {
-    render(
-      <UnfinishedSubmissions
-        submissions={{
-          items: [
-            { ...mockSubmission, submissionId: '123' },
-            { ...mockSubmission, submissionId: '125' },
-            { ...mockSubmission, submissionId: '126' },
-          ],
-          count: 3,
-        }}
-      />
-    );
+    jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          data: {
+            items: [
+              mockInProgressSubmission,
+              mockInProgressSubmission,
+              mockInProgressSubmission,
+            ] as InProgressSubmission[],
+            count: 3,
+          },
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
+
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={1} />);
 
     expect(screen.getByText('Unfinished submissions'));
     expect(screen.getAllByRole('listitem').length).toBe(4);
@@ -27,83 +45,144 @@ describe('UnfinishedSubmissions', () => {
   });
 
   it('truncates a long list', () => {
-    render(
-      <UnfinishedSubmissions
-        submissions={{
-          items: [
-            { ...mockSubmission, submissionId: '123' },
-            { ...mockSubmission, submissionId: '124' },
-            { ...mockSubmission, submissionId: '125' },
-            { ...mockSubmission, submissionId: '126' },
-            { ...mockSubmission, submissionId: '127' },
-            { ...mockSubmission, submissionId: '128' },
-          ],
-          count: 6,
-        }}
-      />
-    );
+    jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          data: {
+            items: [
+              mockInProgressSubmission,
+              mockInProgressSubmission,
+              mockInProgressSubmission,
+              mockInProgressSubmission,
+              mockInProgressSubmission,
+              mockInProgressSubmission,
+            ] as InProgressSubmission[],
+            count: 6,
+          },
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
+
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={1} />);
 
     expect(screen.getByText('and 2 more'));
     expect(screen.getAllByRole('listitem').length).toBe(5);
   });
 
+  it('calculates item left based on response count', () => {
+    jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          data: {
+            items: [
+              mockInProgressSubmission,
+              mockInProgressSubmission,
+              mockInProgressSubmission,
+              mockInProgressSubmission,
+              mockInProgressSubmission,
+              mockInProgressSubmission,
+            ] as InProgressSubmission[],
+            count: 50,
+          },
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
+
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={1} />);
+
+    expect(screen.getByText('and 46 more'));
+    expect(screen.getAllByRole('listitem').length).toBe(5);
+  });
+
   it('displays the percentage of steps completed for a fully complete submission', () => {
-    render(
-      <UnfinishedSubmissions
-        submissions={{
-          items: [mockInProgressSubmission],
-          count: 1,
-        }}
-      />
-    );
+    jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          data: {
+            items: [mockInProgressSubmission] as InProgressSubmission[],
+            count: 3,
+          },
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
+
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={1} />);
 
     expect(screen.getByText('100% complete ·', { exact: false }));
   });
 
   it('displays the percentage of steps completed for an empty submission', () => {
-    render(
-      <UnfinishedSubmissions
-        submissions={{
-          items: [mockInProgressSubmissionFactory.build({ completedSteps: 0 })],
-          count: 1,
-        }}
-      />
-    );
+    jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          data: {
+            items: [
+              mockInProgressSubmissionFactory.build({
+                completedSteps: 0,
+              }),
+            ] as InProgressSubmission[],
+            count: 3,
+          },
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
+
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={1} />);
 
     expect(screen.getByText('0% complete ·', { exact: false }));
   });
 
   it('displays the percentage of steps correctly for a partially completed submission', () => {
-    render(
-      <UnfinishedSubmissions
-        submissions={{
-          items: [
-            mockInProgressSubmissionFactory.build({
-              completedSteps: 2,
-              formId: 'face-overview-assessment',
-            }),
-          ],
-          count: 1,
-        }}
-      />
-    );
+    jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          data: {
+            items: [
+              mockInProgressSubmissionFactory.build({
+                completedSteps: 2,
+                formId: 'face-overview-assessment',
+              }),
+            ] as InProgressSubmission[],
+            count: 3,
+          },
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
+
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={1} />);
 
     expect(screen.getByText('7% complete ·', { exact: false }));
   });
 
   it('handles when we can not find the associated form for a submission', () => {
-    render(
-      <UnfinishedSubmissions
-        submissions={{
-          items: [
-            mockInProgressSubmissionFactory.build({
-              formId: 'invalid form id',
-            }),
-          ],
-          count: 1,
-        }}
-      />
-    );
+    jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          data: {
+            items: [
+              mockInProgressSubmissionFactory.build({
+                formId: 'invalid form id',
+              }),
+            ] as InProgressSubmission[],
+            count: 3,
+          },
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
+
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={1} />);
 
     expect(screen.getByText('Unknown % complete · ', { exact: false }));
   });

--- a/components/NewPersonView/UnfinishedSubmissions.spec.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.spec.tsx
@@ -202,4 +202,61 @@ describe('UnfinishedSubmissions', () => {
 
     expect(screen.getByText('Unknown % complete · ', { exact: false }));
   });
+
+  it('shows an error message when fetching unfinished submissions returns an error', () => {
+    jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          error: {},
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
+
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={1} />);
+
+    expect(
+      screen.getByText('There was a problem fetching unfinished submissions')
+    );
+  });
+
+  it('shows loading spinner when fetching unfinished submissions', () => {
+    jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          isValidating: true,
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
+
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={1} />);
+
+    expect(screen.getByText('MockedSpinner'));
+  });
+
+  it('shows when there are no unfinished submissions', () => {
+    jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          data: {
+            items: [] as InProgressSubmission[],
+            count: 0,
+          },
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
+
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={1} />);
+
+    expect(screen.getByText('No unfinished submissions to show'));
+  });
+
+  // test showing form name when found
+
+  // testing showing form-id when no valid form-name found
 });

--- a/components/NewPersonView/UnfinishedSubmissions.spec.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.spec.tsx
@@ -256,7 +256,47 @@ describe('UnfinishedSubmissions', () => {
     expect(screen.getByText('No unfinished submissions to show'));
   });
 
-  // test showing form name when found
+  it('displays the form name when it can be found from mapFormIdToFormDefinition', () => {
+    jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          data: {
+            items: [mockInProgressSubmission] as InProgressSubmission[],
+            count: 3,
+          },
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
 
-  // testing showing form-id when no valid form-name found
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={1} />);
+
+    expect(screen.getByText('Sandbox form'));
+  });
+
+  it('displays the formId when form cannot be found from mapFormIdToFormDefinition', () => {
+    const mockFormId = 'fake-form-id';
+
+    jest
+      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
+      .mockImplementation(() => {
+        const response = {
+          data: {
+            items: [
+              mockInProgressSubmissionFactory.build({
+                formId: mockFormId,
+              }),
+            ] as InProgressSubmission[],
+            count: 3,
+          },
+        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
+
+        return response;
+      });
+
+    render(<UnfinishedSubmissions personId={1} />);
+
+    expect(screen.getByText(mockFormId));
+  });
 });

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -61,12 +61,11 @@ const UnfinishedSubmissionsEvent = ({
               <Sub sub={sub} key={sub.submissionId} />
             ))}
           </ul>
-          {unfinishedSubmissionRes &&
-            unfinishedSubmissionRes.items.length > 4 && (
-              <p className="lbh-body-s govuk-!-margin-top-4">
-                and {unfinishedSubmissionRes?.items.length - 4} more
-              </p>
-            )}
+          {unfinishedSubmissionRes.items.length > 4 && (
+            <p className="lbh-body-s govuk-!-margin-top-4">
+              and {unfinishedSubmissionRes?.count - 4} more
+            </p>
+          )}
         </>
       )}
     </li>

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -54,14 +54,18 @@ const UnfinishedSubmissionsEvent = ({
       {error && (
         <ErrorMessage label="There was a problem fetching unfinished submissions" />
       )}
-      {unfinishedSubmissionRes && (
+      {unfinishedSubmissionRes?.items?.length === 0 && (
+        <p>No unfinished submissions to show</p>
+      )}
+
+      {unfinishedSubmissionRes?.items?.length && (
         <>
           <ul className="lbh-list lbh-body-s">
             {unfinishedSubmissionRes?.items.slice(0, 4).map((sub) => (
               <Sub sub={sub} key={sub.submissionId} />
             ))}
           </ul>
-          {unfinishedSubmissionRes.items.length > 4 && (
+          {unfinishedSubmissionRes?.items.length > 4 && (
             <p className="lbh-body-s govuk-!-margin-top-4">
               and {unfinishedSubmissionRes?.count - 4} more
             </p>

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -2,8 +2,10 @@ import s from './index.module.scss';
 import { InProgressSubmission } from 'data/flexibleForms/forms.types';
 import Link from 'next/link';
 import { generateSubmissionUrl } from 'lib/submissions';
-import { Paginated } from 'types';
 import { mapFormIdToFormDefinition } from 'data/flexibleForms/mapFormIdsToFormDefinition';
+import { useUnfinishedSubmissions } from 'utils/api/submissions';
+import Spinner from 'components/Spinner/Spinner';
+import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 
 interface SubProps {
   sub: InProgressSubmission;
@@ -21,7 +23,7 @@ const Sub = ({ sub }: SubProps): React.ReactElement => {
 
   return (
     <li key={sub.submissionId}>
-      <Link href={generateSubmissionUrl(sub)}>{sub.formId}</Link>{' '}
+      <Link href={generateSubmissionUrl(sub)}>{form?.name || sub.formId}</Link>
       <p className="lbh-body-xs">
         {completedPercentageDisplay}
         {sub.createdBy.email}
@@ -31,27 +33,44 @@ const Sub = ({ sub }: SubProps): React.ReactElement => {
 };
 
 interface Props {
-  submissions: Paginated<InProgressSubmission>;
+  personId: number;
 }
 
 const UnfinishedSubmissionsEvent = ({
-  submissions,
-}: Props): React.ReactElement => (
-  <li
-    className={`lbh-timeline__event lbh-timeline__event--action-needed ${s.unfinishedSubmissionsPanel}`}
-  >
-    <h3 className="govuk-!-margin-bottom-4">Unfinished submissions</h3>
-    <ul className="lbh-list lbh-body-s">
-      {submissions.items.slice(0, 4).map((sub) => (
-        <Sub sub={sub} key={sub.submissionId} />
-      ))}
-    </ul>
-    {submissions.items.length > 4 && (
-      <p className="lbh-body-s govuk-!-margin-top-4">
-        and {submissions.count - 4} more
-      </p>
-    )}
-  </li>
-);
+  personId,
+}: Props): React.ReactElement => {
+  const {
+    data: unfinishedSubmissionRes,
+    isValidating,
+    error,
+  } = useUnfinishedSubmissions(personId);
+
+  return (
+    <li
+      className={`lbh-timeline__event lbh-timeline__event--action-needed ${s.unfinishedSubmissionsPanel}`}
+    >
+      <h3 className="govuk-!-margin-bottom-4">Unfinished submissions</h3>
+      {isValidating && <Spinner />}
+      {error && (
+        <ErrorMessage label="There was a problem fetching unfinished submissions" />
+      )}
+      {unfinishedSubmissionRes && (
+        <>
+          <ul className="lbh-list lbh-body-s">
+            {unfinishedSubmissionRes?.items.slice(0, 4).map((sub) => (
+              <Sub sub={sub} key={sub.submissionId} />
+            ))}
+          </ul>
+          {unfinishedSubmissionRes &&
+            unfinishedSubmissionRes.items.length > 4 && (
+              <p className="lbh-body-s govuk-!-margin-top-4">
+                and {unfinishedSubmissionRes?.items.length - 4} more
+              </p>
+            )}
+        </>
+      )}
+    </li>
+  );
+};
 
 export default UnfinishedSubmissionsEvent;


### PR DESCRIPTION
**What**  
Fix showing the correct form name instead of the form id (i.e says "Case note" instead of "adult-case-note"
Handle all different states, loading state, error state, no results.
Test all these states and correct form name shown.
Test we call useUnfinishedSubmissions with correct person id.
Tidy up PersonHistory and PersonTimeline components.

**Why**  
Tidy up code.
Handle error better/loading.
More complete testing.

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
