### PR TITLE
fix: Unfinished submissions showing 0 for no reason when there are no submissions

### DIFF
--- a/components/NewPersonView/Layout.tsx
+++ b/components/NewPersonView/Layout.tsx
@@ -148,16 +148,6 @@ const Layout = ({ person, children }: Props): React.ReactElement => {
           </p>
 
           <ConditionalFeature name="case-status">
-            <span hidden>
-              {casestatus &&
-              !groupCaseStatusByType(casestatus.caseStatuses).has('CIN') &&
-              person.contextFlag === 'C'
-                ? secondaryNavigation.push({
-                    text: 'Add a case status',
-                    href: `/people/${person.id}/case-status/add`,
-                  })
-                : null}
-            </span>
             <CaseStatusView person={person} />
           </ConditionalFeature>
         </div>

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -58,7 +58,7 @@ const UnfinishedSubmissionsEvent = ({
         <p>No unfinished submissions to show</p>
       )}
 
-      {unfinishedSubmissionRes?.items?.length && (
+      {unfinishedSubmissionRes && unfinishedSubmissionRes.items.length > 0 && (
         <>
           <ul className="lbh-list lbh-body-s">
             {unfinishedSubmissionRes?.items.slice(0, 4).map((sub) => (

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -54,22 +54,18 @@ const UnfinishedSubmissionsEvent = ({
       {error && (
         <ErrorMessage label="There was a problem fetching unfinished submissions" />
       )}
-      {unfinishedSubmissionRes?.items?.length === 0 ? (
+      {unfinishedSubmissionRes?.items?.length === 0 && (
         <p>No unfinished submissions to show</p>
-      ) : (
-        <>
-          <ul className="lbh-list lbh-body-s">
-            {unfinishedSubmissionRes?.items.slice(0, 4).map((sub) => (
-              <Sub sub={sub} key={sub.submissionId} />
-            ))}
-          </ul>
-          {unfinishedSubmissionRes &&
-            unfinishedSubmissionRes?.items.length > 4 && (
-              <p className="lbh-body-s govuk-!-margin-top-4">
-                and {unfinishedSubmissionRes?.count - 4} more
-              </p>
-            )}
-        </>
+      )}
+      <ul className="lbh-list lbh-body-s">
+        {unfinishedSubmissionRes?.items.slice(0, 4).map((sub) => (
+          <Sub sub={sub} key={sub.submissionId} />
+        ))}
+      </ul>
+      {unfinishedSubmissionRes && unfinishedSubmissionRes?.items.length > 4 && (
+        <p className="lbh-body-s govuk-!-margin-top-4">
+          and {unfinishedSubmissionRes?.count - 4} more
+        </p>
       )}
     </li>
   );

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -54,18 +54,23 @@ const UnfinishedSubmissionsEvent = ({
       {error && (
         <ErrorMessage label="There was a problem fetching unfinished submissions" />
       )}
-      {unfinishedSubmissionRes?.items?.length === 0 && (
-        <p>No unfinished submissions to show</p>
-      )}
-      <ul className="lbh-list lbh-body-s">
-        {unfinishedSubmissionRes?.items.slice(0, 4).map((sub) => (
-          <Sub sub={sub} key={sub.submissionId} />
-        ))}
-      </ul>
-      {unfinishedSubmissionRes && unfinishedSubmissionRes?.items.length > 4 && (
-        <p className="lbh-body-s govuk-!-margin-top-4">
-          and {unfinishedSubmissionRes?.count - 4} more
-        </p>
+
+      {unfinishedSubmissionRes?.items !== undefined && (
+        <>
+          {unfinishedSubmissionRes.items.length === 0 && (
+            <p>No unfinished submissions to show</p>
+          )}
+          <ul className="lbh-list lbh-body-s">
+            {unfinishedSubmissionRes.items.slice(0, 4).map((sub) => (
+              <Sub sub={sub} key={sub.submissionId} />
+            ))}
+          </ul>
+          {unfinishedSubmissionRes.items.length > 4 && (
+            <p className="lbh-body-s govuk-!-margin-top-4">
+              and {unfinishedSubmissionRes?.count - 4} more
+            </p>
+          )}
+        </>
       )}
     </li>
   );

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -54,22 +54,21 @@ const UnfinishedSubmissionsEvent = ({
       {error && (
         <ErrorMessage label="There was a problem fetching unfinished submissions" />
       )}
-      {unfinishedSubmissionRes?.items?.length === 0 && (
+      {unfinishedSubmissionRes?.items?.length === 0 ? (
         <p>No unfinished submissions to show</p>
-      )}
-
-      {unfinishedSubmissionRes && unfinishedSubmissionRes.items.length > 0 && (
+      ) : (
         <>
           <ul className="lbh-list lbh-body-s">
             {unfinishedSubmissionRes?.items.slice(0, 4).map((sub) => (
               <Sub sub={sub} key={sub.submissionId} />
             ))}
           </ul>
-          {unfinishedSubmissionRes?.items.length > 4 && (
-            <p className="lbh-body-s govuk-!-margin-top-4">
-              and {unfinishedSubmissionRes?.count - 4} more
-            </p>
-          )}
+          {unfinishedSubmissionRes &&
+            unfinishedSubmissionRes?.items.length > 4 && (
+              <p className="lbh-body-s govuk-!-margin-top-4">
+                and {unfinishedSubmissionRes?.count - 4} more
+              </p>
+            )}
         </>
       )}
     </li>


### PR DESCRIPTION
**What**  

![Screenshot from 2021-09-15 17-12-07](https://user-images.githubusercontent.com/29123700/133471912-29f97bcc-2d79-44da-9e0b-04d94134332c.png)

^ should not be showing the 0...

**Why**  

It's a mistake, JSX if check meant to be comparing length and only showing unfinished submissions when the length is greater than 0, when you do something like 
```
{unfinishedSubmissionRes?.items?.length && ...}
```

in JSX if the left side of the && expression is true the right side JSX will get rendered, however if the left side is false(y) it actually displays 0, what you need to do is 

```
{unfinishedSubmissionRes?.items?.length > 0 && ...}
```

However, in this case we didn't even need the length check, if the length is 0 then we map over an empty list and render nothing which allowed reduction in nested if clauses.

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
