### PR TITLE
feat(SCT-1505): final decision form to submit answers to api

### DIFF
--- a/components/MashForms/FinalDecisionForm.spec.tsx
+++ b/components/MashForms/FinalDecisionForm.spec.tsx
@@ -1,0 +1,102 @@
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { mockedMashReferral } from 'factories/mashReferral';
+import { submitFinalDecision } from 'utils/api/mashReferrals';
+import { mockedWorker } from 'factories/workers';
+import FinalDecisionForm from './FinalDecisionForm';
+
+jest.mock('utils/api/mashReferrals');
+
+const mockPush = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+describe('#FinalDecisionForm', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    render(
+      <FinalDecisionForm
+        referral={mockedMashReferral}
+        workerEmail={mockedWorker.email}
+      />
+    );
+  });
+
+  it('should render correctly', () => {
+    expect(screen.getByText('Document the decision'));
+
+    expect(screen.getByText('Make final decision'));
+    expect(screen.getByText('Select referral category'));
+    expect(screen.getByText('Is this contact urgent?'));
+    expect(screen.getByText('Submit'));
+  });
+
+  it('should dynamically render hint text for emailing a mash manager if decision is urgent', () => {
+    expect(
+      screen.queryByText(
+        'Please email your MASH manager about the urgent case.'
+      )
+    ).toBeNull();
+
+    fireEvent.click(screen.getByText('Yes'));
+
+    expect(
+      screen.getByText('Please email your MASH manager about the urgent case.')
+    );
+  });
+
+  it('should disable submit button when submitFinalDecision Submit button is clicked', () => {
+    expect(screen.getByText('Submit')).not.toHaveAttribute('disabled');
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    expect(screen.getByText('Submit')).toHaveAttribute('disabled');
+  });
+
+  it('should call submitFinalDecision Submit button is clicked', () => {
+    (submitFinalDecision as jest.Mock).mockResolvedValue(true);
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    expect(submitFinalDecision).toBeCalledWith(
+      mockedMashReferral.id,
+      mockedWorker.email,
+      'NFA',
+      'Abuse linked to faith or belief',
+      false
+    );
+  });
+
+  it('should reroute the user with a confirmation when submitFinalDecision returns successfully', async () => {
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(mockPush).toBeCalledWith({
+        pathname: '/team-assignments',
+        query: {
+          confirmation: `{"title":"A decision has been submitted for ${mockedMashReferral.clients.join(
+            ' and '
+          )}","link":"${
+            mockedMashReferral.referralDocumentURI
+          }","Final decision":"NFA","Referral category":"Abuse linked to faith or belief"}`,
+          tab: 'final-decision',
+        },
+      });
+    });
+  });
+
+  it('should show an error message when submitFinalDecision throws an error', async () => {
+    const errorMessage = 'TEST-ERROR-MESSAGE';
+    const errorObject = { response: { data: errorMessage } };
+    (submitFinalDecision as jest.Mock).mockRejectedValue(errorObject);
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(screen.getByText(errorMessage));
+    });
+  });
+});

