### PR TITLE
chore: Upgrade set-value to version 4.0.1 or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "restana": "^4.9.1",
     "serve-static": "^1.14.1",
     "serverless-http": "^2.7.0",
+    "set-value": "^4.1.0",
     "swr": "^0.5.6",
     "uk-postcode-validator": "^1.1.1",
     "use-resize-observer": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9113,6 +9113,11 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
+is-primitive@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-3.0.1.tgz#98c4db1abff185485a657fc2905052b940524d05"
+  integrity sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==
+
 is-promise@^2.1.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
@@ -13661,6 +13666,14 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
+
+set-value@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-4.1.0.tgz#aa433662d87081b75ad88a4743bd450f044e7d09"
+  integrity sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==
+  dependencies:
+    is-plain-object "^2.0.4"
+    is-primitive "^3.0.1"
 
 setimmediate@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
Dependabot raised a security alert [here](https://github.com/LBHackney-IT/lbh-social-care-frontend/security/dependabot/yarn.lock/set-value/open) about the set-value package needing an upgrade to a version that has been patched to fix a vulnerability.

It seems Dependabot was unable to do this automatically, so this PR manually attempts to fix the issue raised.