### PR TITLE
fix(SCT-1362): Case Status error handling in UI

### DIFF
--- a/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.tsx
+++ b/components/CaseStatus/AddCaseStatusForm/ReviewAddCaseStatusForm.tsx
@@ -76,7 +76,7 @@ const ReviewAddCaseStatusForm: React.FC<{
         query: { flaggedStatus: true },
       });
     } catch (e) {
-      setStatus(e.message);
+      setStatus(`Error ${e.response.data.status}: ${e.response.data.message}`);
     }
   };
 

--- a/pages/api/casestatus/[id]/index.ts
+++ b/pages/api/casestatus/[id]/index.ts
@@ -29,9 +29,10 @@ const endpoint: NextApiHandler = async (
           ? res
               .status(StatusCodes.NOT_FOUND)
               .json({ message: 'Case Status Not Found' })
-          : res
-              .status(StatusCodes.BAD_REQUEST)
-              .json({ message: 'Unable to patch the casestatus' });
+          : res.status(error?.response?.status).json({
+              status: error?.response?.status,
+              message: error?.response?.data,
+            });
       }
       break;
 

--- a/pages/api/casestatus/index.ts
+++ b/pages/api/casestatus/index.ts
@@ -29,9 +29,10 @@ const endpoint: NextApiHandler = async (
           ? res
               .status(StatusCodes.NOT_FOUND)
               .json({ message: 'Case Status Not Found' })
-          : res
-              .status(StatusCodes.BAD_REQUEST)
-              .json({ message: 'Unable to add the casestatus' });
+          : res.status(error?.response?.status).json({
+              status: error?.response?.status,
+              message: error?.response?.data,
+            });
       }
       break;
     default:

--- a/pages/api/casestatus/update/[caseStatusId]/index.ts
+++ b/pages/api/casestatus/update/[caseStatusId]/index.ts
@@ -29,9 +29,10 @@ const endpoint: NextApiHandler = async (
           ? res
               .status(StatusCodes.NOT_FOUND)
               .json({ message: 'Case Status Not Found' })
-          : res
-              .status(StatusCodes.BAD_REQUEST)
-              .json({ message: 'Unable to add the casestatus' });
+          : res.status(error?.response?.status).json({
+              status: error?.response?.status,
+              message: error?.response?.data,
+            });
       }
       break;
     default:


### PR DESCRIPTION
**What**  
Next.JS API routes now returns correctly Case Status error messages sent from the backend to the frontend.
The error definitions are passed from the API routes to the try/catch block when calling the endpoint.

**Why**  
Before this it wasn't clear what the error was when an operation went wrong - all that was displayed was the error number, which doesn't make much sense to the end user.