### PR TITLE
fix: chores and documentation not showing in release notes

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -10,7 +10,25 @@
   },
   "plugins": {
     "@release-it/conventional-changelog": {
-      "preset": "conventionalcommits"
+      "preset": "conventionalcommits",
+      "types": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "chore",
+          "section": "Chores"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
**What**  

Specify the types wanted in our release notes and enable `chore` and `docs`, following [Conventional Changelog Configuration Spec (v2.1.0)](https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.1.0/README.md#types) which is pointed to in the [Conventional Changelog plugin for release-it's docs](https://github.com/release-it/conventional-changelog#preset).

**Why**  

We're seeing empty release notes e.g. [v0.23.1](https://github.com/LBHackney-IT/lbh-social-care-frontend/releases/tag/0.23.1) and it seems it's because `chore` and `docs` are hidden by default. 

![image](https://user-images.githubusercontent.com/42817036/132841991-935e7b39-c7ad-4475-abc7-58d84e2f1b92.png)


**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
