### PR TITLE
fix(SCT-1346): Extend feature flags

### DIFF
--- a/features.ts
+++ b/features.ts
@@ -29,7 +29,7 @@ export const getFeatureFlags = ({
       isActive:
         environmentName === 'development' || user?.hasAdminPermissions || false,
     },
-    // FEATURE-FLAG-EXPIRES [2021-11-31]: workflows-pilot
+    // FEATURE-FLAG-EXPIRES [2022-01-31]: workflows-pilot
     'workflows-pilot': {
       isActive: ['development', 'production'].includes(environmentName),
     },

--- a/features.ts
+++ b/features.ts
@@ -20,11 +20,11 @@ export const getFeatureFlags = ({
       isActive:
         environmentName === 'development' || user?.hasAdminPermissions || false,
     },
-    // FEATURE-FLAG-EXPIRES [2021-12-31]: case-notes-deletion
+    // FEATURE-FLAG-EXPIRES [2022-01-31]: case-notes-deletion
     'case-notes-deletion': {
       isActive: environmentName === 'development',
     },
-    // FEATURE-FLAG-EXPIRES [2021-12-31]: case-status
+    // FEATURE-FLAG-EXPIRES [2022-01-31]: case-status
     'case-status': {
       isActive:
         environmentName === 'development' || user?.hasAdminPermissions || false,


### PR DESCRIPTION
**What**  
Some of the features flags had expiry dates that had passed or were close. These dates have been extended to 31/01/2022.

**Why**  
When we pass the expiry date on the feature flags, the main pipeline fails and it is not possible to deploy to production
