### PR TITLE
feat: workflow pilot on timeline

### DIFF
--- a/components/NewPersonView/Event.spec.tsx
+++ b/components/NewPersonView/Event.spec.tsx
@@ -5,7 +5,11 @@ import Event from './Event';
 
 describe('Event', () => {
   it('renders the right info for a form wizard case note', () => {
-    render(<Event event={mockedCaseNote} />);
+    render(
+      <AppConfigProvider appConfig={{}}>
+        <Event event={mockedCaseNote} />
+      </AppConfigProvider>
+    );
 
     expect(screen.getAllByRole('heading').length).toBe(1);
     expect(screen.getAllByRole('link').length).toBe(1);
@@ -17,7 +21,11 @@ describe('Event', () => {
   });
 
   it('renders the right info for a warning note', () => {
-    render(<Event event={mockedWarningNoteCase} />);
+    render(
+      <AppConfigProvider appConfig={{}}>
+        <Event event={mockedWarningNoteCase} />
+      </AppConfigProvider>
+    );
 
     expect(screen.getAllByRole('heading').length).toBe(1);
     expect(screen.getAllByRole('link').length).toBe(1);

--- a/components/NewPersonView/Event.spec.tsx
+++ b/components/NewPersonView/Event.spec.tsx
@@ -29,7 +29,7 @@ describe('Event', () => {
 
   it('generates and truncates a snippet for form wizard case notes', () => {
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <Event
           event={{
             ...mockedWarningNoteCase,
@@ -55,7 +55,7 @@ describe('Event', () => {
 
   it('marks google docs', () => {
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <Event
           event={{
             ...mockedWarningNoteCase,

--- a/components/NewPersonView/Event.spec.tsx
+++ b/components/NewPersonView/Event.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { mockedCaseNote, mockedWarningNoteCase } from 'factories/cases';
+import { AppConfigProvider } from 'lib/appConfig';
 import Event from './Event';
 
 describe('Event', () => {
@@ -28,17 +29,19 @@ describe('Event', () => {
 
   it('generates and truncates a snippet for form wizard case notes', () => {
     render(
-      <Event
-        event={{
-          ...mockedWarningNoteCase,
-          caseFormData: {
-            ...mockedWarningNoteCase.caseFormData,
-            case_note_title: 'my title here',
-            case_note_description:
-              'my description here my description here my description here',
-          },
-        }}
-      />
+      <AppConfigProvider>
+        <Event
+          event={{
+            ...mockedWarningNoteCase,
+            caseFormData: {
+              ...mockedWarningNoteCase.caseFormData,
+              case_note_title: 'my title here',
+              case_note_description:
+                'my description here my description here my description here',
+            },
+          }}
+        />
+      </AppConfigProvider>
     );
     expect(
       screen.getByText(
@@ -52,12 +55,14 @@ describe('Event', () => {
 
   it('marks google docs', () => {
     render(
-      <Event
-        event={{
-          ...mockedWarningNoteCase,
-          caseFormUrl: 'google.com/123',
-        }}
-      />
+      <AppConfigProvider>
+        <Event
+          event={{
+            ...mockedWarningNoteCase,
+            caseFormUrl: 'google.com/123',
+          }}
+        />
+      </AppConfigProvider>
     );
     expect(screen.getByText('Google document', { exact: false }));
   });

--- a/components/NewPersonView/EventLink.spec.tsx
+++ b/components/NewPersonView/EventLink.spec.tsx
@@ -18,12 +18,28 @@ const mockGoogleForm = {
   caseFormUrl: 'https://docs.google.com/document/whatever',
 } as Case;
 
+const mockWorkflow = {
+  recordId: 'abcd1234',
+  formName: 'Example assessment',
+  personId: 123,
+  caseFormData: {
+    workflowId: '123abc',
+  },
+} as Case;
+
 describe('EventLink', () => {
   it('correctly handles a flexible form', () => {
     render(<EventLink event={mockFlexibleForm} />);
     expect(
       (screen.getByText('Case note - Test title') as HTMLLinkElement).href
     ).toContain(`/people/123/submissions/abcd1234`);
+  });
+
+  it('correctly handles a workflow', () => {
+    render(<EventLink event={mockWorkflow} />);
+    expect(
+      (screen.getByText('Example assessment') as HTMLLinkElement).href
+    ).toContain('/workflows/123abc');
   });
 
   it('correctly handles a google/external form', () => {

--- a/components/NewPersonView/EventLink.spec.tsx
+++ b/components/NewPersonView/EventLink.spec.tsx
@@ -30,7 +30,11 @@ const mockWorkflow = {
 
 describe('EventLink', () => {
   it('correctly handles a flexible form', () => {
-    render(<EventLink event={mockFlexibleForm} />);
+    render(
+      <AppConfigProvider>
+        <EventLink event={mockFlexibleForm} />
+      </AppConfigProvider>
+    );
     expect(
       (screen.getByText('Case note - Test title') as HTMLLinkElement).href
     ).toContain(`/people/123/submissions/abcd1234`);
@@ -50,21 +54,33 @@ describe('EventLink', () => {
   });
 
   it('correctly handles a google/external form', () => {
-    render(<EventLink event={mockGoogleForm} />);
+    render(
+      <AppConfigProvider>
+        <EventLink event={mockGoogleForm} />
+      </AppConfigProvider>
+    );
     expect(
       (screen.getByText('Example form name') as HTMLLinkElement).href
     ).toBe('https://docs.google.com/document/whatever');
   });
 
   it('correctly handles a legacy case note', () => {
-    render(<EventLink event={mockedCaseNote} />);
+    render(
+      <AppConfigProvider>
+        <EventLink event={mockedCaseNote} />
+      </AppConfigProvider>
+    );
     expect((screen.getByText('foorm') as HTMLLinkElement).href).toContain(
       `/people/123/records/4`
     );
   });
 
   it('correctly handles an allocation', () => {
-    render(<EventLink event={mockedAllocationNote} />);
+    render(
+      <AppConfigProvider>
+        <EventLink event={mockedAllocationNote} />
+      </AppConfigProvider>
+    );
     expect(
       (screen.getByText('Worker allocated') as HTMLLinkElement).href
     ).toContain('/people/123/allocations/321?recordId=2');
@@ -72,13 +88,15 @@ describe('EventLink', () => {
 
   it('correctly handles something unrecognisable', () => {
     render(
-      <EventLink
-        event={
-          {
-            caseFormData: {},
-          } as unknown as Case
-        }
-      />
+      <AppConfigProvider>
+        <EventLink
+          event={
+            {
+              caseFormData: {},
+            } as unknown as Case
+          }
+        />
+      </AppConfigProvider>
     );
     expect(screen.getByText('Unknown event'));
   });

--- a/components/NewPersonView/EventLink.spec.tsx
+++ b/components/NewPersonView/EventLink.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { mockedAllocationNote, mockedCaseNote } from 'factories/cases';
+import { AppConfigProvider } from 'lib/appConfig';
 import { Case } from 'types';
 import EventLink from './EventLink';
 
@@ -36,10 +37,16 @@ describe('EventLink', () => {
   });
 
   it('correctly handles a workflow', () => {
-    render(<EventLink event={mockWorkflow} />);
+    render(
+      <AppConfigProvider
+        appConfig={{ workflowsPilotUrl: 'http://example.com' }}
+      >
+        <EventLink event={mockWorkflow} />
+      </AppConfigProvider>
+    );
     expect(
       (screen.getByText('Example assessment') as HTMLLinkElement).href
-    ).toContain('/workflows/123abc');
+    ).toContain('http://example.com/workflows/123abc');
   });
 
   it('correctly handles a google/external form', () => {

--- a/components/NewPersonView/EventLink.spec.tsx
+++ b/components/NewPersonView/EventLink.spec.tsx
@@ -31,7 +31,7 @@ const mockWorkflow = {
 describe('EventLink', () => {
   it('correctly handles a flexible form', () => {
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <EventLink event={mockFlexibleForm} />
       </AppConfigProvider>
     );
@@ -55,7 +55,7 @@ describe('EventLink', () => {
 
   it('correctly handles a google/external form', () => {
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <EventLink event={mockGoogleForm} />
       </AppConfigProvider>
     );
@@ -66,7 +66,7 @@ describe('EventLink', () => {
 
   it('correctly handles a legacy case note', () => {
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <EventLink event={mockedCaseNote} />
       </AppConfigProvider>
     );
@@ -77,7 +77,7 @@ describe('EventLink', () => {
 
   it('correctly handles an allocation', () => {
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <EventLink event={mockedAllocationNote} />
       </AppConfigProvider>
     );
@@ -88,7 +88,7 @@ describe('EventLink', () => {
 
   it('correctly handles something unrecognisable', () => {
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <EventLink
           event={
             {

--- a/components/NewPersonView/EventLink.tsx
+++ b/components/NewPersonView/EventLink.tsx
@@ -28,7 +28,7 @@ const EventLink = ({ event }: Props): React.ReactElement => {
   }
 
   // 2. handle workflows
-  if (event.caseFormData.workflowId)
+  if (event?.caseFormData?.workflowId)
     return (
       <a
         href={`${getConfigValue('workflowsPilotUrl') as string}/workflows/${

--- a/components/NewPersonView/EventLink.tsx
+++ b/components/NewPersonView/EventLink.tsx
@@ -32,7 +32,7 @@ const EventLink = ({ event }: Props): React.ReactElement => {
     return (
       <a
         href={`${getConfigValue('workflowsPilotUrl') as string}/workflows/${
-          caseFormData.workflowId
+          event.caseFormData.workflowId
         }`}
       >
         {event.formName}

--- a/components/NewPersonView/EventLink.tsx
+++ b/components/NewPersonView/EventLink.tsx
@@ -4,13 +4,14 @@ import { Case } from 'types';
 import { generateInternalLink as generateLegacyUrl } from 'utils/urls';
 import s from './index.module.scss';
 
+const workflowsPilotUrl = `https://workflows-social-care-service.hackney.gov.uk`;
+
 interface Props {
   event: Case;
 }
 
 const EventLink = ({ event }: Props): React.ReactElement => {
   // 1. handle flexible forms
-
   if (event.formType === 'flexible-form') {
     const formName =
       mapFormIdToFormDefinition[event.formName]?.displayName || 'Form';
@@ -26,7 +27,15 @@ const EventLink = ({ event }: Props): React.ReactElement => {
     );
   }
 
-  // 2. handle external/google forms
+  // 2. handle workflows
+  if (event.caseFormData.workflowId)
+    return (
+      <a href={`${workflowsPilotUrl}/workflows/${caseFormData.workflowId}`}>
+        {event.formName}
+      </a>
+    );
+
+  // 3. handle external/google forms
   if (event.caseFormUrl)
     return (
       <a
@@ -39,7 +48,7 @@ const EventLink = ({ event }: Props): React.ReactElement => {
       </a>
     );
 
-  // 3. handle legacy forms
+  // 4. handle legacy forms
   const legacyUrl = generateLegacyUrl(event);
   if (legacyUrl)
     return (
@@ -48,7 +57,7 @@ const EventLink = ({ event }: Props): React.ReactElement => {
       </Link>
     );
 
-  // 4. handle anything else
+  // 5. handle anything else
   return <>{event.formName || 'Unknown event'}</>;
 };
 

--- a/components/NewPersonView/EventLink.tsx
+++ b/components/NewPersonView/EventLink.tsx
@@ -1,16 +1,16 @@
 import { mapFormIdToFormDefinition } from 'data/flexibleForms/mapFormIdsToFormDefinition';
+import { useAppConfig } from 'lib/appConfig';
 import Link from 'next/link';
 import { Case } from 'types';
 import { generateInternalLink as generateLegacyUrl } from 'utils/urls';
 import s from './index.module.scss';
-
-const workflowsPilotUrl = `https://workflows-social-care-service.hackney.gov.uk`;
-
 interface Props {
   event: Case;
 }
 
 const EventLink = ({ event }: Props): React.ReactElement => {
+  const { getConfigValue } = useAppConfig();
+
   // 1. handle flexible forms
   if (event.formType === 'flexible-form') {
     const formName =
@@ -30,7 +30,11 @@ const EventLink = ({ event }: Props): React.ReactElement => {
   // 2. handle workflows
   if (event.caseFormData.workflowId)
     return (
-      <a href={`${workflowsPilotUrl}/workflows/${caseFormData.workflowId}`}>
+      <a
+        href={`${getConfigValue('workflowsPilotUrl') as string}/workflows/${
+          caseFormData.workflowId
+        }`}
+      >
         {event.formName}
       </a>
     );

--- a/components/NewPersonView/PersonHistory.spec.tsx
+++ b/components/NewPersonView/PersonHistory.spec.tsx
@@ -5,6 +5,7 @@ import * as caseHooks from 'utils/api/cases';
 import { SWRInfiniteResponse } from 'swr';
 import { CaseData } from 'types';
 import { mockedCaseNote } from 'factories/cases';
+import { AppConfigProvider } from 'lib/appConfig';
 
 jest.mock('utils/api/cases');
 jest.mock('components/Spinner/Spinner', () => () => 'MockedSpinner');
@@ -27,7 +28,11 @@ describe('PersonHistory', () => {
       return response;
     });
 
-    render(<PersonHistory personId={mockedResident.id} />);
+    render(
+      <AppConfigProvider>
+        <PersonHistory personId={mockedResident.id} />
+      </AppConfigProvider>
+    );
     expect(screen.getByText('i am a case title'));
   });
 
@@ -44,7 +49,11 @@ describe('PersonHistory', () => {
       return response;
     });
 
-    render(<PersonHistory personId={mockedResident.id} />);
+    render(
+      <AppConfigProvider>
+        <PersonHistory personId={mockedResident.id} />
+      </AppConfigProvider>
+    );
     expect(screen.getByText('No events to show'));
   });
 
@@ -57,7 +66,11 @@ describe('PersonHistory', () => {
       return response;
     });
 
-    render(<PersonHistory personId={mockedResident.id} />);
+    render(
+      <AppConfigProvider>
+        <PersonHistory personId={mockedResident.id} />
+      </AppConfigProvider>
+    );
     expect(screen.getByText('MockedSpinner'));
   });
 
@@ -74,7 +87,11 @@ describe('PersonHistory', () => {
       return response;
     });
 
-    render(<PersonHistory personId={mockedResident.id} />);
+    render(
+      <AppConfigProvider>
+        <PersonHistory personId={mockedResident.id} />
+      </AppConfigProvider>
+    );
     expect(screen.getByText(errorMessage));
   });
 });

--- a/components/NewPersonView/PersonHistory.spec.tsx
+++ b/components/NewPersonView/PersonHistory.spec.tsx
@@ -29,7 +29,7 @@ describe('PersonHistory', () => {
     });
 
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <PersonHistory personId={mockedResident.id} />
       </AppConfigProvider>
     );
@@ -50,7 +50,7 @@ describe('PersonHistory', () => {
     });
 
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <PersonHistory personId={mockedResident.id} />
       </AppConfigProvider>
     );
@@ -67,7 +67,7 @@ describe('PersonHistory', () => {
     });
 
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <PersonHistory personId={mockedResident.id} />
       </AppConfigProvider>
     );
@@ -88,7 +88,7 @@ describe('PersonHistory', () => {
     });
 
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <PersonHistory personId={mockedResident.id} />
       </AppConfigProvider>
     );

--- a/components/NewPersonView/PersonTimeline.spec.tsx
+++ b/components/NewPersonView/PersonTimeline.spec.tsx
@@ -24,7 +24,7 @@ describe('PersonTimeline', () => {
       );
 
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <PersonTimeline
           setSize={jest.fn()}
           onLastPage={false}
@@ -43,7 +43,7 @@ describe('PersonTimeline', () => {
 
   it('can cope when there are no events to show', () => {
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <PersonTimeline
           setSize={jest.fn()}
           onLastPage={false}
@@ -58,7 +58,7 @@ describe('PersonTimeline', () => {
 
   it('hides the pagination button on the last page', () => {
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <PersonTimeline
           setSize={jest.fn()}
           onLastPage={true}
@@ -74,7 +74,7 @@ describe('PersonTimeline', () => {
   it('can load older events', () => {
     const mockHandler = jest.fn();
     render(
-      <AppConfigProvider>
+      <AppConfigProvider appConfig={{}}>
         <PersonTimeline
           setSize={mockHandler}
           onLastPage={false}

--- a/components/NewPersonView/PersonTimeline.spec.tsx
+++ b/components/NewPersonView/PersonTimeline.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { AppConfigProvider } from 'lib/appConfig';
 import {
   mockedAllocationNote,
   mockedCaseNote,
@@ -23,13 +24,15 @@ describe('PersonTimeline', () => {
       );
 
     render(
-      <PersonTimeline
-        setSize={jest.fn()}
-        onLastPage={false}
-        size={1}
-        events={mockEvents}
-        personId={1}
-      />
+      <AppConfigProvider>
+        <PersonTimeline
+          setSize={jest.fn()}
+          onLastPage={false}
+          size={1}
+          events={mockEvents}
+          personId={1}
+        />
+      </AppConfigProvider>
     );
 
     expect(screen.getAllByRole('listitem').length).toBe(5);
@@ -40,26 +43,30 @@ describe('PersonTimeline', () => {
 
   it('can cope when there are no events to show', () => {
     render(
-      <PersonTimeline
-        setSize={jest.fn()}
-        onLastPage={false}
-        size={1}
-        events={[]}
-        personId={1}
-      />
+      <AppConfigProvider>
+        <PersonTimeline
+          setSize={jest.fn()}
+          onLastPage={false}
+          size={1}
+          events={[]}
+          personId={1}
+        />
+      </AppConfigProvider>
     );
     expect(screen.getByText('No events match your search'));
   });
 
   it('hides the pagination button on the last page', () => {
     render(
-      <PersonTimeline
-        setSize={jest.fn()}
-        onLastPage={true}
-        size={1}
-        events={mockEvents}
-        personId={1}
-      />
+      <AppConfigProvider>
+        <PersonTimeline
+          setSize={jest.fn()}
+          onLastPage={true}
+          size={1}
+          events={mockEvents}
+          personId={1}
+        />
+      </AppConfigProvider>
     );
     expect(screen.queryByText('Load older events')).toBeNull();
   });
@@ -67,13 +74,15 @@ describe('PersonTimeline', () => {
   it('can load older events', () => {
     const mockHandler = jest.fn();
     render(
-      <PersonTimeline
-        setSize={mockHandler}
-        onLastPage={false}
-        size={1}
-        events={mockEvents}
-        personId={1}
-      />
+      <AppConfigProvider>
+        <PersonTimeline
+          setSize={mockHandler}
+          onLastPage={false}
+          size={1}
+          events={mockEvents}
+          personId={1}
+        />
+      </AppConfigProvider>
     );
     fireEvent.click(screen.getByText('Load older events'));
     expect(mockHandler).toBeCalledWith(2);

--- a/types.ts
+++ b/types.ts
@@ -44,6 +44,7 @@ interface CaseFormDataBase {
   form_url?: string;
   case_note_title?: string;
   case_note_description?: string;
+  workflowId?: string;
 }
 
 export interface AllocationCaseFormData extends CaseFormDataBase {
@@ -91,12 +92,7 @@ export type CaseFormData =
   | CaseFormDataBase
   | AllocationCaseFormData
   | DeallocationCaseFormData
-  | WarningNoteCaseFormData
-  | WorkflowData;
-
-export interface WorkflowData {
-  workflowId: string;
-}
+  | WarningNoteCaseFormData;
 
 export interface Case {
   recordId: string;

--- a/types.ts
+++ b/types.ts
@@ -88,11 +88,11 @@ export interface HistoricVisitData {
 }
 
 export type CaseFormData =
-  // | CaseFormDataBase
-  // | AllocationCaseFormData
-  // | DeallocationCaseFormData
-  // | WarningNoteCaseFormData
-  WorkflowData;
+  | CaseFormDataBase
+  | AllocationCaseFormData
+  | DeallocationCaseFormData
+  | WarningNoteCaseFormData
+  | WorkflowData;
 
 export interface WorkflowData {
   workflowId: string;

--- a/types.ts
+++ b/types.ts
@@ -88,10 +88,15 @@ export interface HistoricVisitData {
 }
 
 export type CaseFormData =
-  | CaseFormDataBase
-  | AllocationCaseFormData
-  | DeallocationCaseFormData
-  | WarningNoteCaseFormData;
+  // | CaseFormDataBase
+  // | AllocationCaseFormData
+  // | DeallocationCaseFormData
+  // | WarningNoteCaseFormData
+  WorkflowData;
+
+export interface WorkflowData {
+  workflowId: string;
+}
 
 export interface Case {
   recordId: string;


### PR DESCRIPTION
modify timeline events to correctly show workflows:
- detect whether a case represents a workflow by looking for a `workflowId` string in `caseFormData`
- use a link `href` that correctly links to the pilot app
- show the correct name of the assessment/form type

![Capture](https://user-images.githubusercontent.com/14189497/142200041-d9f26688-beae-4bea-8972-cf36b73034c0.PNG)

