### PR TITLE
fix(SCT-1523): removed hardcoded URL from case status flag

### DIFF
--- a/components/CaseStatus/CaseStatusFlag/CaseStatusFlag.tsx
+++ b/components/CaseStatus/CaseStatusFlag/CaseStatusFlag.tsx
@@ -39,11 +39,7 @@ const CaseStatusFlag = ({ person }: Props): React.ReactElement => {
                   new Date(status.startDate),
                   'dd MMM yyyy'
                 )}`}</p>
-                <a
-                  href={`http://dev.hackney.gov.uk:3000/people/${person.id}/details`}
-                >
-                  View details
-                </a>
+                <a href={`/people/${person.id}/details`}>View details</a>
               </>
             }
           >


### PR DESCRIPTION
**What**  
The URL now uses a relative path so it doesn't matter if we're in dev/staging/prod, the link will always work

**Why**  
The Case Status flag had the development link hardcoded in the link, making it useless on production.