### PR TITLE
fix: start date validator

### DIFF
--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -101,7 +101,7 @@ export const generateFlexibleSchema = (
       );
     } else if (field.type === 'timetable') {
       shape[field.id] = Yup.object();
-    } else if (field.type === 'date' && field.startDate !== null) {
+    } else if (field.type === 'date' && field.startDate) {
       shape[field.id] = Yup.string().test(
         'Validate date is future',
         'Date cannot be before start date',


### PR DESCRIPTION
**What**  
I've added a check for a start_date in the previous release which checks if the date is in the past.
This check does not work properly so I'm pushing a quick fix for this - it was not checking if the date was undefined, only null, thus failing

**Why**  
To fix the Start Date component in the date picker
