### PR TITLE
chore: Added "immer" to package list

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "uk-postcode-validator": "^1.1.1",
     "use-resize-observer": "^7.0.0",
     "yup": "^0.32.9",
-    "immer": "9.0.6"
+    "immer": "^9.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "swr": "^0.5.6",
     "uk-postcode-validator": "^1.1.1",
     "use-resize-observer": "^7.0.0",
-    "yup": "^0.32.9"
+    "yup": "^0.32.9",
+    "immer": "9.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8542,6 +8542,11 @@ immer@8.0.1:
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
+immer@9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
+  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
+
 import-cwd@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-3.0.0.tgz#20845547718015126ea9b3676b7592fb8bd4cf92"


### PR DESCRIPTION
**What**  
This PR upgrades the package `immer` manually to the Dependabot version (9.0.6)

**Why**  
The package 'immer' was added to the dependabot warning checklist as it was an older version.
It wasn't able to upgrade it automatically.