### PR TITLE
feat(SCT-1378): add EDIT announcement for changing case status start date consequences

### DIFF
--- a/cypress/integration/case_status.ts
+++ b/cypress/integration/case_status.ts
@@ -519,6 +519,25 @@ describe('Using case status', () => {
         cy.contains(caseStatusScheduledStartDateText).should('be.visible');
       });
 
+      //Updating A pre-existing scheduled case status - Announcement
+      it('should render an announcement when updating a LAC case status that has a pre-existing scheduled case status', () => {
+        cy.visitAs(
+          `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}/details`,
+          AuthRoles.ChildrensGroup
+        );
+
+        cy.contains('a', 'Edit / End', {
+          timeout: 20000,
+        }).click();
+        cy.get(`input[value=update]`).check();
+        cy.get('[data-testid=submit_button]').click();
+        cy.url().should('include', '/update/edit');
+        cy.get('[data-testid=announcement_message_box]').should('exist');
+        cy.contains(
+          'An update has already been scheduled for this status'
+        ).should('be.visible');
+      });
+
       it('should validate when ending a LAC case status that the end date cannot be before the case status start date, start date can be in the future', () => {
         cy.visitAs(
           `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}/details`,

--- a/pages/people/[id]/case-status/[caseStatusId]/edit/edit.tsx
+++ b/pages/people/[id]/case-status/[caseStatusId]/edit/edit.tsx
@@ -34,12 +34,14 @@ const EditCaseStatus = (): React.ReactElement => {
 
   return (
     <>
-      {pastCaseStatusStartDate && action == 'edit' && (
-        <AnnouncementMessage
-          title="Changes made here may affect previous status items"
-          content="Changing the start date of the current case status will also change the end date of the previous case status"
-        />
-      )}
+      {pastCaseStatusStartDate &&
+        pastCaseStatusStartDate !== 'undefined' &&
+        action == 'edit' && (
+          <AnnouncementMessage
+            title="Changes made here may affect previous status items"
+            content="Changing the start date of the current case status will also change the end date of the previous case status"
+          />
+        )}
       {isScheduledCaseStatus && action == 'end' && (
         <AnnouncementMessage
           title="An update has already been scheduled for this status"

--- a/pages/people/[id]/case-status/[caseStatusId]/edit/edit.tsx
+++ b/pages/people/[id]/case-status/[caseStatusId]/edit/edit.tsx
@@ -34,7 +34,13 @@ const EditCaseStatus = (): React.ReactElement => {
 
   return (
     <>
-      {isScheduledCaseStatus && (
+      {pastCaseStatusStartDate && action == 'edit' && (
+        <AnnouncementMessage
+          title="Changes made here may affect previous status items"
+          content="Changing the start date of the current case status will also change the end date of the previous case status"
+        />
+      )}
+      {isScheduledCaseStatus && action == 'end' && (
         <AnnouncementMessage
           title="An update has already been scheduled for this status"
           content="Any changes you make here will overwrite the scheduled update"

--- a/pages/people/[id]/case-status/[caseStatusId]/update/edit.tsx
+++ b/pages/people/[id]/case-status/[caseStatusId]/update/edit.tsx
@@ -29,7 +29,7 @@ const EditCaseStatus = (): React.ReactElement => {
 
   return (
     <>
-      {isScheduledCaseStatus && (
+      {isScheduledCaseStatus && action === 'update' && (
         <AnnouncementMessage
           title="An update has already been scheduled for this status"
           content="Any changes you make here will overwrite the scheduled update"


### PR DESCRIPTION
**What**  
If changing the start date of the current case status, will affect the end date of the previous case status. 
Adding an Announcement box to alert the user of this.

**Why**  
This announcement box is to make this fact more explicit to the user.

**Anything else?**
Separate but related, I added an E2E Cypress test for displaying an announcement box on the LAC Update page when making a scheduled case status and there is a pre-existing scheduled case status
