### PR TITLE
chore: When case status array is empty, don't show the case status title

### DIFF
--- a/components/CaseStatus/CaseStatusDetails.tsx
+++ b/components/CaseStatus/CaseStatusDetails.tsx
@@ -23,7 +23,7 @@ const CaseStatusDetails = ({ person }: Props): React.ReactElement => {
     );
   }
 
-  if (!caseStatuses) {
+  if (!caseStatuses || caseStatuses?.length === 0) {
     return <></>;
   }
   return (


### PR DESCRIPTION
**What**  
This adds a condition for when the case status array is empty.

**Before**
<img width="1272" alt="Screenshot 2021-09-28 at 15 30 02" src="https://user-images.githubusercontent.com/32823756/135108474-cf33a41d-932d-49f6-b454-b6ea564bc742.png">

**After**
<img width="1220" alt="Screenshot 2021-09-28 at 15 30 19" src="https://user-images.githubusercontent.com/32823756/135108517-a86dc026-132c-4280-a40a-ee4bd98480c9.png">


**Why**  
The details page would show the case statuses title even if there were no case statuses. This checks if the array is empty as well as if it's undefined before returning the UI for case statuses.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
