### PR TITLE
fix: update return type when getting case statuses by person id

### DIFF
--- a/components/CaseStatus/CaseStatusDetails.spec.tsx
+++ b/components/CaseStatus/CaseStatusDetails.spec.tsx
@@ -2,10 +2,7 @@ import { render, fireEvent } from '@testing-library/react';
 import * as caseStatusApi from 'utils/api/caseStatus';
 import CaseStatusDetails from './CaseStatusDetails';
 import { mockedAPIservererror } from 'factories/APIerrors';
-import {
-  mockedCaseStatusFactory,
-  mockedPersonCaseStatusFactory,
-} from 'factories/caseStatus';
+import { mockedCaseStatusFactory } from 'factories/caseStatus';
 import { mockedResident } from 'factories/residents';
 
 jest.mock('next/router', () => ({
@@ -19,10 +16,7 @@ jest.mock('next/router', () => ({
 describe('CaseStatusDetail component', () => {
   it("displays nothing if there's no case status", async () => {
     jest.spyOn(caseStatusApi, 'useCaseStatuses').mockImplementation(() => ({
-      data: mockedPersonCaseStatusFactory.build({
-        personId: mockedResident.id,
-        caseStatuses: [],
-      }),
+      data: [],
       isValidating: false,
       mutate: jest.fn(),
       revalidate: jest.fn(),
@@ -37,15 +31,12 @@ describe('CaseStatusDetail component', () => {
 
   it('displays correctly the start date', async () => {
     jest.spyOn(caseStatusApi, 'useCaseStatuses').mockImplementation(() => ({
-      data: mockedPersonCaseStatusFactory.build({
-        personId: mockedResident.id,
-        caseStatuses: [
-          mockedCaseStatusFactory.build({
-            type: 'CIN',
-            startDate: '2021-09-09',
-          }),
-        ],
-      }),
+      data: [
+        mockedCaseStatusFactory.build({
+          type: 'CIN',
+          startDate: '2021-09-09',
+        }),
+      ],
       isValidating: false,
       mutate: jest.fn(),
       revalidate: jest.fn(),
@@ -61,16 +52,13 @@ describe('CaseStatusDetail component', () => {
 
   it('displays correctly the end date', async () => {
     jest.spyOn(caseStatusApi, 'useCaseStatuses').mockImplementation(() => ({
-      data: mockedPersonCaseStatusFactory.build({
-        personId: mockedResident.id,
-        caseStatuses: [
-          mockedCaseStatusFactory.build({
-            type: 'CIN',
-            startDate: '2021-09-09',
-            endDate: '2021-12-09',
-          }),
-        ],
-      }),
+      data: [
+        mockedCaseStatusFactory.build({
+          type: 'CIN',
+          startDate: '2021-09-09',
+          endDate: '2021-12-09',
+        }),
+      ],
       isValidating: false,
       mutate: jest.fn(),
       revalidate: jest.fn(),
@@ -88,15 +76,12 @@ describe('CaseStatusDetail component', () => {
 
   it('displays the notes of a person when the detail panel is expanded', async () => {
     jest.spyOn(caseStatusApi, 'useCaseStatuses').mockImplementation(() => ({
-      data: mockedPersonCaseStatusFactory.build({
-        personId: mockedResident.id,
-        caseStatuses: [
-          mockedCaseStatusFactory.build({
-            type: 'CIN',
-            notes: 'This is a note',
-          }),
-        ],
-      }),
+      data: [
+        mockedCaseStatusFactory.build({
+          type: 'CIN',
+          notes: 'This is a note',
+        }),
+      ],
       isValidating: false,
       mutate: jest.fn(),
       revalidate: jest.fn(),
@@ -114,19 +99,16 @@ describe('CaseStatusDetail component', () => {
 
   it('displays multiple CIN in case they exist', async () => {
     jest.spyOn(caseStatusApi, 'useCaseStatuses').mockImplementation(() => ({
-      data: mockedPersonCaseStatusFactory.build({
-        personId: mockedResident.id,
-        caseStatuses: [
-          mockedCaseStatusFactory.build({
-            type: 'CIN',
-            notes: 'first note',
-          }),
-          mockedCaseStatusFactory.build({
-            type: 'CIN',
-            notes: 'second note',
-          }),
-        ],
-      }),
+      data: [
+        mockedCaseStatusFactory.build({
+          type: 'CIN',
+          notes: 'first note',
+        }),
+        mockedCaseStatusFactory.build({
+          type: 'CIN',
+          notes: 'first note',
+        }),
+      ],
       isValidating: false,
       mutate: jest.fn(),
       revalidate: jest.fn(),

--- a/components/CaseStatus/CaseStatusDetails.tsx
+++ b/components/CaseStatus/CaseStatusDetails.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const CaseStatusDetails = ({ person }: Props): React.ReactElement => {
-  const { data: caseStatusData, error } = useCaseStatuses(person.id);
+  const { data: caseStatuses, error } = useCaseStatuses(person.id);
   const valueMapping = new CaseStatusMapping();
 
   if (error) {
@@ -23,7 +23,7 @@ const CaseStatusDetails = ({ person }: Props): React.ReactElement => {
     );
   }
 
-  if (!caseStatusData) {
+  if (!caseStatuses) {
     return <></>;
   }
   return (
@@ -31,7 +31,7 @@ const CaseStatusDetails = ({ person }: Props): React.ReactElement => {
       <div>
         <h2 style={{ fontSize: '24px' }}>Case statuses</h2>
 
-        {caseStatusData.caseStatuses.map((status: CaseStatus) => {
+        {caseStatuses.map((status: CaseStatus) => {
           const title = (
             <div className={styles.align}>
               {status.type && (

--- a/components/CaseStatus/CaseStatusView.spec.tsx
+++ b/components/CaseStatus/CaseStatusView.spec.tsx
@@ -3,11 +3,9 @@ import * as caseStatusApi from 'utils/api/caseStatus';
 import { mockedAPIservererror } from 'factories/APIerrors';
 import CaseStatusView from './CaseStatusView';
 
-import {
-  mockedCaseStatusFactory,
-  mockedPersonCaseStatusFactory,
-} from 'factories/caseStatus';
+import { mockedCaseStatusFactory } from 'factories/caseStatus';
 import { mockedResident } from 'factories/residents';
+import { CaseStatus } from 'types';
 
 jest.mock('next/router', () => ({
   useRouter: () => ({
@@ -22,16 +20,13 @@ jest.mock('components/Spinner/Spinner', () => () => 'MockedSpinner');
 const person = mockedResident;
 
 describe('CaseStatusView component', () => {
-  it('displays the casestatus of a person', async () => {
+  it('displays the case status of a person', async () => {
     jest.spyOn(caseStatusApi, 'useCaseStatuses').mockImplementation(() => ({
-      data: mockedPersonCaseStatusFactory.build({
-        personId: person.id,
-        caseStatuses: [
-          mockedCaseStatusFactory.build({
-            type: 'CIN',
-          }),
-        ],
-      }),
+      data: [
+        mockedCaseStatusFactory.build({
+          type: 'CIN',
+        }),
+      ],
       isValidating: false,
       mutate: jest.fn(),
       revalidate: jest.fn(),
@@ -44,17 +39,14 @@ describe('CaseStatusView component', () => {
 
   it('displays only one "CIN" in case they are multiple', async () => {
     jest.spyOn(caseStatusApi, 'useCaseStatuses').mockImplementation(() => ({
-      data: mockedPersonCaseStatusFactory.build({
-        personId: person.id,
-        caseStatuses: [
-          mockedCaseStatusFactory.build({
-            type: 'CIN',
-          }),
-          mockedCaseStatusFactory.build({
-            type: 'CIN',
-          }),
-        ],
-      }),
+      data: [
+        mockedCaseStatusFactory.build({
+          type: 'CIN',
+        }),
+        mockedCaseStatusFactory.build({
+          type: 'CIN',
+        }),
+      ],
       isValidating: false,
       mutate: jest.fn(),
       revalidate: jest.fn(),
@@ -64,22 +56,19 @@ describe('CaseStatusView component', () => {
     expect(queryByText('Child in need')).toBeInTheDocument();
   });
 
-  it('displays only one "CIN", one "CPP" and one "LAC"', async () => {
+  it('displays only one "CIN", one "CP" and one "LAC"', async () => {
     jest.spyOn(caseStatusApi, 'useCaseStatuses').mockImplementation(() => ({
-      data: mockedPersonCaseStatusFactory.build({
-        personId: person.id,
-        caseStatuses: [
-          mockedCaseStatusFactory.build({
-            type: 'CIN',
-          }),
-          mockedCaseStatusFactory.build({
-            type: 'CP',
-          }),
-          mockedCaseStatusFactory.build({
-            type: 'LAC',
-          }),
-        ],
-      }),
+      data: [
+        mockedCaseStatusFactory.build({
+          type: 'CIN',
+        }),
+        mockedCaseStatusFactory.build({
+          type: 'CP',
+        }),
+        mockedCaseStatusFactory.build({
+          type: 'LAC',
+        }),
+      ],
       isValidating: false,
       mutate: jest.fn(),
       revalidate: jest.fn(),
@@ -94,10 +83,7 @@ describe('CaseStatusView component', () => {
 
   it("displays nothing if there's no case status", async () => {
     jest.spyOn(caseStatusApi, 'useCaseStatuses').mockImplementation(() => ({
-      data: mockedPersonCaseStatusFactory.build({
-        personId: person.id,
-        caseStatuses: [],
-      }),
+      data: [] as CaseStatus[],
       isValidating: false,
       mutate: jest.fn(),
       revalidate: jest.fn(),

--- a/components/CaseStatus/CaseStatusView.tsx
+++ b/components/CaseStatus/CaseStatusView.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const CaseStatusView = ({ person }: Props): React.ReactElement => {
-  const { data: caseStatusData, error } = useCaseStatuses(person.id);
+  const { data: caseStatuses, error } = useCaseStatuses(person.id);
 
   if (error) {
     return (
@@ -15,13 +15,13 @@ const CaseStatusView = ({ person }: Props): React.ReactElement => {
     );
   }
 
-  if (!caseStatusData) {
+  if (!caseStatuses) {
     return <></>;
   }
 
   return (
     <>
-      {groupByType(caseStatusData.caseStatuses).map((status) => (
+      {groupByType(caseStatuses).map((status) => (
         <span
           className="govuk-tag lbh-tag lbh-tag--yellow govuk-!-margin-right-1 govuk-!-margin-top-2"
           key={status}

--- a/components/NewPersonView/Layout.tsx
+++ b/components/NewPersonView/Layout.tsx
@@ -109,8 +109,7 @@ const Layout = ({ person, children }: Props): React.ReactElement => {
   if (
     isFeatureActive('case-status') &&
     casestatus &&
-    casestatus.caseStatuses &&
-    !groupCaseStatusByType(casestatus.caseStatuses).has('CIN') &&
+    !groupCaseStatusByType(casestatus).has('CIN') &&
     person.contextFlag === 'C'
   ) {
     secondaryNavigation.push({

--- a/factories/caseStatus.ts
+++ b/factories/caseStatus.ts
@@ -1,20 +1,12 @@
 import { Factory } from 'fishery';
 import {
   CaseStatus,
-  PersonCaseStatus,
   FormValue,
   FormFields,
   FormOption,
   CaseStatusFields,
   AddCaseStatusFormData,
 } from 'types';
-
-export const mockedPersonCaseStatusFactory = Factory.define<PersonCaseStatus>(
-  ({ sequence }) => ({
-    personId: sequence,
-    caseStatuses: [mockedCaseStatusFactory.build()],
-  })
-);
 
 export const mockedCaseStatusFactory = Factory.define<CaseStatus>(
   ({ sequence }) => ({

--- a/lib/caseStatus.ts
+++ b/lib/caseStatus.ts
@@ -1,12 +1,13 @@
 import axios from 'axios';
-import type { PersonCaseStatus } from 'types';
+import { CaseStatus } from 'types';
+
 const ENDPOINT_API = process.env.ENDPOINT_API;
 const AWS_KEY = process.env.AWS_KEY;
 const headers = { 'x-api-key': AWS_KEY };
 export const getCaseStatusByPersonId = async (
   personId: number
-): Promise<PersonCaseStatus> => {
-  const { data }: { data: PersonCaseStatus } = await axios.get(
+): Promise<CaseStatus[]> => {
+  const { data } = await axios.get<CaseStatus[]>(
     `${ENDPOINT_API}/residents/${personId}/case-statuses`,
     {
       headers,
@@ -15,10 +16,8 @@ export const getCaseStatusByPersonId = async (
   return data;
 };
 
-export const getFormValues = async (
-  type: string
-): Promise<PersonCaseStatus> => {
-  const { data }: { data: PersonCaseStatus } = await axios.get(
+export const getFormValues = async (type: string): Promise<CaseStatus[]> => {
+  const { data } = await axios.get<CaseStatus[]>(
     `${ENDPOINT_API}/case-statuses/form-options/${type}`,
     {
       headers,

--- a/types.ts
+++ b/types.ts
@@ -329,11 +329,6 @@ export interface FormFields {
   fields: Array<FormValue>;
 }
 
-export interface PersonCaseStatus {
-  personId: number;
-  caseStatuses: Array<CaseStatus>;
-}
-
 export interface FormOption {
   name: string;
   description: string;

--- a/utils/api/caseStatus.ts
+++ b/utils/api/caseStatus.ts
@@ -3,10 +3,10 @@ import axios from 'axios';
 import useSWR, { SWRResponse } from 'swr';
 
 import type {
-  PersonCaseStatus,
   AddCaseStatusFormData,
   FormFields,
   ErrorAPI,
+  CaseStatus,
 } from 'types';
 
 export const addCaseStatus = async (
@@ -18,7 +18,7 @@ export const addCaseStatus = async (
 
 export const useCaseStatuses = (
   id: number
-): SWRResponse<PersonCaseStatus, ErrorAPI> =>
+): SWRResponse<CaseStatus[], ErrorAPI> =>
   useSWR(`/api/residents/${id}/casestatus`);
 
 export const useFormValues = (


### PR DESCRIPTION
**What**  
Response type from the API has changed when calling GET api/v1/case-statuses/{personId}
This PR updates our expected response from the API and handles the new data accordingly as well as updates related tests.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
