### PR TITLE
feat(SCT-1420): Action page for initial decision

### DIFF
--- a/components/MashDashboard/MashDashboard.tsx
+++ b/components/MashDashboard/MashDashboard.tsx
@@ -41,10 +41,10 @@ export const MashDashboard = ({ referrals }: Props): React.ReactElement => {
     undefined;
 
   const { contact, initial, screening, final } = {
-    contact: referrals.filter((ref) => ref.stage === 'Contact'),
-    initial: referrals.filter((ref) => ref.stage === 'Initial decision'),
-    screening: referrals.filter((ref) => ref.stage === 'Screening'),
-    final: referrals.filter((ref) => ref.stage === 'Final'),
+    contact: referrals.filter((ref) => ref.stage === 'CONTACT'),
+    initial: referrals.filter((ref) => ref.stage === 'INITIAL'),
+    screening: referrals.filter((ref) => ref.stage === 'SCREENING'),
+    final: referrals.filter((ref) => ref.stage === 'FINAL'),
   };
 
   let mashReferrals: MashReferral[] = [];

--- a/components/MashDashboard/MashDashboard.tsx
+++ b/components/MashDashboard/MashDashboard.tsx
@@ -2,7 +2,7 @@ import st from 'components/Tabs/Tabs.module.scss';
 import { useEffect, useState } from 'react';
 import Tab from 'components/SubmissionsTable/Tab';
 import MainCard from 'components/MashCards/MainCard';
-import { MashReferral } from 'types';
+import { MashReferral, ReferralStage } from 'types';
 import { useRouter } from 'next/router';
 import SuccessSummary from 'components/SuccessSummary/SuccessSummary';
 
@@ -41,10 +41,10 @@ export const MashDashboard = ({ referrals }: Props): React.ReactElement => {
     undefined;
 
   const { contact, initial, screening, final } = {
-    contact: referrals.filter((ref) => ref.stage === 'CONTACT'),
-    initial: referrals.filter((ref) => ref.stage === 'INITIAL'),
-    screening: referrals.filter((ref) => ref.stage === 'SCREENING'),
-    final: referrals.filter((ref) => ref.stage === 'FINAL'),
+    contact: referrals.filter((ref) => ref.stage === ReferralStage.CONTACT),
+    initial: referrals.filter((ref) => ref.stage === ReferralStage.INITIAL),
+    screening: referrals.filter((ref) => ref.stage === ReferralStage.SCREENING),
+    final: referrals.filter((ref) => ref.stage === ReferralStage.FINAL),
   };
 
   let mashReferrals: MashReferral[] = [];

--- a/factories/mashReferral.ts
+++ b/factories/mashReferral.ts
@@ -1,5 +1,5 @@
 import { Factory } from 'fishery';
-import { MashReferral } from 'types';
+import { MashReferral, ReferralStage } from 'types';
 import { mockedWorker } from './workers';
 
 export const mashReferralFactory = Factory.define<MashReferral>(
@@ -9,7 +9,7 @@ export const mashReferralFactory = Factory.define<MashReferral>(
     assignedTo: mockedWorker,
     clients: ['test-client'],
     createdAt: '2021-10-27T09:32:17.319Z',
-    stage: 'Initial decision',
+    stage: ReferralStage.INITIAL,
     requestedSupport: 'test-requested-support',
     finalDecision: 'test-final-decision',
     initialDecision: 'test-initial-decision',

--- a/lib/mashReferral.ts
+++ b/lib/mashReferral.ts
@@ -39,7 +39,7 @@ interface ScreeningDecision {
   referralId: string;
 }
 
-export const patchReferral = async (
+export const patchReferralScreening = async (
   update: ScreeningDecision
 ): Promise<MashReferral> => {
   const { data } = await axios.patch<MashReferral>(
@@ -49,6 +49,35 @@ export const patchReferral = async (
       updateType: update.updateType,
       decision: update.decision,
       requiresUrgentContact: update.requiresUrgentContact,
+    },
+    {
+      headers: { 'Content-Type': 'application/json', 'x-api-key': AWS_KEY },
+    }
+  );
+
+  return data;
+};
+
+interface InitialDecision {
+  workerEmail: string;
+  updateType: 'INITIAL-DECISION';
+  decision: string;
+  referralCategory: string;
+  requiresUrgentContact: boolean;
+  referralId: string;
+}
+
+export const patchReferralInitial = async (
+  update: InitialDecision
+): Promise<MashReferral> => {
+  const { data } = await axios.patch<MashReferral>(
+    `${ENDPOINT_API}/mash-referral/${update.referralId}`,
+    {
+      workerEmail: update.workerEmail,
+      updateType: update.updateType,
+      decision: update.decision,
+      requiresUrgentContact: update.requiresUrgentContact,
+      referralCategory: update.referralCategory,
     },
     {
       headers: { 'Content-Type': 'application/json', 'x-api-key': AWS_KEY },

--- a/pages/api/mash-referral/[id]/index.ts
+++ b/pages/api/mash-referral/[id]/index.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import { isAuthorised } from 'utils/auth';
 
 import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
-import { patchReferral } from 'lib/mashReferral';
+import { patchReferralInitial, patchReferralScreening } from 'lib/mashReferral';
 
 const endpoint: NextApiHandler = async (
   req: NextApiRequest,
@@ -19,21 +19,51 @@ const endpoint: NextApiHandler = async (
   switch (req.method) {
     case 'PATCH':
       try {
-        const { referralId, decision, requiresUrgentContact, workerEmail } = {
-          referralId: req.query.id as string,
-          decision: req.body.decision,
-          requiresUrgentContact: req.body.requiresUrgentContact,
-          workerEmail: req.body.workerEmail,
-        };
+        const updateTye = req.body.updateType;
 
-        const data = await patchReferral({
-          referralId,
-          decision,
-          requiresUrgentContact,
-          updateType: 'SCREENING-DECISION',
-          workerEmail,
-        });
-        res.status(StatusCodes.OK).json(data);
+        if (updateTye === 'SCREENING-DECISION') {
+          const { referralId, decision, requiresUrgentContact, workerEmail } = {
+            referralId: req.query.id as string,
+            decision: req.body.decision,
+            requiresUrgentContact: req.body.requiresUrgentContact,
+            workerEmail: req.body.workerEmail,
+          };
+
+          const data = await patchReferralScreening({
+            referralId,
+            decision,
+            requiresUrgentContact,
+            updateType: 'SCREENING-DECISION',
+            workerEmail,
+          });
+
+          res.status(StatusCodes.OK).json(data);
+        } else if (updateTye === 'INITIAL-DECISION') {
+          const {
+            referralId,
+            decision,
+            requiresUrgentContact,
+            workerEmail,
+            referralCategory,
+          } = {
+            referralId: req.query.id as string,
+            decision: req.body.decision,
+            requiresUrgentContact: req.body.requiresUrgentContact,
+            workerEmail: req.body.workerEmail,
+            referralCategory: req.body.referralCategory,
+          };
+
+          const data = await patchReferralInitial({
+            referralId,
+            decision,
+            requiresUrgentContact,
+            updateType: 'INITIAL-DECISION',
+            workerEmail,
+            referralCategory,
+          });
+
+          res.status(StatusCodes.OK).json(data);
+        }
       } catch (error: any) {
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: error });
       }

--- a/pages/mash-referral/[id]/initial-decision.tsx
+++ b/pages/mash-referral/[id]/initial-decision.tsx
@@ -8,6 +8,7 @@ import { isAuthorised } from 'utils/auth';
 import { getMashReferral } from 'lib/mashReferral';
 import { MashReferral } from 'types';
 import { useState } from 'react';
+import { submitInitialDecision } from 'utils/api/mashReferrals';
 
 interface Props {
   referral: MashReferral;
@@ -24,8 +25,15 @@ const InitialDecision = ({
 
   const router = useRouter();
 
+  const confirmation = {
+    title: `A decision has been submitted for ${referral.clients.join(
+      ' and '
+    )}`,
+    link: referral.referralDocumentURI,
+  };
+
   const submitForm = async () => {
-    await SubmitInitialDecision(
+    await submitInitialDecision(
       referral.id,
       workerEmail,
       decision,
@@ -36,7 +44,8 @@ const InitialDecision = ({
     router.push({
       pathname: `/team-assignments`,
       query: {
-        tab: 'screening-decision',
+        tab: 'initial-decision',
+        confirmation: JSON.stringify(confirmation),
       },
     });
   };
@@ -128,18 +137,20 @@ const InitialDecision = ({
                     Yes
                   </label>
                 </div>
-                <div className="govuk-radios__conditional" id="hint-email">
-                  <label className="govuk-label" htmlFor="hint">
-                    Please email your MASH manager about the urgent case.
-                  </label>
-                </div>
+                {urgent && (
+                  <div className="govuk-radios__conditional" id="hint-email">
+                    <label className="govuk-label" htmlFor="hint">
+                      Please email your MASH manager about the urgent case.
+                    </label>
+                  </div>
+                )}
               </div>
             </fieldset>
           </>,
         ]}
       />
       <div style={{ display: 'flex', alignItems: 'center' }}>
-        <Button label="Submit" type="submit" />
+        <Button label="Submit" type="submit" onClick={submitForm} />
         <p className="lbh-body">
           <a
             href="#"

--- a/pages/mash-referral/[id]/initial-decision.tsx
+++ b/pages/mash-referral/[id]/initial-decision.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 import { GetServerSideProps } from 'next';
 import { isAuthorised } from 'utils/auth';
 import { getMashReferral } from 'lib/mashReferral';
-import { MashReferral } from 'types';
+import { MashReferral, ReferralStage } from 'types';
 import { useState } from 'react';
 import { submitInitialDecision } from 'utils/api/mashReferrals';
 
@@ -189,7 +189,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   const referral = await getMashReferral(params?.id as string);
 
-  if (!referral || referral.stage.toUpperCase() !== 'INITIAL DECISION') {
+  if (!referral || referral.stage !== ReferralStage.INITIAL) {
     return {
       props: {},
       redirect: {

--- a/pages/mash-referral/[id]/initial-decision.tsx
+++ b/pages/mash-referral/[id]/initial-decision.tsx
@@ -2,130 +2,197 @@ import Button from 'components/Button/Button';
 import Heading from 'components/MashHeading/Heading';
 import NumberedSteps from 'components/NumberedSteps/NumberedSteps';
 import { Select } from 'components/Form';
+import { useRouter } from 'next/router';
+import { GetServerSideProps } from 'next';
+import { isAuthorised } from 'utils/auth';
+import { getMashReferral } from 'lib/mashReferral';
+import { MashReferral } from 'types';
+import { useState } from 'react';
 
-const InitialDecision = (): React.ReactElement => (
-  <>
-    <h1>Make initial decision</h1>
-    <Heading
-      clientname="Jan Smith"
-      timeleft="3 hours"
-      datetime="2021-11-04T13:50:10.6120000Z"
-    />
+interface Props {
+  referral: MashReferral;
+  workerEmail: string;
+}
 
-    <NumberedSteps
-      nodes={[
-        <>
-          <h3 className="lbh-heading-h3">Document the decision</h3>
-          <p className="lbh-body">
-            Write the rationale for your screening decision.
-          </p>
-          <p className="lbh-body">
-            <a href="#" className="lbh-link lbh-link--no-visited-state">
-              See Google document
-            </a>
-          </p>
-        </>,
-        <>
-          <label htmlFor="screening-decision" className="lbh-heading-h3">
-            Select initial decision
-          </label>
-          <Select
-            id="initial-decision"
-            name="initial-decision"
-            ignoreValue
-            options={['option 1', 'option 2']}
-          />
-        </>,
-        <>
-          <label htmlFor="referral-category" className="lbh-heading-h3">
-            Select referral category
-          </label>
-          <Select
-            id="referral-category"
-            name="referral-category"
-            ignoreValue
-            options={['option 1', 'option 2']}
-          />
-        </>,
-        <>
-          <fieldset className="govuk-fieldset">
-            <legend className="lbh-heading-h3">Is this contact urgent?</legend>
-            <div
-              className="govuk-radios lbh-radios govuk-radios--conditional"
-              data-module="govuk-radios"
-            >
-              <div className="govuk-radios__item">
-                <input
-                  className="govuk-radios__input"
-                  id="no-input"
-                  name="urgency"
-                  type="radio"
-                  value="text"
-                />
-                <label
-                  className="govuk-label govuk-radios__label"
-                  htmlFor="no-input"
-                >
-                  No
-                </label>
+const InitialDecision = ({
+  referral,
+  workerEmail,
+}: Props): React.ReactElement => {
+  const [decision, setDecision] = useState('option 1');
+  const [referralCategory, setReferralCategory] = useState('option 1');
+  const [urgent, setUrgent] = useState(false);
+
+  const router = useRouter();
+
+  const submitForm = async () => {
+    await SubmitInitialDecision(
+      referral.id,
+      workerEmail,
+      decision,
+      referralCategory,
+      urgent
+    );
+
+    router.push({
+      pathname: `/team-assignments`,
+      query: {
+        tab: 'screening-decision',
+      },
+    });
+  };
+
+  return (
+    <>
+      <h1>Make initial decision</h1>
+      <Heading
+        clientname="Jan Smith"
+        timeleft="3 hours"
+        datetime="2021-11-04T13:50:10.6120000Z"
+      />
+
+      <NumberedSteps
+        nodes={[
+          <>
+            <h3 className="lbh-heading-h3">Document the decision</h3>
+            <p className="lbh-body">
+              Write the rationale for your screening decision.
+            </p>
+            <p className="lbh-body">
+              <a href="#" className="lbh-link lbh-link--no-visited-state">
+                See Google document
+              </a>
+            </p>
+          </>,
+          <>
+            <label htmlFor="screening-decision" className="lbh-heading-h3">
+              Select initial decision
+            </label>
+            <Select
+              id="initial-decision"
+              name="initial-decision"
+              value={decision}
+              onChange={(value) => setDecision(value)}
+              options={['option 1', 'option 2']}
+            />
+          </>,
+          <>
+            <label htmlFor="referral-category" className="lbh-heading-h3">
+              Select referral category
+            </label>
+            <Select
+              id="referral-category"
+              name="referral-category"
+              value={referralCategory}
+              onChange={(value) => setReferralCategory(value)}
+              options={['option 1', 'option 2']}
+            />
+          </>,
+          <>
+            <fieldset className="govuk-fieldset">
+              <legend className="lbh-heading-h3">
+                Is this contact urgent?
+              </legend>
+              <div
+                className="govuk-radios lbh-radios govuk-radios--conditional"
+                data-module="govuk-radios"
+              >
+                <div className="govuk-radios__item">
+                  <input
+                    className="govuk-radios__input"
+                    id="no-input"
+                    name="urgency"
+                    type="radio"
+                    onClick={() => setUrgent(false)}
+                    checked={!urgent}
+                  />
+                  <label
+                    className="govuk-label govuk-radios__label"
+                    htmlFor="no-input"
+                  >
+                    No
+                  </label>
+                </div>
+                <div className="govuk-radios__item">
+                  <input
+                    className="govuk-radios__input"
+                    id="yes-input"
+                    name="urgency"
+                    type="radio"
+                    onClick={() => setUrgent(true)}
+                    checked={urgent}
+                  />
+                  <label
+                    className="govuk-label govuk-radios__label"
+                    htmlFor="yes-input"
+                  >
+                    Yes
+                  </label>
+                </div>
+                <div className="govuk-radios__conditional" id="hint-email">
+                  <label className="govuk-label" htmlFor="hint">
+                    Please email your MASH manager about the urgent case.
+                  </label>
+                </div>
               </div>
-              <div className="govuk-radios__item">
-                <input
-                  className="govuk-radios__input"
-                  id="yes-input"
-                  name="urgency"
-                  type="radio"
-                  value="phone"
-                  checked
-                />
-                <label
-                  className="govuk-label govuk-radios__label"
-                  htmlFor="yes-input"
-                >
-                  Yes
-                </label>
-              </div>
-              <div className="govuk-radios__conditional" id="hint-email">
-                <label className="govuk-label" htmlFor="hint">
-                  Please email your MASH manager about the urgent case.
-                </label>
-              </div>
-            </div>
-          </fieldset>
-        </>,
-        <>
-          <label htmlFor="assign-worker" className="lbh-heading-h3">
-            (Optional) Assign to worker
-          </label>
-          <Select
-            id="assign-worker"
-            name="assign-worker"
-            ignoreValue
-            options={['option 1', 'option 2']}
-          />
-        </>,
-      ]}
-    />
-    <div style={{ display: 'flex', alignItems: 'center' }}>
-      <Button label="Submit" type="submit" />
-      <p className="lbh-body">
-        <a
-          href="#"
-          className={`lbh-link lbh-link--no-visited-state govuk-!-margin-left-3`}
-        >
-          Cancel
-        </a>
-      </p>
-      <p>
-        <a
-          href="#"
-          className={`lbh-link lbh-link--no-visited-state govuk-!-margin-left-3`}
-        >
-          Return to contact
-        </a>
-      </p>
-    </div>
-  </>
-);
+            </fieldset>
+          </>,
+        ]}
+      />
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <Button label="Submit" type="submit" />
+        <p className="lbh-body">
+          <a
+            href="#"
+            className={`lbh-link lbh-link--no-visited-state govuk-!-margin-left-3`}
+          >
+            Cancel
+          </a>
+        </p>
+        <p>
+          <a
+            href="#"
+            className={`lbh-link lbh-link--no-visited-state govuk-!-margin-left-3`}
+          >
+            Return to contact
+          </a>
+        </p>
+      </div>
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async ({
+  req,
+  params,
+}) => {
+  const user = isAuthorised(req);
+
+  if (!user) {
+    return {
+      props: {},
+      redirect: {
+        destination: `/login`,
+      },
+    };
+  }
+
+  const referral = await getMashReferral(params?.id as string);
+
+  if (!referral || referral.stage.toUpperCase() !== 'INITIAL DECISION') {
+    return {
+      props: {},
+      redirect: {
+        destination: `/404`,
+      },
+    };
+  }
+
+  return {
+    props: {
+      referral,
+      workerEmail: user.email,
+    },
+  };
+};
 
 export default InitialDecision;

--- a/pages/mash-referral/[id]/screening-decision.tsx
+++ b/pages/mash-referral/[id]/screening-decision.tsx
@@ -129,11 +129,13 @@ const ScreeningDecision = ({
                     Yes
                   </label>
                 </div>
-                <div className="govuk-radios__conditional" id="hint-email">
-                  <label className="govuk-label" htmlFor="hint">
-                    Please email your MASH manager about the urgent case.
-                  </label>
-                </div>
+                {urgencyScreeningDecision && (
+                  <div className="govuk-radios__conditional" id="hint-email">
+                    <label className="govuk-label" htmlFor="hint">
+                      Please email your MASH manager about the urgent case.
+                    </label>
+                  </div>
+                )}
               </div>
             </fieldset>
           </>,

--- a/pages/mash-referral/[id]/screening-decision.tsx
+++ b/pages/mash-referral/[id]/screening-decision.tsx
@@ -159,7 +159,6 @@ export const getServerSideProps: GetServerSideProps = async ({
   params,
 }) => {
   const user = isAuthorised(req);
-  console.log('🚀 ~ file: screening.tsx ~ line 148 ~ user', user);
 
   if (!user) {
     return {

--- a/pages/mash-referral/[id]/screening-decision.tsx
+++ b/pages/mash-referral/[id]/screening-decision.tsx
@@ -3,7 +3,7 @@ import Heading from 'components/MashHeading/Heading';
 import NumberedSteps from 'components/NumberedSteps/NumberedSteps';
 import { useState } from 'react';
 import { Select } from 'components/Form';
-import { MashReferral } from 'types';
+import { MashReferral, ReferralStage } from 'types';
 import { getMashReferral } from 'lib/mashReferral';
 import { GetServerSideProps } from 'next';
 import { isAuthorised } from 'utils/auth';
@@ -181,7 +181,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   const referral = await getMashReferral(params?.id as string);
 
-  if (!referral || referral.stage.toUpperCase() !== 'SCREENING') {
+  if (!referral || referral.stage !== ReferralStage.SCREENING) {
     return {
       props: {},
       redirect: {

--- a/types.ts
+++ b/types.ts
@@ -469,6 +469,13 @@ export interface Paginated<T> {
   count: number;
 }
 
+export enum ReferralStage {
+  CONTACT = 'CONTACT',
+  INITIAL = 'INITIAL',
+  SCREENING = 'SCREENING',
+  FINAL = 'FINAL',
+}
+
 export interface MashReferral {
   id: string;
   referrer: string;
@@ -477,7 +484,7 @@ export interface MashReferral {
   createdAt: string;
   clients: string[];
   referralDocumentURI: string;
-  stage: string;
+  stage: ReferralStage;
   initialDecision: string | undefined;
   screeningDecision: string | undefined;
   screeningUrgentContactRequired: boolean | undefined;

--- a/utils/api/mashReferrals.ts
+++ b/utils/api/mashReferrals.ts
@@ -10,10 +10,29 @@ export const submitScreeningDecision = async (
   const response = await axios.patch<MashReferral>(
     `/api/mash-referral/${referralId}/`,
     {
-      referralId,
       decision,
       requiresUrgentContact,
       updateType: 'SCREENING-DECISION',
+      workerEmail: workerEmail,
+    }
+  );
+  return response?.data;
+};
+
+export const submitInitialDecision = async (
+  referralId: string,
+  workerEmail: string,
+  decision: string,
+  referralCategory: string,
+  requiresUrgentContact: boolean
+): Promise<MashReferral> => {
+  const response = await axios.patch<MashReferral>(
+    `/api/mash-referral/${referralId}/`,
+    {
+      decision,
+      requiresUrgentContact,
+      referralCategory,
+      updateType: 'INITIAL-DECISION',
       workerEmail: workerEmail,
     }
   );


### PR DESCRIPTION
**What**  
Create a form for initial decision that when completed submits the data to the API, on 200 response redirect user back to team assignments page in the inital-decisions tab, see the referral has moved into screening tab.

**Why**  
Important part of Mash Referral workflow.

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
