### PR TITLE
fix(SCT-1444): intial decision card to match designs

### DIFF
--- a/components/MashCards/ContactCard.tsx
+++ b/components/MashCards/ContactCard.tsx
@@ -30,9 +30,9 @@ const ContactCard = ({ mashReferral }: Props): React.ReactElement => {
               <dd>
                 <Link href={mashReferral.referralDocumentURI}>
                   <a>
-                    {mashReferral.clients[0]}
+                    {mashReferral.clients[0]} +{' '}
                     {mashReferral.clients.length > 1 &&
-                      ` + ${mashReferral.clients.length - 1} `}
+                      `+ ${mashReferral.clients.length - 1} `}
                     (referral)
                   </a>
                 </Link>

--- a/components/MashCards/ContactCard.tsx
+++ b/components/MashCards/ContactCard.tsx
@@ -30,7 +30,7 @@ const ContactCard = ({ mashReferral }: Props): React.ReactElement => {
               <dd>
                 <Link href={mashReferral.referralDocumentURI}>
                   <a>
-                    {mashReferral.clients[0]} +{' '}
+                    {mashReferral.clients[0] + ' '}
                     {mashReferral.clients.length > 1 &&
                       `+ ${mashReferral.clients.length - 1} `}
                     (referral)

--- a/components/MashCards/FinalDecisionCard.tsx
+++ b/components/MashCards/FinalDecisionCard.tsx
@@ -29,9 +29,9 @@ const FinalDecisionCard = ({ mashReferral }: Props): React.ReactElement => {
               <dd>
                 <Link href={mashReferral.referralDocumentURI}>
                   <a>
-                    {mashReferral.clients[0]}
+                    {mashReferral.clients[0]} +{' '}
                     {mashReferral.clients.length > 1 &&
-                      ` + ${mashReferral.clients.length - 1} `}
+                      `+ ${mashReferral.clients.length - 1} `}
                     (referral)
                   </a>
                 </Link>

--- a/components/MashCards/FinalDecisionCard.tsx
+++ b/components/MashCards/FinalDecisionCard.tsx
@@ -29,7 +29,7 @@ const FinalDecisionCard = ({ mashReferral }: Props): React.ReactElement => {
               <dd>
                 <Link href={mashReferral.referralDocumentURI}>
                   <a>
-                    {mashReferral.clients[0]} +{' '}
+                    {mashReferral.clients[0] + ' '}
                     {mashReferral.clients.length > 1 &&
                       `+ ${mashReferral.clients.length - 1} `}
                     (referral)

--- a/components/MashCards/InitialDecisionCard.tsx
+++ b/components/MashCards/InitialDecisionCard.tsx
@@ -29,9 +29,9 @@ const InitialDecisionCard = ({ mashReferral }: Props): React.ReactElement => {
               <dd>
                 <Link href={mashReferral.referralDocumentURI}>
                   <a>
-                    {mashReferral.clients[0]}
+                    {mashReferral.clients[0]} +{' '}
                     {mashReferral.clients.length > 1 &&
-                      ` + ${mashReferral.clients.length - 1} `}
+                      `+ ${mashReferral.clients.length - 1} `}
                     (referral)
                   </a>
                 </Link>

--- a/components/MashCards/InitialDecisionCard.tsx
+++ b/components/MashCards/InitialDecisionCard.tsx
@@ -29,7 +29,7 @@ const InitialDecisionCard = ({ mashReferral }: Props): React.ReactElement => {
               <dd>
                 <Link href={mashReferral.referralDocumentURI}>
                   <a>
-                    {mashReferral.clients[0]} +{' '}
+                    {mashReferral.clients[0] + ' '}
                     {mashReferral.clients.length > 1 &&
                       `+ ${mashReferral.clients.length - 1} `}
                     (referral)

--- a/components/MashCards/InitialDecisionCard.tsx
+++ b/components/MashCards/InitialDecisionCard.tsx
@@ -38,12 +38,12 @@ const InitialDecisionCard = ({ mashReferral }: Props): React.ReactElement => {
               </dd>
             </div>
             <div>
-              <dt>Screening decision</dt>
-              <dd>{mashReferral.screeningDecision}</dd>
+              <dt>Requested support</dt>
+              <dd>{mashReferral.requestedSupport}</dd>
             </div>
             <div>
-              <dt>Referral category</dt>
-              <dd>{mashReferral.referralCategory}</dd>
+              <dt></dt>
+              <dd></dd>
             </div>
             <div>
               <Link href="assign">

--- a/components/MashCards/ScreeningCard.tsx
+++ b/components/MashCards/ScreeningCard.tsx
@@ -31,9 +31,9 @@ const ScreeningCard = ({ mashReferral }: Props): React.ReactElement => {
               <dd>
                 <Link href={mashReferral.referralDocumentURI}>
                   <a>
-                    {mashReferral.clients[0]}
+                    {mashReferral.clients[0]} +{' '}
                     {mashReferral.clients.length > 1 &&
-                      ` + ${mashReferral.clients.length - 1} `}
+                      `+ ${mashReferral.clients.length - 1} `}
                     (referral)
                   </a>
                 </Link>

--- a/components/MashCards/ScreeningCard.tsx
+++ b/components/MashCards/ScreeningCard.tsx
@@ -31,7 +31,7 @@ const ScreeningCard = ({ mashReferral }: Props): React.ReactElement => {
               <dd>
                 <Link href={mashReferral.referralDocumentURI}>
                   <a>
-                    {mashReferral.clients[0]} +{' '}
+                    {mashReferral.clients[0] + ' '}
                     {mashReferral.clients.length > 1 &&
                       `+ ${mashReferral.clients.length - 1} `}
                     (referral)


### PR DESCRIPTION
**What**  
Minor changes to the initial decision card so it matches the designs from figma

https://www.figma.com/file/Mw7tNmwNUGzpZDBXMaGhAj/MASH?node-id=5%3A2

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
