### PR TITLE
chore: Make zap fail on absence of anti csrf tokens

### DIFF
--- a/zap-baseline.conf
+++ b/zap-baseline.conf
@@ -4,7 +4,7 @@
 # You can add your own messages to each rule by appending them after a tab on each line.
 10017	WARN	(Cross-Domain JavaScript Source File Inclusion)
 10021	WARN	(X-Content-Type-Options Header Missing)
-10202	WARN	(Absence of Anti-CSRF Tokens)
+10202	FAIL	(Absence of Anti-CSRF Tokens)
 10055	FAIL	(CSP)
 10038	FAIL	(Content Security Policy (CSP) Header Not Set)
 10037	FAIL	(Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s))


### PR DESCRIPTION
**What**  

Application of [PR 696](https://github.com/LBHackney-IT/lbh-social-care-frontend/pull/696) means that 
`10202	WARN	(Absence of Anti-CSRF Tokens)` now passes so the scan rule can be upgraded from `WARN` to `FAIL`.