### PR TITLE
feat: update CloudFront alias for production to be non-existent

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -110,7 +110,7 @@ custom:
         - amazonaws.com
   aliases:
     staging: social-care-service-staging.hackney.gov.uk
-    production: social-care-service-alb-temp.hackney.gov.uk
+    production: social-care-service-alb-temp-non-existent.hackney.gov.uk
     mosaic-prod: social-care-service.hackney.gov.uk
   certificate-arn:
     staging: arn:aws:acm:us-east-1:715003523189:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a


### PR DESCRIPTION
**What**  

Update the CloudFront alias for production to be something that is non-existent.

**Why**  

We want to switch around the domain names attached to CloudFront distributions in ProductionAPIs and Mosaic-Production but can't because they're both attached to a distribution. As a result, we need to point production to something non-existent, deploy that to remove the association and then deploy to Mosaic-Production to switcharoo.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
