### PR TITLE
fix: security/pin-zap-version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
 
       - run:
           name: Pull owasp zap docker image
-          command: docker pull owasp/zap2docker-stable
+          command: docker pull owasp/zap2docker-stable:2.10.0
 
       - run:
           name: ZAP baseline test of application
@@ -113,7 +113,7 @@ jobs:
           # Link to above:https://github.com/zaproxy/zaproxy/blob/main/docker/zap-baseline.py#L31-L35
           command: |
             (
-              docker run -t owasp/zap2docker-stable zap-baseline.py \
+              docker run -t owasp/zap2docker-stable:2.10.0 zap-baseline.py \
               -j \
               -u https://raw.githubusercontent.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}/zap-baseline.conf \
               -t http://$(ip -f inet -o addr show docker0 | awk '{print $4}' | cut -d '/' -f 1):3000 || \


### PR DESCRIPTION
**What**  
pin-zap-version to owasp/zap2docker-stable:2.10.0

**Why**  
Latest stable image wasn't playing well with CircleCi 
