### PR TITLE
fix: Remove sorting logic for tables that is never actually used

### DIFF
--- a/components/Cases/CasesTable.tsx
+++ b/components/Cases/CasesTable.tsx
@@ -115,34 +115,15 @@ export type CaseTableColumns = keyof typeof tableEntities;
 interface Props {
   records: Case[];
   columns: CaseTableColumns[];
-  sort?: {
-    sort_by?: string;
-    order_by?: string;
-  };
-  onSort?: (id: string) => void;
 }
 
-const CasesTable = ({
-  records,
-  columns,
-  sort = {},
-  onSort,
-}: Props): React.ReactElement => (
+const CasesTable = ({ records, columns }: Props): React.ReactElement => (
   <table className="govuk-table">
     <thead className="govuk-table__head">
       <tr className="govuk-table__row">
         {columns.map((column) => (
-          <th
-            key={column}
-            scope="col"
-            className="govuk-table__header"
-            role={onSort && 'button'}
-            onClick={() => onSort && onSort(column)}
-          >
+          <th key={column} scope="col" className="govuk-table__header">
             {tableEntities[column].text}{' '}
-            {column === sort.sort_by && (
-              <>{sort.order_by === 'desc' ? '🔽' : '🔼'}</>
-            )}
           </th>
         ))}
       </tr>

--- a/components/Search/Search.jsx
+++ b/components/Search/Search.jsx
@@ -103,20 +103,6 @@ const Search = ({
     },
     [pathname, query, replace]
   );
-  // commented out as the feature is not ready in the BE
-  // eslint-disable-next-line no-unused-vars
-  const onSort = useCallback(
-    (value) => {
-      const { order_by, sort_by } = query || {};
-      onFormSubmit({
-        ...(query || {}),
-        ...(sort_by === value && order_by === 'desc'
-          ? { order_by: 'asc', sort_by }
-          : { order_by: 'desc', sort_by: value }),
-      });
-    },
-    [onFormSubmit, query]
-  );
 
   return (
     <>


### PR DESCRIPTION
**What**  
Some frontend logic exists for sorting by column name and if the sort should be ascending or descending. At the current moment though we don't ever sort these tables so I have deleted the code as it adds complexity without any functionality.

**Why**  
Cleaner code/Less code == less bugs maybe

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
