### PR TITLE
feat(SCT-1436): query param to pre select mash dashboard tab

### DIFF
--- a/components/MashCards/MainCard.tsx
+++ b/components/MashCards/MainCard.tsx
@@ -26,7 +26,7 @@ const MainCard = ({ filter, mashReferrals }: Props): React.ReactElement => {
         ))}
       </div>
     );
-  } else if (filter === 'screening') {
+  } else if (filter === 'screening-decision') {
     return (
       <div>
         {mashReferrals.map((referral) => (

--- a/components/MashDashboard/MashDashboard.tsx
+++ b/components/MashDashboard/MashDashboard.tsx
@@ -41,7 +41,7 @@ export const MashDashboard = ({ referrals }: Props): React.ReactElement => {
     mashReferrals = contact;
   } else if (filter === 'initial-decision') {
     mashReferrals = initial;
-  } else if (filter === 'screening') {
+  } else if (filter === 'screening-decision') {
     mashReferrals = screening;
   } else {
     mashReferrals = final;

--- a/components/MashDashboard/MashDashboard.tsx
+++ b/components/MashDashboard/MashDashboard.tsx
@@ -1,15 +1,32 @@
 import st from 'components/Tabs/Tabs.module.scss';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Tab from 'components/SubmissionsTable/Tab';
 import MainCard from 'components/MashCards/MainCard';
 import { MashReferral } from 'types';
+import { useRouter } from 'next/router';
 
 interface Props {
   referrals: MashReferral[];
 }
 
+const possibleTabs = new Set([
+  'contact',
+  'initial-decision',
+  'screening-decision',
+  'final-decision',
+]);
+
 export const MashDashboard = ({ referrals }: Props): React.ReactElement => {
-  const [filter, setFilter] = useState<string>('contact');
+  const [filter, setFilter] = useState('contact');
+
+  const router = useRouter();
+
+  useEffect(() => {
+    const tab = (router.query.tab as string).toLowerCase();
+    if (possibleTabs.has(tab)) {
+      setFilter(tab);
+    }
+  }, [router.query]);
 
   const { contact, initial, screening, final } = {
     contact: referrals.filter((ref) => ref.stage === 'Contact'),
@@ -29,22 +46,37 @@ export const MashDashboard = ({ referrals }: Props): React.ReactElement => {
   } else {
     mashReferrals = final;
   }
+
+  const onTabClick = (tabClicked: string) => {
+    setFilter(tabClicked);
+    router.query.tab = tabClicked;
+    router.push(router);
+  };
+
   return (
     <div>
       <>
         <h1 className="govuk-!-margin-bottom-8">Team assignments</h1>
         <fieldset className="govuk-tabs lbh-tabs govuk-!-margin-top-8">
           <ul className={st.tabList}>
-            <Tab filter={filter} value="contact" setFilter={setFilter}>
+            <Tab filter={filter} value="contact" setFilter={onTabClick}>
               <>Contact ({contact.length}) </>
             </Tab>
-            <Tab filter={filter} value="initial-decision" setFilter={setFilter}>
+            <Tab
+              filter={filter}
+              value="initial-decision"
+              setFilter={onTabClick}
+            >
               <>Initial decision ({initial.length})</>
             </Tab>
-            <Tab filter={filter} value="screening" setFilter={setFilter}>
+            <Tab
+              filter={filter}
+              value="screening-decision"
+              setFilter={onTabClick}
+            >
               <>Screening decision ({screening.length}) </>
             </Tab>
-            <Tab filter={filter} value="final-decision" setFilter={setFilter}>
+            <Tab filter={filter} value="final-decision" setFilter={onTabClick}>
               <>Final decision ({final.length})</>
             </Tab>
           </ul>

--- a/pages/mash-referral/[id]/screening-decision.tsx
+++ b/pages/mash-referral/[id]/screening-decision.tsx
@@ -8,6 +8,7 @@ import { getMashReferral } from 'lib/mashReferral';
 import { GetServerSideProps } from 'next';
 import { isAuthorised } from 'utils/auth';
 import { submitScreeningDecision } from 'utils/api/mashReferrals';
+import { useRouter } from 'next/router';
 interface Props {
   referral: MashReferral;
   workerEmail: string;
@@ -21,6 +22,8 @@ const ScreeningDecision = ({
   const [urgencyScreeningDecision, setUrgencyScreeningDecision] =
     useState(false);
 
+  const router = useRouter();
+
   const submitForm = async () => {
     await submitScreeningDecision(
       referral.id,
@@ -28,6 +31,13 @@ const ScreeningDecision = ({
       urgencyScreeningDecision,
       workerEmail
     );
+
+    router.push({
+      pathname: `/team-assignments`,
+      query: {
+        tab: 'screening-decision',
+      },
+    });
   };
 
   return (


### PR DESCRIPTION
**What**  
Allows the tab within team-assignment to be selected based on query params from the URL.
This allows linking to the page with a tab open.
Enables us on completion of a mash action such as screening decision to redirect the user back to the team-assignments page with the screen decision tab being open.

**Why**  
Slightly better than contact always being pre-selected on laoding team-assignments page.
Will enable us in a follow up PR to show a confirmation component after the direct from the action page.

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
