### PR TITLE
feat(SCT-1348): Added description to deleted case notes in timeline

### DIFF
--- a/components/NewPersonView/Event.spec.tsx
+++ b/components/NewPersonView/Event.spec.tsx
@@ -1,5 +1,9 @@
 import { render, screen } from '@testing-library/react';
-import { mockedCaseNote, mockedWarningNoteCase } from 'factories/cases';
+import {
+  mockedCaseNote,
+  mockedWarningNoteCase,
+  mockedDeletedCaseNote,
+} from 'factories/cases';
 import { AppConfigProvider } from 'lib/appConfig';
 import Event from './Event';
 
@@ -33,6 +37,21 @@ describe('Event', () => {
     expect(screen.getByText('Warning Note'));
     expect(screen.getByText('25 Oct 2020 1.49 pm', { exact: false }));
     expect(screen.getByText('Fname.Lname@hackney.gov.uk', { exact: false }));
+  });
+  it('renders the right info for a deleted case note', () => {
+    render(
+      <AppConfigProvider appConfig={{}}>
+        <Event event={mockedDeletedCaseNote} />
+      </AppConfigProvider>
+    );
+
+    expect(screen.getAllByRole('heading').length).toBe(1);
+    expect(screen.getAllByRole('link').length).toBe(1);
+
+    expect(screen.queryByText('deleted 31 Dec 2020')).toBeInTheDocument;
+    expect(screen.queryByText('Some reason')).toBeInTheDocument;
+    expect(screen.queryByText('requested by Some people')).not
+      .toBeInTheDocument;
   });
 
   it('generates and truncates a snippet for form wizard case notes', () => {

--- a/components/NewPersonView/Event.tsx
+++ b/components/NewPersonView/Event.tsx
@@ -48,15 +48,11 @@ const Event = ({ event }: Props): React.ReactElement => {
         {safelyFormat(displayDate)}
         {event.caseFormUrl?.includes('google') && ` · Google document`}
         {event.officerEmail && ` · ${event.officerEmail}`}
-        {event.deleted && event.deletedFields
-          ? ` · deleted ${safelyFormat(event.deletedFields?.dateOfDeletion)}`
-          : null}
-        {event.deleted && event.deletedFields
-          ? ` · ${event.deletedFields?.deleteReason}`
-          : null}
-        {event.deleted && event.deletedFields
-          ? ` · requested by ${event.deletedFields?.deleteRequestedBy}`
-          : null}
+        {event.deleted &&
+          event.deletedFields &&
+          ` · deleted ${safelyFormat(event.deletedFields?.dateOfDeletion)}
+          · ${event.deletedFields?.deleteReason}
+          · requested by ${event.deletedFields?.deleteRequestedBy}`}
       </p>
 
       {displaySnippet && (

--- a/components/NewPersonView/Event.tsx
+++ b/components/NewPersonView/Event.tsx
@@ -48,6 +48,15 @@ const Event = ({ event }: Props): React.ReactElement => {
         {safelyFormat(displayDate)}
         {event.caseFormUrl?.includes('google') && ` · Google document`}
         {event.officerEmail && ` · ${event.officerEmail}`}
+        {event.deleted && event.deletedFields
+          ? ` · deleted ${safelyFormat(event.deletedFields?.dateOfDeletion)}`
+          : null}
+        {event.deleted && event.deletedFields
+          ? ` · ${event.deletedFields?.deleteReason}`
+          : null}
+        {event.deleted && event.deletedFields
+          ? ` · requested by ${event.deletedFields?.deleteRequestedBy}`
+          : null}
       </p>
 
       {displaySnippet && (

--- a/components/NewPersonView/Event.tsx
+++ b/components/NewPersonView/Event.tsx
@@ -49,10 +49,10 @@ const Event = ({ event }: Props): React.ReactElement => {
         {event.caseFormUrl?.includes('google') && ` · Google document`}
         {event.officerEmail && ` · ${event.officerEmail}`}
         {event.deleted &&
-          event.deletedFields &&
-          ` · deleted ${safelyFormat(event.deletedFields?.dateOfDeletion)}
-          · ${event.deletedFields?.deleteReason}
-          · requested by ${event.deletedFields?.deleteRequestedBy}`}
+          event.deletionDetails &&
+          ` · deleted ${safelyFormat(event.deletionDetails?.deletedAt)}
+          · ${event.deletionDetails?.deleteReason}
+          · requested by ${event.deletionDetails?.deleteRequestedBy}`}
       </p>
 
       {displaySnippet && (

--- a/cypress/integration/delete_case_note.ts
+++ b/cypress/integration/delete_case_note.ts
@@ -1,0 +1,45 @@
+import { AuthRoles } from '../support/commands';
+
+describe('Deleting case notes', () => {
+  describe('As a user not in the Admin group', () => {
+    it('should not be possible to delete a case note', () => {
+      cy.visitAs(
+        `people/${Cypress.env(
+          'CHILDREN_RECORD_PERSON_ID'
+        )}/submissions/61a8cedff9756ca60348fee8`,
+        AuthRoles.ChildrensGroup
+      );
+      cy.contains(/Delete record/).should('not.exist');
+    });
+    it('should be not possible to view a deleted case note', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}`,
+        AuthRoles.ChildrensGroup
+      );
+      cy.contains(/Show deleted records/).should('not.exist');
+    });
+  });
+
+  describe('As a user in the Admin group', () => {
+    it('should be possible to delete a case note', () => {
+      cy.visitAs(
+        `people/${Cypress.env(
+          'CHILDREN_RECORD_PERSON_ID'
+        )}/submissions/61a8cedff9756ca60348fee8`,
+        AuthRoles.AdminDevGroup
+      );
+      cy.contains(/Delete record/).should('exist');
+    });
+    it('should be possible to view a deleted case note', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}`,
+        AuthRoles.AdminDevGroup
+      );
+      cy.contains(/Show deleted records/).click();
+      cy.contains(/Hide deleted records/).should('be.visible');
+      cy.contains(/(deleted record)/).should('be.visible');
+      cy.contains(/deleted 2 Dec 2021 1.51 pm/).should('be.visible');
+      cy.contains(/requested by requester/).should('be.visible');
+    });
+  });
+});

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -163,6 +163,7 @@ export interface Submission {
   title?: string;
   deleted: boolean;
   deletedFields?: {
+    dateOfDeletion: string;
     deletedBy: string;
     deleteReason: string;
     deleteRequestedBy: string;

--- a/data/flexibleForms/forms.types.ts
+++ b/data/flexibleForms/forms.types.ts
@@ -162,8 +162,8 @@ export interface Submission {
   completedSteps: number;
   title?: string;
   deleted: boolean;
-  deletedFields?: {
-    dateOfDeletion: string;
+  deletionDetails?: {
+    deletedAt: string;
     deletedBy: string;
     deleteReason: string;
     deleteRequestedBy: string;

--- a/factories/cases.ts
+++ b/factories/cases.ts
@@ -59,7 +59,7 @@ export const mockedDeletedCaseNote = caseFactory.build({
   deleted: true,
   deletedFields: {
     deletedBy: 'jack.musajo@hackney.gov.uk',
-    dateOfDeletion: '2020-12-31',
+    dateOfDeletion: '2020-12-31T00:00:00Z',
     deleteReason: 'Some reason',
     deleteRequestedBy: 'Some people',
   },

--- a/factories/cases.ts
+++ b/factories/cases.ts
@@ -57,9 +57,9 @@ export const mockedDeletedCaseNote = caseFactory.build({
   },
   formName: 'adult-case-note',
   deleted: true,
-  deletedFields: {
+  deletionDetails: {
     deletedBy: 'jack.musajo@hackney.gov.uk',
-    dateOfDeletion: '2020-12-31T00:00:00Z',
+    deletedAt: '2020-12-31T00:00:00Z',
     deleteReason: 'Some reason',
     deleteRequestedBy: 'Some people',
   },

--- a/factories/cases.ts
+++ b/factories/cases.ts
@@ -57,6 +57,12 @@ export const mockedDeletedCaseNote = caseFactory.build({
   },
   formName: 'adult-case-note',
   deleted: true,
+  deletedFields: {
+    deletedBy: 'jack.musajo@hackney.gov.uk',
+    dateOfDeletion: '2020-12-31',
+    deleteReason: 'Some reason',
+    deleteRequestedBy: 'Some people',
+  },
 });
 export const mockedWarningNoteCase = caseFactory.build({
   formName: 'Warning Note',

--- a/types.ts
+++ b/types.ts
@@ -111,6 +111,7 @@ export interface Case {
   isImported: boolean;
   deleted: boolean;
   deletedFields?: {
+    dateOfDeletion: string;
     deletedBy: string;
     deleteReason: string;
     deleteRequestedBy: string;

--- a/types.ts
+++ b/types.ts
@@ -110,8 +110,8 @@ export interface Case {
   title?: string;
   isImported: boolean;
   deleted: boolean;
-  deletedFields?: {
-    dateOfDeletion: string;
+  deletionDetails?: {
+    deletedAt: string;
     deletedBy: string;
     deleteReason: string;
     deleteRequestedBy: string;

--- a/utils/api/cases.spec.ts
+++ b/utils/api/cases.spec.ts
@@ -39,7 +39,7 @@ describe('cases APIs', () => {
         '/api/residents/123/cases?bar=foobar'
       );
     });
-    it.only('should send multiple parameters properly', () => {
+    it('should send multiple parameters properly', () => {
       jest
         .spyOn(SWR, 'useSWRInfinite')
         .mockImplementation(


### PR DESCRIPTION
[Link to ticket ](https://hackney.atlassian.net/browse/SCT-1348)

**What**  

- Added extra information to a deleted case notes in the timeline
- Added tests
- Enabled some Case Note deletion test that were disabled by mistake

**Why**  
We need to display the deletion extra information in the timeline (requested by / date / reason for deletion)


![image](https://user-images.githubusercontent.com/13645306/144276656-11b71b85-6a8c-4b11-8da7-7914cdb83ec7.png)
