### PR TITLE
feat: update onboarding dialog to open link in a new tab

### DIFF
--- a/components/OnboardingDialog/index.spec.tsx
+++ b/components/OnboardingDialog/index.spec.tsx
@@ -79,4 +79,15 @@ describe('OnboardingDialog component', () => {
       )
     ).not.toBeInTheDocument();
   });
+
+  it('opens the link in a new tab', () => {
+    global.Storage.prototype.getItem = jest.fn().mockReturnValue(null);
+
+    render(<OnboardingDialog />);
+
+    expect(screen.queryByText('Okay, show me')).toHaveAttribute(
+      'target',
+      '_blank'
+    );
+  });
 });

--- a/components/OnboardingDialog/index.tsx
+++ b/components/OnboardingDialog/index.tsx
@@ -15,12 +15,6 @@ const OnboardingDialog = (): React.ReactElement | null => {
     setOpen(false);
   };
 
-  const handleLearnMore = async () => {
-    handleDismiss();
-    window.location.href =
-      'https://sites.google.com/hackney.gov.uk/moderntoolsforsocialcare/core-pathway-pilot';
-  };
-
   if (isOpen)
     return (
       <Dialog
@@ -45,12 +39,15 @@ const OnboardingDialog = (): React.ReactElement | null => {
           </p>
 
           <div className="lbh-dialog__actions">
-            <button
+            <a
+              href="https://sites.google.com/hackney.gov.uk/moderntoolsforsocialcare/core-pathway-pilot"
+              onClick={handleDismiss}
               className="govuk-button lbh-button"
-              onClick={handleLearnMore}
+              target="_blank"
+              rel="noreferrer noopener"
             >
               Okay, show me
-            </button>
+            </a>
             <button className="lbh-link" onClick={handleDismiss}>
               Got it, dismiss
             </button>


### PR DESCRIPTION
**What**

Update onboarding dialog to open the roadmap link in a new tab.

**Why**  

It's an external page and so the user doesn't have to go back to the application.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
