### PR TITLE
feat(SCT-1375): End case status Announcement

### DIFF
--- a/pages/people/[id]/case-status/[caseStatusId]/edit/edit.tsx
+++ b/pages/people/[id]/case-status/[caseStatusId]/edit/edit.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import PersonView from 'components/PersonView/PersonView';
 import EditCaseStatusForm from 'components/CaseStatus/EditCaseStatusForm/EditCaseStatusForm';
@@ -10,7 +10,12 @@ const EditCaseStatus = (): React.ReactElement => {
   const type = String(router.query.type as string);
   const caseStatusId = Number(router.query.caseStatusId as string);
   let action = String(router.query.action as string);
-  const isScheduledCaseStatus = Number(router.query.isScheduledCaseStatus);
+
+  const [isScheduledCaseStatus, setIsScheduledCaseStatus] = useState(false);
+
+  useEffect(() => {
+    setIsScheduledCaseStatus(Boolean(router.query.isScheduledCaseStatus));
+  }, [router.query.isScheduledCaseStatus]);
 
   let prefilledFields;
   if (router.query.prefilledFields) {
@@ -21,20 +26,14 @@ const EditCaseStatus = (): React.ReactElement => {
     action.charAt(0).toUpperCase();
   }
 
-  let announcement;
-
-  if (isScheduledCaseStatus) {
-    announcement = (
-      <AnnouncementMessage
-        title="An update has already been scheduled for this status"
-        content="Any changes you make here will overwrite the scheduled update"
-      />
-    );
-  } else announcement = null;
-
   return (
     <>
-      {announcement}
+      {isScheduledCaseStatus && (
+        <AnnouncementMessage
+          title="An update has already been scheduled for this status"
+          content="Any changes you make here will overwrite the scheduled update"
+        />
+      )}
       <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
         {capitalize(action)} a case status
       </h1>


### PR DESCRIPTION

**What**
Add an Announcement component that will be rendered on the End page for each case status type when there is a pre-existing scheduled case status.

Uses the values returned by calling sortCaseStatusAnswers(status) in CaseStatusDetails, which returns a scheduled case status object if there is one scheduled.
We pass this along as a boolean in the query params so that it's available on the UpdateCaseStatusForm page to check against and conditionally render the Announcement if a scheduled case status is present.

**Why**
To alert the user that if they create a new scheduled case status, then this will overwrite the pre-existing scheduled case status.
