### PR TITLE
feat: reset button for dummy data

### DIFF
--- a/components/MashDashboard/MashDashboard.tsx
+++ b/components/MashDashboard/MashDashboard.tsx
@@ -1,10 +1,12 @@
 import st from 'components/Tabs/Tabs.module.scss';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Tab from 'components/SubmissionsTable/Tab';
 import MainCard from 'components/MashCards/MainCard';
 import { MashReferral, ReferralStage } from 'types';
 import { useRouter } from 'next/router';
 import SuccessSummary from 'components/SuccessSummary/SuccessSummary';
+import Button from 'components/Button/Button';
+import { resetDummyData } from 'utils/api/mashReferrals';
 
 interface Props {
   referrals: MashReferral[];
@@ -19,6 +21,7 @@ const possibleTabs = new Set([
 
 export const MashDashboard = ({ referrals }: Props): React.ReactElement => {
   const [filter, setFilter] = useState('contact');
+  const [submitting, setSubmitting] = useState(false);
 
   const router = useRouter();
 
@@ -66,6 +69,13 @@ export const MashDashboard = ({ referrals }: Props): React.ReactElement => {
     router.push(router);
   };
 
+  const resetData = async () => {
+    setSubmitting(true);
+    await resetDummyData();
+    setSubmitting(false);
+    router.reload();
+  };
+
   return (
     <div>
       <>
@@ -101,6 +111,12 @@ export const MashDashboard = ({ referrals }: Props): React.ReactElement => {
             </Tab>
           </ul>
         </fieldset>
+        <Button
+          label="Reset Dummy Data"
+          type="submit"
+          onClick={resetData}
+          disabled={submitting}
+        />
         <div>
           <MainCard filter={filter} mashReferrals={mashReferrals}></MainCard>
         </div>

--- a/lib/mashReferral.ts
+++ b/lib/mashReferral.ts
@@ -115,3 +115,15 @@ export const patchReferralFinal = async (
 
   return data;
 };
+
+export const resetDummyData = async (): Promise<undefined> => {
+  const { data } = await axios.post<undefined>(
+    `${ENDPOINT_API}/mash-referral/reset`,
+    undefined,
+    {
+      headers: { 'Content-Type': 'application/json', 'x-api-key': AWS_KEY },
+    }
+  );
+
+  return data;
+};

--- a/pages/api/mash-referral/reset.ts
+++ b/pages/api/mash-referral/reset.ts
@@ -1,0 +1,41 @@
+import { StatusCodes } from 'http-status-codes';
+
+import { isAuthorised } from 'utils/auth';
+
+import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
+
+import { AxiosError } from 'axios';
+import { resetDummyData } from 'lib/mashReferral';
+
+const endpoint: NextApiHandler = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
+  const user = isAuthorised(req);
+  if (!user) {
+    return res.status(StatusCodes.UNAUTHORIZED).end();
+  }
+  if (!user.isAuthorised) {
+    return res.status(StatusCodes.FORBIDDEN).end();
+  }
+  switch (req.method) {
+    case 'POST':
+      try {
+        await resetDummyData();
+        res.status(StatusCodes.OK).json(undefined);
+      } catch (error: unknown) {
+        const axiosError = error as AxiosError;
+        res
+          .status(axiosError.response?.status || 500)
+          .json(axiosError?.response?.data);
+      }
+      break;
+
+    default:
+      res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: 'Invalid request method' });
+  }
+};
+
+export default endpoint;

--- a/utils/api/mashReferrals.ts
+++ b/utils/api/mashReferrals.ts
@@ -58,3 +58,8 @@ export const submitFinalDecision = async (
   );
   return response.data;
 };
+
+export const resetDummyData = async (): Promise<undefined> => {
+  const response = await axios.post<undefined>(`api/mash-referral/reset`);
+  return response.data;
+};


### PR DESCRIPTION
This is just for testing purposes, allow staff to easily hit reset endpoint to revert all the staging dummy data.