--- a/components/MashForms/FinalDecisionForm.tsx
+++ b/components/MashForms/FinalDecisionForm.tsx
@@ -157,11 +157,13 @@ const FinalDecisionForm = ({
                     Yes
                   </label>
                 </div>
-                <div className="govuk-radios__conditional" id="hint-email">
-                  <label className="govuk-label" htmlFor="hint">
-                    Please email your MASH manager about the urgent case.
-                  </label>
-                </div>
+                {urgent && (
+                  <div className="govuk-radios__conditional" id="hint-email">
+                    <label className="govuk-label" htmlFor="hint">
+                      Please email your MASH manager about the urgent case.
+                    </label>
+                  </div>
+                )}
               </div>
             </fieldset>
           </>,

--- a/components/MashForms/FinalDecisionForm.tsx
+++ b/components/MashForms/FinalDecisionForm.tsx
@@ -1,17 +1,74 @@
+import { AxiosError } from 'axios';
 import Button from 'components/Button/Button';
+import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import Select from 'components/Form/Select/Select';
 import Heading from 'components/MashHeading/Heading';
 import NumberedSteps from 'components/NumberedSteps/NumberedSteps';
 import finalDecisionOptions from 'data/mashOptions/finalDecisionOptions';
 import referralCategories from 'data/mashOptions/referralCategories';
+import { useRouter } from 'next/router';
 import React, { useState } from 'react';
+import { MashReferral } from 'types';
+import { submitFinalDecision } from 'utils/api/mashReferrals';
 
-const FinalDecisionForm = (): React.ReactElement => {
+interface Props {
+  referral: MashReferral;
+  workerEmail: string;
+}
+
+const FinalDecisionForm = ({
+  referral,
+  workerEmail,
+}: Props): React.ReactElement => {
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
   const [decision, setDecision] = useState('NFA');
   const [referralCategory, setReferralCategory] = useState(
     'Abuse linked to faith or belief'
   );
   const [urgent, setUrgent] = useState(false);
+
+  const router = useRouter();
+
+  const confirmation = {
+    title: `A decision has been submitted for ${referral.clients.join(
+      ' and '
+    )}`,
+    link: referral.referralDocumentURI,
+    'Final decision': decision,
+    'Referral category': referralCategory,
+  };
+
+  const submitForm = async () => {
+    setSubmitting(true);
+    setErrorMessage('');
+
+    try {
+      await submitFinalDecision(
+        referral.id,
+        workerEmail,
+        decision,
+        referralCategory,
+        urgent
+      );
+
+      setSubmitting(false);
+
+      router.push({
+        pathname: `/team-assignments`,
+        query: {
+          tab: 'final-decision',
+          confirmation: JSON.stringify(confirmation),
+        },
+      });
+    } catch (error) {
+      const axiosError = error as AxiosError;
+
+      setSubmitting(false);
+      setErrorMessage(axiosError.response?.data);
+    }
+  };
 
   return (
     <>
@@ -85,7 +142,7 @@ const FinalDecisionForm = (): React.ReactElement => {
                     id="no-input"
                     name="urgency"
                     type="radio"
-                    onClick={() => setUrgent(false)}
+                    onChange={() => setUrgent(false)}
                     checked={!urgent}
                   />
                   <label
@@ -101,7 +158,7 @@ const FinalDecisionForm = (): React.ReactElement => {
                     id="yes-input"
                     name="urgency"
                     type="radio"
-                    onClick={() => setUrgent(true)}
+                    onChange={() => setUrgent(true)}
                     checked={urgent}
                   />
                   <label
@@ -121,9 +178,14 @@ const FinalDecisionForm = (): React.ReactElement => {
           </>,
         ]}
       />
-
+      {errorMessage && <ErrorMessage label={errorMessage} />}
       <div style={{ display: 'flex', alignItems: 'center' }}>
-        <Button label="Submit" type="submit" />
+        <Button
+          label="Submit"
+          type="submit"
+          onClick={submitForm}
+          disabled={submitting}
+        />
         <p className="lbh-body">
           <a
             href="#"

--- a/components/MashForms/FinalDecisionForm.tsx
+++ b/components/MashForms/FinalDecisionForm.tsx
@@ -117,17 +117,6 @@ const FinalDecisionForm = ({
             />
           </>,
           <>
-            <label htmlFor="referral-category" className="lbh-heading-h3">
-              Allocate out of MASH
-            </label>
-            <Select
-              id="allocate"
-              name="allocate"
-              ignoreValue
-              options={['option 1', 'option 2']}
-            />
-          </>,
-          <>
             <fieldset className="govuk-fieldset">
               <legend className="lbh-heading-h3">
                 Is this contact urgent?

--- a/lib/mashReferral.ts
+++ b/lib/mashReferral.ts
@@ -86,3 +86,32 @@ export const patchReferralInitial = async (
 
   return data;
 };
+
+interface FinalDecision {
+  workerEmail: string;
+  updateType: 'FINAL-DECISION';
+  decision: string;
+  referralCategory: string;
+  requiresUrgentContact: boolean;
+  referralId: string;
+}
+
+export const patchReferralFinal = async (
+  update: FinalDecision
+): Promise<MashReferral> => {
+  const { data } = await axios.patch<MashReferral>(
+    `${ENDPOINT_API}/mash-referral/${update.referralId}`,
+    {
+      workerEmail: update.workerEmail,
+      updateType: update.updateType,
+      decision: update.decision,
+      requiresUrgentContact: update.requiresUrgentContact,
+      referralCategory: update.referralCategory,
+    },
+    {
+      headers: { 'Content-Type': 'application/json', 'x-api-key': AWS_KEY },
+    }
+  );
+
+  return data;
+};

--- a/pages/api/mash-referral/[id]/index.ts
+++ b/pages/api/mash-referral/[id]/index.ts
@@ -3,7 +3,11 @@ import { StatusCodes } from 'http-status-codes';
 import { isAuthorised } from 'utils/auth';
 
 import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
-import { patchReferralInitial, patchReferralScreening } from 'lib/mashReferral';
+import {
+  patchReferralFinal,
+  patchReferralInitial,
+  patchReferralScreening,
+} from 'lib/mashReferral';
 import { AxiosError } from 'axios';
 
 const endpoint: NextApiHandler = async (
@@ -59,6 +63,31 @@ const endpoint: NextApiHandler = async (
             decision,
             requiresUrgentContact,
             updateType: 'INITIAL-DECISION',
+            workerEmail,
+            referralCategory,
+          });
+
+          res.status(StatusCodes.OK).json(data);
+        } else if (updateTye === 'FINAL-DECISION') {
+          const {
+            referralId,
+            decision,
+            requiresUrgentContact,
+            workerEmail,
+            referralCategory,
+          } = {
+            referralId: req.query.id as string,
+            decision: req.body.decision,
+            requiresUrgentContact: req.body.requiresUrgentContact,
+            workerEmail: req.body.workerEmail,
+            referralCategory: req.body.referralCategory,
+          };
+
+          const data = await patchReferralFinal({
+            referralId,
+            decision,
+            requiresUrgentContact,
+            updateType: 'FINAL-DECISION',
             workerEmail,
             referralCategory,
           });

--- a/pages/mash-referral/[id]/final-decision.tsx
+++ b/pages/mash-referral/[id]/final-decision.tsx
@@ -1,6 +1,53 @@
 import FinalDecisionForm from 'components/MashForms/FinalDecisionForm';
+import { getMashReferral } from 'lib/mashReferral';
+import { GetServerSideProps } from 'next';
+import { MashReferral, ReferralStage } from 'types';
+import { isAuthorised } from 'utils/auth';
 
-const FinalDecision = (): React.ReactElement => {
-  return <FinalDecisionForm />;
+interface Props {
+  referral: MashReferral;
+  workerEmail: string;
+}
+
+const FinalDecision = ({
+  referral,
+  workerEmail,
+}: Props): React.ReactElement => {
+  return <FinalDecisionForm referral={referral} workerEmail={workerEmail} />;
 };
+
+export const getServerSideProps: GetServerSideProps = async ({
+  req,
+  params,
+}) => {
+  const user = isAuthorised(req);
+
+  if (!user) {
+    return {
+      props: {},
+      redirect: {
+        destination: `/login`,
+      },
+    };
+  }
+
+  const referral = await getMashReferral(params?.id as string);
+
+  if (!referral || referral.stage !== ReferralStage.FINAL) {
+    return {
+      props: {},
+      redirect: {
+        destination: `/404`,
+      },
+    };
+  }
+
+  return {
+    props: {
+      referral,
+      workerEmail: user.email,
+    },
+  };
+};
+
 export default FinalDecision;

--- a/utils/api/mashReferrals.ts
+++ b/utils/api/mashReferrals.ts
@@ -16,7 +16,7 @@ export const submitScreeningDecision = async (
       workerEmail: workerEmail,
     }
   );
-  return response?.data;
+  return response.data;
 };
 
 export const submitInitialDecision = async (
@@ -36,6 +36,25 @@ export const submitInitialDecision = async (
       workerEmail: workerEmail,
     }
   );
+  return response.data;
+};
 
+export const submitFinalDecision = async (
+  referralId: string,
+  workerEmail: string,
+  decision: string,
+  referralCategory: string,
+  requiresUrgentContact: boolean
+): Promise<MashReferral> => {
+  const response = await axios.patch<MashReferral>(
+    `/api/mash-referral/${referralId}/`,
+    {
+      decision,
+      requiresUrgentContact,
+      referralCategory,
+      updateType: 'FINAL-DECISION',
+      workerEmail: workerEmail,
+    }
+  );
   return response.data;
 };


### PR DESCRIPTION
**What**  
Pass in required props to our FinalDecisionForm
Hitting submit on final decision form now submits answers to the API. API is not setup to handle the incoming data yet and update the referral.
Handle error and submitting state.

**Why**  
The form actually needs to be able to submit data to the backend...

**Anything else?**

- Have you added any new third-party libraries? No
- Are any new environment variables or configuration values needed? No
- Anything else in this PR that isn't covered by the what/why? No
