### PR TITLE
fix(SCT-1155): Align endpoint names

### DIFF
--- a/lib/caseStatus.spec.ts
+++ b/lib/caseStatus.spec.ts
@@ -23,7 +23,7 @@ describe('case status APIs', () => {
 
       expect(mockedAxios.get).toHaveBeenCalled();
       expect(mockedAxios.get.mock.calls[0][0]).toEqual(
-        `${ENDPOINT_API}/residents/123/casestatuses`
+        `${ENDPOINT_API}/residents/123/case-statuses`
       );
       expect(mockedAxios.get.mock.calls[0][1]?.headers).toEqual({
         'x-api-key': AWS_KEY,

--- a/lib/caseStatus.ts
+++ b/lib/caseStatus.ts
@@ -7,7 +7,7 @@ export const getCaseStatusByPersonId = async (
   personId: number
 ): Promise<PersonCaseStatus> => {
   const { data }: { data: PersonCaseStatus } = await axios.get(
-    `${ENDPOINT_API}/residents/${personId}/casestatuses`,
+    `${ENDPOINT_API}/residents/${personId}/case-statuses`,
     {
       headers,
     }
@@ -19,7 +19,7 @@ export const getFormValues = async (
   type: string
 ): Promise<PersonCaseStatus> => {
   const { data }: { data: PersonCaseStatus } = await axios.get(
-    `${ENDPOINT_API}/case-status/form-options/${type}`,
+    `${ENDPOINT_API}/case-statuses/form-options/${type}`,
     {
       headers,
     }


### PR DESCRIPTION
## Link to JIRA ticket

[SCT-1555](https://hackney.atlassian.net/browse/SCT-1155)

## Describe this PR

### *What is the problem we're trying to solve*

Case status endpoint names have various way of spelling "case status".
This PR aligns them to "case-statuses"

`${ENDPOINT_API}/residents/${personId}/casestatuses` becomes `${ENDPOINT_API}/residents/${personId}/case-statuses`
`${ENDPOINT_API}/case-status/form-options/${type}` is now `${ENDPOINT_API}/case-statuses/form-options/${type}`