### PR TITLE
feat(SCT-1552): Add deleted information to case note history

### DIFF
--- a/components/RevisionTimeline/RevisionTimeline.spec.tsx
+++ b/components/RevisionTimeline/RevisionTimeline.spec.tsx
@@ -82,6 +82,29 @@ describe('RevisionTimeline', () => {
     expect(screen.getByText('28 Jul 2021', { exact: false }));
   });
 
+  it('correctly renders a deleted approval', () => {
+    mockSubmission.deleted = true;
+    mockSubmission.deletionDetails = {
+      deletedAt: '2021-07-28T11:00:00.000Z',
+      deleteReason: 'Reason',
+      deletedBy: 'Jack Musajo',
+      deleteRequestedBy: 'jack.musajo@hackney.gov.uk',
+    };
+    render(
+      <RevisionTimeline
+        submission={{
+          ...mockSubmission,
+          approvedAt: '2021-07-28T11:00:00.000Z',
+          approvedBy: mockedWorker,
+        }}
+      />
+    );
+
+    expect(screen.queryByText(/Deleted record/));
+    expect(screen.queryByText(/Deleted by jack.musajo@hackney.gov.uk/));
+    expect(screen.queryByText(/28 Jun 2021/));
+  });
+
   it('correctly renders a panel approval', () => {
     render(
       <RevisionTimeline
@@ -96,6 +119,6 @@ describe('RevisionTimeline', () => {
     expect(
       screen.getByText(`Approved on behalf of panel by ${mockedWorker.email}`)
     );
-    expect(screen.getByText('28 Jul 2021', { exact: false }));
+    expect(screen.queryByText(/28 Jun 2021/));
   });
 });

--- a/components/RevisionTimeline/RevisionTimeline.tsx
+++ b/components/RevisionTimeline/RevisionTimeline.tsx
@@ -14,6 +14,26 @@ const RevisionTimeline = ({ submission }: Props): React.ReactElement | null => {
     <>
       <h2>History</h2>
       <ol className="lbh-timeline">
+        {submission.deleted && (
+          <li
+            className={`lbh-timeline__event lbh-timeline__event--minor && 'lbh-timeline__event--gap-below'
+            }`}
+            key={'deleted'}
+          >
+            <h3 className="lbh-body">
+              Deleted by {submission.deletionDetails?.deletedBy}
+            </h3>
+
+            {submission.deletionDetails?.deletedAt && (
+              <p className="lbh-body-xs">
+                {format(
+                  new Date(submission.deletionDetails?.deletedAt),
+                  'd MMM yyyy K.mm aaa'
+                )}
+              </p>
+            )}
+          </li>
+        )}
         {submission.panelApprovedAt && (
           <li className={`lbh-timeline__event ${s.approvalEvent}`}>
             <svg width="34" height="30" viewBox="0 0 34 30" fill="none">

--- a/cypress/integration/delete_case_note.ts
+++ b/cypress/integration/delete_case_note.ts
@@ -30,7 +30,7 @@ describe('Deleting case notes', () => {
       );
       cy.contains(/Delete record/).should('exist');
     });
-    it('should be possible to view a deleted case note', () => {
+    it('should be possible to view a deleted case note on the time line', () => {
       cy.visitAs(
         `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}`,
         AuthRoles.AdminDevGroup
@@ -40,6 +40,17 @@ describe('Deleting case notes', () => {
       cy.contains(/(deleted record)/).should('be.visible');
       cy.contains(/deleted 2 Dec 2021 1.51 pm/).should('be.visible');
       cy.contains(/requested by requester/).should('be.visible');
+    });
+    it('should be possible to view a specific deleted case note', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}`,
+        AuthRoles.AdminDevGroup
+      );
+      cy.contains(/Show deleted records/).click();
+      cy.contains(/(deleted record)/).click();
+      cy.contains(/Case note/).should('be.visible');
+      cy.contains(/(deleted record)/).should('be.visible');
+      cy.contains(/Deleted by/).should('be.visible');
     });
   });
 });


### PR DESCRIPTION
**What**  
Have added in a 'Deleted by' history point to deleted case note records

**Why**  
This keeps the interface consistent and provides additional information when on a specific case note
![image](https://user-images.githubusercontent.com/32848419/144624628-9b59e13e-849a-4254-a4ba-df9a620fe00d.png)


**Anything else?**
Have added an additional e2e test to confirm this works as expected
