### PR TITLE
feat: switch around aliases for production in serverless config

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -110,8 +110,8 @@ custom:
         - amazonaws.com
   aliases:
     staging: social-care-service-staging.hackney.gov.uk
-    production: social-care-service.hackney.gov.uk
-    mosaic-prod: social-care-service-alb-temp.hackney.gov.uk
+    production: social-care-service-alb-temp.hackney.gov.uk
+    mosaic-prod: social-care-service.hackney.gov.uk
   certificate-arn:
     staging: arn:aws:acm:us-east-1:715003523189:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a
     production: arn:aws:acm:us-east-1:153306643385:certificate/71728a39-cd3e-4570-a440-e87f84ef9a0d


### PR DESCRIPTION
**What**  

Switcharoo domain names for production in serverless config to get them using the right Cloudfront distributions.

**Why**  

To enable the frontend migration to Mosaic-Production. 

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
