### PR TITLE
fix: Fetch unfinished submissions as paginated

### DIFF
--- a/components/NewPersonView/Layout.tsx
+++ b/components/NewPersonView/Layout.tsx
@@ -148,16 +148,6 @@ const Layout = ({ person, children }: Props): React.ReactElement => {
           </p>
 
           <ConditionalFeature name="case-status">
-            <span hidden>
-              {casestatus &&
-              !groupCaseStatusByType(casestatus.caseStatuses).has('CIN') &&
-              person.contextFlag === 'C'
-                ? secondaryNavigation.push({
-                    text: 'Add a case status',
-                    href: `/people/${person.id}/case-status/add`,
-                  })
-                : null}
-            </span>
             <CaseStatusView person={person} />
           </ConditionalFeature>
         </div>

--- a/components/NewPersonView/UnfinishedSubmissions.spec.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.spec.tsx
@@ -60,42 +60,13 @@ describe('UnfinishedSubmissions', () => {
     expect(screen.getAllByRole('link').length).toBe(3);
   });
 
-  it('truncates a long list', () => {
+  it('calculates item left based on paginated count', () => {
     jest
       .spyOn(submissionHooks, 'useUnfinishedSubmissions')
       .mockImplementation(() => {
         const response = {
           data: {
             items: [
-              mockInProgressSubmission,
-              mockInProgressSubmission,
-              mockInProgressSubmission,
-              mockInProgressSubmission,
-              mockInProgressSubmission,
-              mockInProgressSubmission,
-            ] as InProgressSubmission[],
-            count: 6,
-          },
-        } as SWRResponse<Paginated<InProgressSubmission>, ErrorAPI>;
-
-        return response;
-      });
-
-    render(<UnfinishedSubmissions personId={1} />);
-
-    expect(screen.getByText('and 2 more'));
-    expect(screen.getAllByRole('listitem').length).toBe(5);
-  });
-
-  it('calculates item left based on response count', () => {
-    jest
-      .spyOn(submissionHooks, 'useUnfinishedSubmissions')
-      .mockImplementation(() => {
-        const response = {
-          data: {
-            items: [
-              mockInProgressSubmission,
-              mockInProgressSubmission,
               mockInProgressSubmission,
               mockInProgressSubmission,
               mockInProgressSubmission,

--- a/components/NewPersonView/UnfinishedSubmissions.spec.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.spec.tsx
@@ -32,7 +32,7 @@ describe('UnfinishedSubmissions', () => {
 
     render(<UnfinishedSubmissions personId={mockPersonId} />);
 
-    expect(mock).toHaveBeenCalledWith(mockPersonId);
+    expect(mock).toHaveBeenCalledWith(mockPersonId, 1, 4);
   });
 
   it('renders a list of clickable submissions', () => {

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -43,7 +43,7 @@ const UnfinishedSubmissionsEvent = ({
     data: unfinishedSubmissionRes,
     isValidating,
     error,
-  } = useUnfinishedSubmissions(personId);
+  } = useUnfinishedSubmissions(personId, 1, 4);
 
   return (
     <li
@@ -61,11 +61,11 @@ const UnfinishedSubmissionsEvent = ({
             <p>No unfinished submissions to show</p>
           )}
           <ul className="lbh-list lbh-body-s">
-            {unfinishedSubmissionRes.items.slice(0, 4).map((sub) => (
+            {unfinishedSubmissionRes.items.map((sub) => (
               <Sub sub={sub} key={sub.submissionId} />
             ))}
           </ul>
-          {unfinishedSubmissionRes.items.length > 4 && (
+          {unfinishedSubmissionRes.count > 4 && (
             <p className="lbh-body-s govuk-!-margin-top-4">
               and {unfinishedSubmissionRes?.count - 4} more
             </p>

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -58,7 +58,7 @@ const UnfinishedSubmissionsEvent = ({
         <p>No unfinished submissions to show</p>
       )}
 
-      {unfinishedSubmissionRes?.items?.length && (
+      {unfinishedSubmissionRes && unfinishedSubmissionRes.items.length > 0 && (
         <>
           <ul className="lbh-list lbh-body-s">
             {unfinishedSubmissionRes?.items.slice(0, 4).map((sub) => (

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -54,22 +54,18 @@ const UnfinishedSubmissionsEvent = ({
       {error && (
         <ErrorMessage label="There was a problem fetching unfinished submissions" />
       )}
-      {unfinishedSubmissionRes?.items?.length === 0 ? (
+      {unfinishedSubmissionRes?.items?.length === 0 && (
         <p>No unfinished submissions to show</p>
-      ) : (
-        <>
-          <ul className="lbh-list lbh-body-s">
-            {unfinishedSubmissionRes?.items.slice(0, 4).map((sub) => (
-              <Sub sub={sub} key={sub.submissionId} />
-            ))}
-          </ul>
-          {unfinishedSubmissionRes &&
-            unfinishedSubmissionRes?.items.length > 4 && (
-              <p className="lbh-body-s govuk-!-margin-top-4">
-                and {unfinishedSubmissionRes?.count - 4} more
-              </p>
-            )}
-        </>
+      )}
+      <ul className="lbh-list lbh-body-s">
+        {unfinishedSubmissionRes?.items.slice(0, 4).map((sub) => (
+          <Sub sub={sub} key={sub.submissionId} />
+        ))}
+      </ul>
+      {unfinishedSubmissionRes && unfinishedSubmissionRes?.items.length > 4 && (
+        <p className="lbh-body-s govuk-!-margin-top-4">
+          and {unfinishedSubmissionRes?.count - 4} more
+        </p>
       )}
     </li>
   );

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -54,18 +54,23 @@ const UnfinishedSubmissionsEvent = ({
       {error && (
         <ErrorMessage label="There was a problem fetching unfinished submissions" />
       )}
-      {unfinishedSubmissionRes?.items?.length === 0 && (
-        <p>No unfinished submissions to show</p>
-      )}
-      <ul className="lbh-list lbh-body-s">
-        {unfinishedSubmissionRes?.items.slice(0, 4).map((sub) => (
-          <Sub sub={sub} key={sub.submissionId} />
-        ))}
-      </ul>
-      {unfinishedSubmissionRes && unfinishedSubmissionRes?.items.length > 4 && (
-        <p className="lbh-body-s govuk-!-margin-top-4">
-          and {unfinishedSubmissionRes?.count - 4} more
-        </p>
+
+      {unfinishedSubmissionRes?.items !== undefined && (
+        <>
+          {unfinishedSubmissionRes.items.length === 0 && (
+            <p>No unfinished submissions to show</p>
+          )}
+          <ul className="lbh-list lbh-body-s">
+            {unfinishedSubmissionRes.items.slice(0, 4).map((sub) => (
+              <Sub sub={sub} key={sub.submissionId} />
+            ))}
+          </ul>
+          {unfinishedSubmissionRes.items.length > 4 && (
+            <p className="lbh-body-s govuk-!-margin-top-4">
+              and {unfinishedSubmissionRes?.count - 4} more
+            </p>
+          )}
+        </>
       )}
     </li>
   );

--- a/components/NewPersonView/UnfinishedSubmissions.tsx
+++ b/components/NewPersonView/UnfinishedSubmissions.tsx
@@ -54,22 +54,21 @@ const UnfinishedSubmissionsEvent = ({
       {error && (
         <ErrorMessage label="There was a problem fetching unfinished submissions" />
       )}
-      {unfinishedSubmissionRes?.items?.length === 0 && (
+      {unfinishedSubmissionRes?.items?.length === 0 ? (
         <p>No unfinished submissions to show</p>
-      )}
-
-      {unfinishedSubmissionRes && unfinishedSubmissionRes.items.length > 0 && (
+      ) : (
         <>
           <ul className="lbh-list lbh-body-s">
             {unfinishedSubmissionRes?.items.slice(0, 4).map((sub) => (
               <Sub sub={sub} key={sub.submissionId} />
             ))}
           </ul>
-          {unfinishedSubmissionRes?.items.length > 4 && (
-            <p className="lbh-body-s govuk-!-margin-top-4">
-              and {unfinishedSubmissionRes?.count - 4} more
-            </p>
-          )}
+          {unfinishedSubmissionRes &&
+            unfinishedSubmissionRes?.items.length > 4 && (
+              <p className="lbh-body-s govuk-!-margin-top-4">
+                and {unfinishedSubmissionRes?.count - 4} more
+              </p>
+            )}
         </>
       )}
     </li>

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -26,7 +26,9 @@ const headersWithKey = {
 export const getInProgressSubmissions = async (
   ageContext?: AgeContext,
   personID?: number,
-  workerEmail?: string
+  workerEmail?: string,
+  page = 1,
+  size = 1000
 ): Promise<Paginated<InProgressSubmission>> => {
   const ageContextQuery =
     ageContext !== undefined ? `&ageContext=${ageContext}` : '';
@@ -37,7 +39,7 @@ export const getInProgressSubmissions = async (
     workerEmail !== undefined ? `&workerEmail=${workerEmail}` : '';
 
   const { data } = await axios.get<Paginated<InProgressSubmission>>(
-    `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=1&size=1000${ageContextQuery}${personIdQuery}${workerEmailQuery}`,
+    `${ENDPOINT_API}/submissions?submissionStates=in_progress&page=${page}&size=${size}${ageContextQuery}${personIdQuery}${workerEmailQuery}`,
     {
       headers: headersWithKey,
     }

--- a/pages/api/submissions/index.ts
+++ b/pages/api/submissions/index.ts
@@ -22,11 +22,14 @@ const handler = async (
       break;
     case 'GET':
       {
-        const { personID } = req.query;
+        const { personID, page, size } = req.query;
 
         const submissions = await getInProgressSubmissions(
           user?.permissionFlag,
-          Number(personID)
+          Number(personID),
+          undefined,
+          Number(page),
+          Number(size)
         );
         res.json(submissions);
       }

--- a/utils/api/submissions.spec.ts
+++ b/utils/api/submissions.spec.ts
@@ -7,7 +7,7 @@ describe('submissions APIs', () => {
   describe('useUnfinishedSubmissions', () => {
     it('should call swr and pass the person id as a query filter', () => {
       jest.spyOn(SWR, 'default');
-      useUnfinishedSubmissions(1);
+      useUnfinishedSubmissions(1, 1, 5);
       expect(SWR.default).toHaveBeenLastCalledWith(
         '/api/submissions?page=1&size=5&personID=1&submissionStates=in_progress'
       );

--- a/utils/api/submissions.ts
+++ b/utils/api/submissions.ts
@@ -23,12 +23,14 @@ export const useSubmission = (
 
 /** fetch unfinished submissions in the user's current service context, either for everyone, or by social care id */
 export const useUnfinishedSubmissions = (
-  socialCareId: number
+  socialCareId: number,
+  page: number,
+  size: number
 ): SWRResponse<Paginated<InProgressSubmission>, ErrorAPI> => {
   const personIdQuery = `&personID=${socialCareId}`;
 
   const res: SWRResponse<Paginated<InProgressSubmission>, ErrorAPI> = useSWR(
-    `/api/submissions?page=1&size=5${personIdQuery}&submissionStates=in_progress`
+    `/api/submissions?page=${page}&size=${size}${personIdQuery}&submissionStates=in_progress`
   );
 
   return res;


### PR DESCRIPTION
**What**  
Make a sensible paginated request for unfinished submissions as we currently only display 4.

**Why**  

Before

![Screenshot from 2021-09-16 00-31-24](https://user-images.githubusercontent.com/29123700/133526410-42c3985f-5959-41d2-8601-e29450bf5ad6.png)

After

![Screenshot from 2021-09-16 00-31-45](https://user-images.githubusercontent.com/29123700/133526416-53ac8543-b5f3-4641-b1b8-a956e30f6e44.png)

Admittedly I hope there aren't people on the system with 100's (242) of unfinished submissions like this staging user.

http://dev.hackney.gov.uk:3000/people/1

See a 89% decrease in response time.
See a 96% decrease in response size.

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
