### PR TITLE
feat(SCT-1055): Add CP option to the case status add form UI

### DIFF
--- a/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.spec.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.spec.tsx
@@ -5,7 +5,7 @@ import { residentFactory } from 'factories/residents';
 const mockedResident = residentFactory.build();
 
 describe('AddCaseStatusForm - CIN', () => {
-  it('displays the form', () => {
+  it('displays CIN type option in the form', () => {
     const { getByText } = render(
       <AddCaseStatusForm personId={mockedResident.id} prefilledFields={{}} />
     );
@@ -13,7 +13,7 @@ describe('AddCaseStatusForm - CIN', () => {
     expect(getByText('Child in need')).toBeInTheDocument();
   });
 
-  it('should disable the submit button when not completed', () => {
+  it('should disable the submit button when no type has been selected', () => {
     const { getByTestId } = render(
       <AddCaseStatusForm personId={mockedResident.id} prefilledFields={{}} />
     );
@@ -28,7 +28,6 @@ describe('AddCaseStatusForm - CIN', () => {
 
     fireEvent.click(getByText('Child in need'));
 
-    expect(getByText('Child in need')).toBeInTheDocument();
     expect(getByText('Start Date')).toBeInTheDocument();
     expect(getByText('Notes')).toBeInTheDocument();
   });
@@ -85,19 +84,18 @@ describe('AddCaseStatusForm - CP', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('displays start date and category when selecting CP', () => {
+  it('displays start date and category question when CP is selected', () => {
     const { getByText } = render(
       <AddCaseStatusForm personId={mockedResident.id} prefilledFields={{}} />
     );
 
     fireEvent.click(getByText('Child protection'));
 
-    expect(getByText('Child protection')).toBeInTheDocument();
     expect(getByText('Start Date')).toBeInTheDocument();
     expect(getByText('Category of child protection plan')).toBeInTheDocument();
   });
 
-  it('displays the category options when selecting CP', () => {
+  it('displays the category options when CP is selected', () => {
     const { getByText } = render(
       <AddCaseStatusForm personId={mockedResident.id} prefilledFields={{}} />
     );
@@ -108,7 +106,21 @@ describe('AddCaseStatusForm - CP', () => {
     expect(getByText('Physical abuse')).toBeInTheDocument();
     expect(getByText('Emotional abuse')).toBeInTheDocument();
     expect(getByText('Sexual abuse')).toBeInTheDocument();
+  });
+
+  it('pre-select CP and fills the other fields', () => {
+    const { getByText } = render(
+      <AddCaseStatusForm
+        personId={mockedResident.id}
+        prefilledFields={{
+          type: 'CP',
+          category: 'C1',
+        }}
+      />
+    );
+
+    expect(getByText('Child protection')).toBeInTheDocument();
     expect(getByText('Start Date')).toBeInTheDocument();
-    expect(getByText('Category of child protection plan')).toBeInTheDocument();
+    expect(getByText('Neglect')).toBeInTheDocument();
   });
 });

--- a/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.spec.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.spec.tsx
@@ -75,7 +75,7 @@ describe('AddCaseStatusForm - CP', () => {
     expect(getByText('Child protection')).toBeInTheDocument();
   });
 
-  it('displays start date and protection categories when selecting CP', () => {
+  it('displays start date when selecting CP', () => {
     const { getByText } = render(
       <AddCaseStatusForm personId={mockedResident.id} prefilledFields={{}} />
     );

--- a/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.spec.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.spec.tsx
@@ -65,3 +65,24 @@ describe('AddCaseStatusForm - CIN', () => {
     expect(getByText('this is a note')).toBeInTheDocument();
   });
 });
+
+describe('AddCaseStatusForm - CP', () => {
+  it('displays the form', () => {
+    const { getByText } = render(
+      <AddCaseStatusForm personId={mockedResident.id} prefilledFields={{}} />
+    );
+
+    expect(getByText('Child protection')).toBeInTheDocument();
+  });
+
+  it('displays start date and protection categories when selecting CP', () => {
+    const { getByText } = render(
+      <AddCaseStatusForm personId={mockedResident.id} prefilledFields={{}} />
+    );
+
+    fireEvent.click(getByText('Child protection'));
+
+    expect(getByText('Child protection')).toBeInTheDocument();
+    expect(getByText('Start Date')).toBeInTheDocument();
+  });
+});

--- a/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.spec.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.spec.tsx
@@ -75,7 +75,17 @@ describe('AddCaseStatusForm - CP', () => {
     expect(getByText('Child protection')).toBeInTheDocument();
   });
 
-  it('displays start date when selecting CP', () => {
+  it('does not display category question unless CP is clicked the form', () => {
+    const { queryByText } = render(
+      <AddCaseStatusForm personId={mockedResident.id} prefilledFields={{}} />
+    );
+
+    expect(
+      queryByText('Category of child protection plan')
+    ).not.toBeInTheDocument();
+  });
+
+  it('displays start date and category when selecting CP', () => {
     const { getByText } = render(
       <AddCaseStatusForm personId={mockedResident.id} prefilledFields={{}} />
     );
@@ -84,5 +94,21 @@ describe('AddCaseStatusForm - CP', () => {
 
     expect(getByText('Child protection')).toBeInTheDocument();
     expect(getByText('Start Date')).toBeInTheDocument();
+    expect(getByText('Category of child protection plan')).toBeInTheDocument();
+  });
+
+  it('displays the category options when selecting CP', () => {
+    const { getByText } = render(
+      <AddCaseStatusForm personId={mockedResident.id} prefilledFields={{}} />
+    );
+
+    fireEvent.click(getByText('Child protection'));
+
+    expect(getByText('Neglect')).toBeInTheDocument();
+    expect(getByText('Physical abuse')).toBeInTheDocument();
+    expect(getByText('Emotional abuse')).toBeInTheDocument();
+    expect(getByText('Sexual abuse')).toBeInTheDocument();
+    expect(getByText('Start Date')).toBeInTheDocument();
+    expect(getByText('Category of child protection plan')).toBeInTheDocument();
   });
 });

--- a/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
@@ -64,7 +64,7 @@ const AddCaseStatusForm: React.FC<{
           ...values,
         },
       });
-    } catch (e) {
+    } catch (e: any) {
       setStatus(e.toString());
     }
   };

--- a/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
@@ -15,7 +15,7 @@ const AddCaseStatusForm: React.FC<{
 }> = ({ personId, prefilledFields }) => {
   const router = useRouter();
 
-  const form_fields = CASE_STATUS.steps[0].fields;
+  const form_fields = [...CASE_STATUS.steps[0].fields];
   const { data: CpCaseStatusFields } = useFormValues('CP');
 
   form_fields.map((field) => {

--- a/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
@@ -6,6 +6,8 @@ import FlexibleField from 'components/FlexibleForms/FlexibleFields';
 import Button from 'components/Button/Button';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useFormValues } from 'utils/api/caseStatus';
+import { Choice, Field } from 'data/flexibleForms/forms.types';
 
 const AddCaseStatusForm: React.FC<{
   personId: number;
@@ -13,12 +15,41 @@ const AddCaseStatusForm: React.FC<{
 }> = ({ personId, prefilledFields }) => {
   const router = useRouter();
   const form_fields = CASE_STATUS.steps[0].fields;
+  const { data: CpCaseStatusFields } = useFormValues('CP');
 
   form_fields.map((field) => {
     if (prefilledFields && prefilledFields[field.id]) {
       field.default = String(prefilledFields[field.id]);
     }
   });
+
+  if (CpCaseStatusFields) {
+    CpCaseStatusFields.fields.map((field) => {
+      const choices: Choice[] = [];
+      field.options.map((option: any) => {
+        choices.push({
+          value: option.name,
+          label: option.description,
+        });
+      });
+
+      const cpFieldObj: Field = {
+        id: field.name,
+        question: field.description,
+        type: 'radios',
+        required: true,
+        conditions: [
+          {
+            id: 'type',
+            value: 'CP',
+          },
+        ],
+        choices: choices,
+      };
+
+      form_fields.push(cpFieldObj);
+    });
+  }
 
   const handleSubmit = async (
     values: FormikValues,

--- a/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
@@ -14,6 +14,7 @@ const AddCaseStatusForm: React.FC<{
   prefilledFields: any;
 }> = ({ personId, prefilledFields }) => {
   const router = useRouter();
+
   const form_fields = CASE_STATUS.steps[0].fields;
   const { data: CpCaseStatusFields } = useFormValues('CP');
 

--- a/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
@@ -89,7 +89,7 @@ const AddCaseStatusForm: React.FC<{
 
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <Button
-              label="Submit"
+              label="Continue"
               disabled={values.type == '' || Object.keys(errors).length > 0}
               type="submit"
               data-testid="submit_button"

--- a/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
@@ -60,9 +60,7 @@ const AddCaseStatusForm: React.FC<{
         pathname: `/people/${personId}/case-status/add/review`,
         query: {
           personId: personId,
-          type: values.type,
-          startDate: values.startDate,
-          notes: values.notes,
+          ...values,
         },
       });
     } catch (e) {

--- a/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/AddCaseStatusForm.tsx
@@ -6,8 +6,6 @@ import FlexibleField from 'components/FlexibleForms/FlexibleFields';
 import Button from 'components/Button/Button';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useFormValues } from 'utils/api/caseStatus';
-import { Choice, Field } from 'data/flexibleForms/forms.types';
 
 const AddCaseStatusForm: React.FC<{
   personId: number;
@@ -16,41 +14,12 @@ const AddCaseStatusForm: React.FC<{
   const router = useRouter();
 
   const form_fields = [...CASE_STATUS.steps[0].fields];
-  const { data: CpCaseStatusFields } = useFormValues('CP');
 
   form_fields.map((field) => {
     if (prefilledFields && prefilledFields[field.id]) {
       field.default = String(prefilledFields[field.id]);
     }
   });
-
-  if (CpCaseStatusFields) {
-    CpCaseStatusFields.fields.map((field) => {
-      const choices: Choice[] = [];
-      field.options.map((option: any) => {
-        choices.push({
-          value: option.name,
-          label: option.description,
-        });
-      });
-
-      const cpFieldObj: Field = {
-        id: field.name,
-        question: field.description,
-        type: 'radios',
-        required: true,
-        conditions: [
-          {
-            id: 'type',
-            value: 'CP',
-          },
-        ],
-        choices: choices,
-      };
-
-      form_fields.push(cpFieldObj);
-    });
-  }
 
   const handleSubmit = async (
     values: FormikValues,

--- a/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.spec.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.spec.tsx
@@ -50,17 +50,29 @@ describe('ReviewAddRelationshipForm', () => {
         formAnswers={{
           type: 'CP',
           startDate: '2020-12-01',
-          fields: [
-            {
-              name: 'placementReason',
-              selected: 'C1',
-            },
-          ],
+          category: 'C1',
         }}
       />
     );
 
     expect(getByText('Child protection')).toBeInTheDocument();
+    expect(getByText('01 Dec 2020')).toBeInTheDocument();
+  });
+
+  it('displays selected category when CP is selected', () => {
+    const { getByText } = render(
+      <ReviewAddCaseStatusForm
+        title="Review case status details"
+        personId={mockedResident.id}
+        formAnswers={{
+          type: 'CP',
+          startDate: '2020-12-01',
+          category: 'C1',
+        }}
+      />
+    );
+
+    expect(getByText('Neglect')).toBeInTheDocument();
     expect(getByText('01 Dec 2020')).toBeInTheDocument();
   });
 });

--- a/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.spec.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.spec.tsx
@@ -41,4 +41,27 @@ describe('ReviewAddRelationshipForm', () => {
     expect(getByText('blabla')).toBeInTheDocument();
     expect(getByText('01 Dec 2020')).toBeInTheDocument();
   });
+
+  it('displays type, date and reason for placement when CP is selected', () => {
+    const { getByText } = render(
+      <ReviewAddCaseStatusForm
+        title="Review case status details"
+        personId={mockedResident.id}
+        formAnswers={{
+          type: 'CP',
+          startDate: '2020-12-01',
+          fields: [
+            {
+              name: 'placementReason',
+              selected: 'C1',
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(getByText('Child protection')).toBeInTheDocument();
+    expect(getByText('01 Dec 2020')).toBeInTheDocument();
+    expect(getByText('Reason for placement')).toBeInTheDocument();
+  });
 });

--- a/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.spec.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.spec.tsx
@@ -42,7 +42,7 @@ describe('ReviewAddRelationshipForm', () => {
     expect(getByText('01 Dec 2020')).toBeInTheDocument();
   });
 
-  it('displays type, date and reason for placement when CP is selected', () => {
+  it('displays type and date when CP is selected', () => {
     const { getByText } = render(
       <ReviewAddCaseStatusForm
         title="Review case status details"
@@ -62,6 +62,5 @@ describe('ReviewAddRelationshipForm', () => {
 
     expect(getByText('Child protection')).toBeInTheDocument();
     expect(getByText('01 Dec 2020')).toBeInTheDocument();
-    expect(getByText('Reason for placement')).toBeInTheDocument();
   });
 });

--- a/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.tsx
@@ -2,11 +2,10 @@ import FlexibleAnswers from 'components/FlexibleAnswers/FlexibleAnswers';
 import Button from 'components/Button/Button';
 import Link from 'next/link';
 import Banner from 'components/FlexibleForms/Banner';
-import { User, CaseStatusMapping } from 'types';
+import { User, CaseStatusMapping, ChildProtectionCategoryOptions } from 'types';
 import { FlexibleAnswers as FlexibleAnswersT } from 'data/flexibleForms/forms.types';
 import { useState } from 'react';
 import { addCaseStatus } from 'utils/api/caseStatus';
-import { useFormValues } from 'utils/api/caseStatus';
 import { useAuth } from 'components/UserContext/UserContext';
 import { useRouter } from 'next/router';
 
@@ -20,7 +19,6 @@ const ReviewAddCaseStatusForm: React.FC<{
   const { user } = useAuth() as { user: User };
 
   const valueMapping = new CaseStatusMapping();
-  const { data: cpCaseStatusFields } = useFormValues('CP');
 
   const submitAnswers = async () => {
     try {
@@ -49,7 +47,7 @@ const ReviewAddCaseStatusForm: React.FC<{
     }
   };
 
-  const diplayObj: any = {
+  const displayObj: any = {
     Type: [valueMapping[formAnswers.type as keyof CaseStatusMapping]],
     'Start date': new Date(formAnswers.startDate).toLocaleDateString('en-GB', {
       day: '2-digit',
@@ -57,25 +55,15 @@ const ReviewAddCaseStatusForm: React.FC<{
       year: 'numeric',
     }),
     Notes: String(formAnswers.notes),
+    'Category of child protection plan':
+      ChildProtectionCategoryOptions[
+        formAnswers.category as keyof typeof ChildProtectionCategoryOptions
+      ],
   };
-
-  if (cpCaseStatusFields) {
-    cpCaseStatusFields.fields.map((reason) => {
-      Object.keys(formAnswers).map((selectedOption) => {
-        if (selectedOption === reason.name) {
-          reason.options.map((option) => {
-            if (option.name === formAnswers[selectedOption]) {
-              diplayObj[reason.description] = option.description;
-            }
-          });
-        }
-      });
-    });
-  }
 
   const displayValue: FlexibleAnswersT = {
     answers: {
-      ...diplayObj,
+      ...displayObj,
     },
   };
 

--- a/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.tsx
@@ -20,7 +20,7 @@ const ReviewAddCaseStatusForm: React.FC<{
   const { user } = useAuth() as { user: User };
 
   const valueMapping = new CaseStatusMapping();
-  const { data: caseStatusFields } = useFormValues('CP');
+  const { data: cpCaseStatusFields } = useFormValues('CP');
 
   const submitAnswers = async () => {
     try {
@@ -29,6 +29,12 @@ const ReviewAddCaseStatusForm: React.FC<{
         type: String(formAnswers.type),
         startDate: String(formAnswers.startDate),
         notes: String(formAnswers.notes),
+        fields: [
+          {
+            name: 'category',
+            selected: String(formAnswers.category),
+          },
+        ],
         createdby: user.email,
       });
 
@@ -43,19 +49,33 @@ const ReviewAddCaseStatusForm: React.FC<{
     }
   };
 
+  const diplayObj: any = {
+    Type: [valueMapping[formAnswers.type as keyof CaseStatusMapping]],
+    'Start date': new Date(formAnswers.startDate).toLocaleDateString('en-GB', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    }),
+    Notes: String(formAnswers.notes),
+  };
+
+  if (cpCaseStatusFields) {
+    cpCaseStatusFields.fields.map((elmField) => {
+      Object.keys(formAnswers).map((elm) => {
+        if (elm === elmField.name) {
+          elmField.options.map((option) => {
+            if (option.name === formAnswers[elm]) {
+              diplayObj[elmField.description] = option.description;
+            }
+          });
+        }
+      });
+    });
+  }
+
   const displayValue: FlexibleAnswersT = {
     answers: {
-      Type: [valueMapping[formAnswers.type as keyof CaseStatusMapping]],
-      'Start date': new Date(formAnswers.startDate).toLocaleDateString(
-        'en-GB',
-        {
-          day: '2-digit',
-          month: 'short',
-          year: 'numeric',
-        }
-      ),
-      Notes: String(formAnswers.notes),
-      'Reason for placement': String(formAnswers.category),
+      ...diplayObj,
     },
   };
 

--- a/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.tsx
@@ -97,7 +97,11 @@ const ReviewAddCaseStatusForm: React.FC<{
       <div>
         <p className="lbh-body">Do you want to add this case status?</p>
         <div style={{ display: 'flex', alignItems: 'center' }}>
-          <Button label="Yes, add" onClick={submitAnswers} wideButton />
+          <Button
+            label="Yes, add this status"
+            onClick={submitAnswers}
+            wideButton
+          />
           <Link
             href={{
               pathname: `/people/${personId}/case-status/add`,

--- a/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.tsx
@@ -6,6 +6,7 @@ import { User, CaseStatusMapping } from 'types';
 import { FlexibleAnswers as FlexibleAnswersT } from 'data/flexibleForms/forms.types';
 import { useState } from 'react';
 import { addCaseStatus } from 'utils/api/caseStatus';
+import { useFormValues } from 'utils/api/caseStatus';
 import { useAuth } from 'components/UserContext/UserContext';
 import { useRouter } from 'next/router';
 
@@ -19,6 +20,7 @@ const ReviewAddCaseStatusForm: React.FC<{
   const { user } = useAuth() as { user: User };
 
   const valueMapping = new CaseStatusMapping();
+  const { data: caseStatusFields } = useFormValues('CP');
 
   const submitAnswers = async () => {
     try {
@@ -53,6 +55,7 @@ const ReviewAddCaseStatusForm: React.FC<{
         }
       ),
       Notes: String(formAnswers.notes),
+      'Reason for placement': String(formAnswers.category),
     },
   };
 

--- a/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.tsx
@@ -60,12 +60,12 @@ const ReviewAddCaseStatusForm: React.FC<{
   };
 
   if (cpCaseStatusFields) {
-    cpCaseStatusFields.fields.map((elmField) => {
-      Object.keys(formAnswers).map((elm) => {
-        if (elm === elmField.name) {
-          elmField.options.map((option) => {
-            if (option.name === formAnswers[elm]) {
-              diplayObj[elmField.description] = option.description;
+    cpCaseStatusFields.fields.map((reason) => {
+      Object.keys(formAnswers).map((selectedOption) => {
+        if (selectedOption === reason.name) {
+          reason.options.map((option) => {
+            if (option.name === formAnswers[selectedOption]) {
+              diplayObj[reason.description] = option.description;
             }
           });
         }

--- a/data/flexibleForms/caseStatus.ts
+++ b/data/flexibleForms/caseStatus.ts
@@ -25,6 +25,10 @@ const form: Form = {
               value: 'CIN',
               label: 'Child in need',
             },
+            {
+              value: 'CP',
+              label: 'Child protection',
+            },
           ],
         },
         {
@@ -53,6 +57,21 @@ const form: Form = {
           ],
           type: 'textarea',
           required: false,
+        },
+        {
+          id: 'startDate',
+          question: 'Start Date',
+          type: 'date',
+          required: true,
+          conditions: [
+            {
+              id: 'type',
+              value: 'CP',
+            },
+          ],
+          className: 'govuk-input--width-10',
+          default: format(new Date(), 'yyyy-MM-dd'),
+          isfutureDateValid: false,
         },
       ],
     },

--- a/data/flexibleForms/caseStatus.ts
+++ b/data/flexibleForms/caseStatus.ts
@@ -73,6 +73,36 @@ const form: Form = {
           default: format(new Date(), 'yyyy-MM-dd'),
           isfutureDateValid: false,
         },
+        {
+          id: 'category',
+          question: 'Category of child protection plan',
+          type: 'radios',
+          conditions: [
+            {
+              id: 'type',
+              value: 'CP',
+            },
+          ],
+          choices: [
+            {
+              value: 'C1',
+              label: 'Neglect',
+            },
+            {
+              value: 'C2',
+              label: 'Physical abuse',
+            },
+            {
+              value: 'C3',
+              label: 'Emotional abuse',
+            },
+            {
+              value: 'C4',
+              label: 'Sexual abuse',
+            },
+          ],
+          required: true,
+        },
       ],
     },
   ],

--- a/types.ts
+++ b/types.ts
@@ -355,6 +355,13 @@ export class CaseStatusMapping {
   'LAC' = 'Looked after child';
 }
 
+export enum ChildProtectionCategoryOptions {
+  C1 = 'Neglect',
+  C2 = 'Physical abuse',
+  C3 = 'Emotional abuse',
+  C4 = 'Sexual abuse',
+}
+
 export interface AddCaseStatusFormData {
   personId: number;
   type: string;

--- a/utils/api/caseStatus.spec.ts
+++ b/utils/api/caseStatus.spec.ts
@@ -22,7 +22,7 @@ describe('caseStatusAPI', () => {
 
       caseStatusAPI.useFormValues('CIN');
       expect(SWR.default).toHaveBeenCalledWith(
-        '/api/casestatus/form-options/CIN'
+        '/api/casestatus/form-options?type=CIN'
       );
     });
   });

--- a/utils/api/caseStatus.ts
+++ b/utils/api/caseStatus.ts
@@ -24,4 +24,4 @@ export const useCaseStatuses = (
 export const useFormValues = (
   type: string
 ): SWRResponse<FormFields, ErrorAPI> =>
-  useSWR(`/api/casestatus/form-options/${type}`);
+  useSWR(`/api/casestatus/form-options?type=${type}`);


### PR DESCRIPTION
**What**  
This adds changes that would allow a user to add a CP case status with a specific category to a child resident.

**Why**  
Users want to be able to add and view a CP case status saved on a child resident.
