### PR TITLE
chore: remove workflows pilot feature flag

### DIFF
--- a/components/AddFormDialog/AddFormDialog.spec.tsx
+++ b/components/AddFormDialog/AddFormDialog.spec.tsx
@@ -11,10 +11,6 @@ import ADULT_GFORMS from 'data/googleForms/adultForms';
 import CHILD_GFORMS from 'data/googleForms/childForms';
 import 'data/flexibleForms';
 import 'next/router';
-import {
-  FeatureFlagProvider,
-  FeatureSet,
-} from 'lib/feature-flags/feature-flags';
 import { AppConfigProvider } from 'lib/appConfig';
 
 jest.mock('next/router', () => ({
@@ -29,12 +25,6 @@ beforeEach(() => {
   jest.resetModules();
 });
 
-const features: FeatureSet = {
-  'workflows-pilot': {
-    isActive: false,
-  },
-};
-
 describe('AddFormDialog', () => {
   it('shows forms from two sources', () => {
     render(
@@ -42,13 +32,11 @@ describe('AddFormDialog', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedUser}>
-          <FeatureFlagProvider features={features}>
-            <AddFormDialog
-              isOpen={true}
-              onDismiss={jest.fn()}
-              person={mockedResident}
-            />
-          </FeatureFlagProvider>
+          <AddFormDialog
+            isOpen={true}
+            onDismiss={jest.fn()}
+            person={mockedResident}
+          />
         </AuthProvider>
       </AppConfigProvider>
     );
@@ -69,13 +57,11 @@ describe('AddFormDialog', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedUser}>
-          <FeatureFlagProvider features={features}>
-            <AddFormDialog
-              isOpen={true}
-              onDismiss={jest.fn()}
-              person={mockedResident}
-            />
-          </FeatureFlagProvider>
+          <AddFormDialog
+            isOpen={true}
+            onDismiss={jest.fn()}
+            person={mockedResident}
+          />
         </AuthProvider>
       </AppConfigProvider>
     );
@@ -89,13 +75,11 @@ describe('AddFormDialog', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedUser}>
-          <FeatureFlagProvider features={features}>
-            <AddFormDialog
-              isOpen={true}
-              onDismiss={jest.fn()}
-              person={{ ...mockedResident, contextFlag: 'C' }}
-            />
-          </FeatureFlagProvider>
+          <AddFormDialog
+            isOpen={true}
+            onDismiss={jest.fn()}
+            person={{ ...mockedResident, contextFlag: 'C' }}
+          />
         </AuthProvider>
       </AppConfigProvider>
     );
@@ -109,13 +93,11 @@ describe('AddFormDialog', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedUser}>
-          <FeatureFlagProvider features={features}>
-            <AddFormDialog
-              isOpen={true}
-              onDismiss={jest.fn()}
-              person={mockedResident}
-            />
-          </FeatureFlagProvider>
+          <AddFormDialog
+            isOpen={true}
+            onDismiss={jest.fn()}
+            person={mockedResident}
+          />
         </AuthProvider>
       </AppConfigProvider>
     );
@@ -134,13 +116,11 @@ describe('AddFormDialog', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedUser}>
-          <FeatureFlagProvider features={features}>
-            <AddFormDialog
-              isOpen={true}
-              onDismiss={jest.fn()}
-              person={{ ...mockedResident, contextFlag: 'C' }}
-            />
-          </FeatureFlagProvider>
+          <AddFormDialog
+            isOpen={true}
+            onDismiss={jest.fn()}
+            person={{ ...mockedResident, contextFlag: 'C' }}
+          />
         </AuthProvider>
       </AppConfigProvider>
     );
@@ -158,13 +138,11 @@ describe('AddFormDialog', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedUser}>
-          <FeatureFlagProvider features={features}>
-            <AddFormDialog
-              isOpen={true}
-              onDismiss={jest.fn()}
-              person={mockedResident}
-            />
-          </FeatureFlagProvider>
+          <AddFormDialog
+            isOpen={true}
+            onDismiss={jest.fn()}
+            person={mockedResident}
+          />
         </AuthProvider>
       </AppConfigProvider>
     );
@@ -195,13 +173,11 @@ describe('AddFormDialog', () => {
             hasAdminPermissions: false,
           }}
         >
-          <FeatureFlagProvider features={features}>
-            <AddFormDialog
-              isOpen={true}
-              onDismiss={jest.fn()}
-              person={mockedResident}
-            />
-          </FeatureFlagProvider>
+          <AddFormDialog
+            isOpen={true}
+            onDismiss={jest.fn()}
+            person={mockedResident}
+          />
         </AuthProvider>
       </AppConfigProvider>
     );
@@ -214,13 +190,11 @@ describe('AddFormDialog', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedAdminUser}>
-          <FeatureFlagProvider features={features}>
-            <AddFormDialog
-              isOpen={true}
-              onDismiss={jest.fn()}
-              person={mockedResident}
-            />
-          </FeatureFlagProvider>
+          <AddFormDialog
+            isOpen={true}
+            onDismiss={jest.fn()}
+            person={mockedResident}
+          />
         </AuthProvider>
       </AppConfigProvider>
     );
@@ -229,113 +203,59 @@ describe('AddFormDialog', () => {
     ).toBeGreaterThan(0);
   });
 
-  describe('when workflows pilot feature flag is on', () => {
-    it('displays link for workflows if user is in workflows pilot', () => {
-      render(
-        <AppConfigProvider
-          appConfig={{ workflowsPilotUrl: 'http://example.com' }}
-        >
-          <AuthProvider user={mockedUserInWorkflowsPilot}>
-            <FeatureFlagProvider
-              features={{
-                'workflows-pilot': {
-                  isActive: true,
-                },
-              }}
-            >
-              <AddFormDialog
-                isOpen={true}
-                onDismiss={jest.fn()}
-                person={mockedResident}
-              />
-            </FeatureFlagProvider>
-          </AuthProvider>
-        </AppConfigProvider>
-      );
+  it('displays link for workflows if user is in workflows pilot', () => {
+    render(
+      <AppConfigProvider
+        appConfig={{ workflowsPilotUrl: 'http://example.com' }}
+      >
+        <AuthProvider user={mockedUserInWorkflowsPilot}>
+          <AddFormDialog
+            isOpen={true}
+            onDismiss={jest.fn()}
+            person={mockedResident}
+          />
+        </AuthProvider>
+      </AppConfigProvider>
+    );
 
-      expect(screen.queryByText('Pilot assessment')).toBeVisible();
-    });
-
-    it('display link for workflow at the top if user is in workflows pilot', () => {
-      render(
-        <AppConfigProvider
-          appConfig={{ workflowsPilotUrl: 'http://example.com' }}
-        >
-          <AuthProvider user={mockedUserInWorkflowsPilot}>
-            <FeatureFlagProvider
-              features={{
-                'workflows-pilot': {
-                  isActive: true,
-                },
-              }}
-            >
-              <AddFormDialog
-                isOpen={true}
-                onDismiss={jest.fn()}
-                person={mockedResident}
-              />
-            </FeatureFlagProvider>
-          </AuthProvider>
-        </AppConfigProvider>
-      );
-
-      expect(screen.queryAllByRole('link')[0]).toHaveTextContent(
-        'Pilot assessment'
-      );
-    });
-
-    it('does not display link for workflows if user is not in workflows pilot', () => {
-      render(
-        <AppConfigProvider
-          appConfig={{ workflowsPilotUrl: 'http://example.com' }}
-        >
-          <AuthProvider user={mockedUser}>
-            <FeatureFlagProvider
-              features={{
-                'workflows-pilot': {
-                  isActive: true,
-                },
-              }}
-            >
-              <AddFormDialog
-                isOpen={true}
-                onDismiss={jest.fn()}
-                person={mockedResident}
-              />
-            </FeatureFlagProvider>
-          </AuthProvider>
-        </AppConfigProvider>
-      );
-
-      expect(screen.queryByText('Pilot assessment')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByText('Pilot assessment')).toBeVisible();
   });
 
-  describe('when workflows pilot feature flag is off', () => {
-    it('does not display link for workflows if feature flag is off', () => {
-      render(
-        <AppConfigProvider
-          appConfig={{ workflowsPilotUrl: 'http://example.com' }}
-        >
-          <AuthProvider user={mockedUser}>
-            <FeatureFlagProvider
-              features={{
-                'workflows-pilot': {
-                  isActive: false,
-                },
-              }}
-            >
-              <AddFormDialog
-                isOpen={true}
-                onDismiss={jest.fn()}
-                person={mockedResident}
-              />
-            </FeatureFlagProvider>
-          </AuthProvider>
-        </AppConfigProvider>
-      );
+  it('displays link for workflow at the top if user is in workflows pilot', () => {
+    render(
+      <AppConfigProvider
+        appConfig={{ workflowsPilotUrl: 'http://example.com' }}
+      >
+        <AuthProvider user={mockedUserInWorkflowsPilot}>
+          <AddFormDialog
+            isOpen={true}
+            onDismiss={jest.fn()}
+            person={mockedResident}
+          />
+        </AuthProvider>
+      </AppConfigProvider>
+    );
 
-      expect(screen.queryByText('Pilot assessment')).not.toBeInTheDocument();
-    });
+    expect(screen.queryAllByRole('link')[0]).toHaveTextContent(
+      'Pilot assessment'
+    );
+  });
+
+  it('does not display link for workflows if user is not in workflows pilot', () => {
+    render(
+      <AppConfigProvider
+        appConfig={{ workflowsPilotUrl: 'http://example.com' }}
+      >
+        <AuthProvider user={mockedUser}>
+          <AddFormDialog
+            isOpen={true}
+            onDismiss={jest.fn()}
+            person={mockedResident}
+          />
+        </AuthProvider>
+      </AppConfigProvider>
+    );
+
+    expect(screen.queryByText('Pilot assessment')).not.toBeInTheDocument();
   });
 });

--- a/components/AddFormDialog/AddFormDialog.tsx
+++ b/components/AddFormDialog/AddFormDialog.tsx
@@ -11,7 +11,6 @@ import ADULT_GFORMS from 'data/googleForms/adultForms';
 import CHILD_GFORMS from 'data/googleForms/childForms';
 import flexibleForms from 'data/flexibleForms';
 import { populateChildForm } from 'utils/populate';
-import { useFeatureFlags } from 'lib/feature-flags/feature-flags';
 import { useAppConfig } from 'lib/appConfig';
 
 interface Props {
@@ -27,8 +26,6 @@ const AddFormDialog = ({
 }: Props): React.ReactElement => {
   const { user } = useAuth() as { user: User };
   const [searchQuery, setSearchQuery] = useState<string>('');
-
-  const { isFeatureActive } = useFeatureFlags();
   const { getConfigValue } = useAppConfig();
 
   useEffect(() => {
@@ -84,7 +81,7 @@ const AddFormDialog = ({
         }))
       );
 
-    if (isFeatureActive('workflows-pilot') && user.isInWorkflowsPilot) {
+    if (user.isInWorkflowsPilot) {
       forms.unshift({
         label: 'Pilot assessment',
         href: `${getConfigValue(
@@ -98,7 +95,7 @@ const AddFormDialog = ({
     }
 
     return forms;
-  }, [gForms, serviceContext, user, person, isFeatureActive, getConfigValue]);
+  }, [gForms, serviceContext, user, person, getConfigValue]);
 
   const results = useSearch(
     searchQuery,

--- a/components/Dashboard/DashboardWrapper.spec.tsx
+++ b/components/Dashboard/DashboardWrapper.spec.tsx
@@ -1,8 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import {
-  FeatureFlagProvider,
-  FeatureSet,
-} from 'lib/feature-flags/feature-flags';
 import { AppConfigProvider } from 'lib/appConfig';
 import DashboardWrapper from './DashboardWrapper';
 
@@ -12,44 +8,28 @@ jest.mock('next/router', () => ({
   useRouter: () => mockedUseRouter,
 }));
 
-const features: FeatureSet = {
-  'workflows-pilot': {
-    isActive: false,
-  },
-};
-
 describe(`DashboardWrapper`, () => {
   it('should render properly', () => {
     const { asFragment } = render(
       <AppConfigProvider
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
-        <FeatureFlagProvider features={features}>
-          <DashboardWrapper>
-            <div>foo</div>
-          </DashboardWrapper>
-        </FeatureFlagProvider>
+        <DashboardWrapper>
+          <div>foo</div>
+        </DashboardWrapper>
       </AppConfigProvider>
     );
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('displays link for workflows if workflows pilot feature flag is on', () => {
+  it('displays link for workflows', () => {
     render(
       <AppConfigProvider
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
-        <FeatureFlagProvider
-          features={{
-            'workflows-pilot': {
-              isActive: true,
-            },
-          }}
-        >
-          <DashboardWrapper>
-            <div>foo</div>
-          </DashboardWrapper>
-        </FeatureFlagProvider>
+        <DashboardWrapper>
+          <div>foo</div>
+        </DashboardWrapper>
       </AppConfigProvider>
     );
 
@@ -58,27 +38,5 @@ describe(`DashboardWrapper`, () => {
       'href',
       'http://example.com'
     );
-  });
-
-  it('does not display link for workflows if workflows pilot feature flag is off', () => {
-    render(
-      <AppConfigProvider
-        appConfig={{ workflowsPilotUrl: 'http://example.com' }}
-      >
-        <FeatureFlagProvider
-          features={{
-            'workflows-pilot': {
-              isActive: false,
-            },
-          }}
-        >
-          <DashboardWrapper>
-            <div>foo</div>
-          </DashboardWrapper>
-        </FeatureFlagProvider>
-      </AppConfigProvider>
-    );
-
-    expect(screen.queryByText('Workflows')).not.toBeInTheDocument();
   });
 });

--- a/components/Dashboard/DashboardWrapper.tsx
+++ b/components/Dashboard/DashboardWrapper.tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import s from './DashboardWrapper.module.scss';
 import MyData from './MyData';
-import { ConditionalFeature } from 'lib/feature-flags/feature-flags';
 import { useAppConfig } from 'lib/appConfig';
 
 interface NavLinkProps {
@@ -64,11 +63,9 @@ const DashboardWrapper = ({ children }: Props): React.ReactElement => {
                   </NavLink>
                 ))}
 
-                <ConditionalFeature name="workflows-pilot">
-                  <NavLink href={getConfigValue('workflowsPilotUrl') as string}>
-                    Workflows
-                  </NavLink>
-                </ConditionalFeature>
+                <NavLink href={getConfigValue('workflowsPilotUrl') as string}>
+                  Workflows
+                </NavLink>
               </ul>
             </nav>
             <MyData />

--- a/components/Dashboard/__snapshots__/DashboardWrapper.spec.tsx.snap
+++ b/components/Dashboard/__snapshots__/DashboardWrapper.spec.tsx.snap
@@ -39,6 +39,14 @@ exports[`DashboardWrapper should render properly 1`] = `
                 My work
               </a>
             </li>
+            <li>
+              <a
+                class="lbh-link lbh-link--no-visited-state navLink"
+                href="http://example.com"
+              >
+                Workflows
+              </a>
+            </li>
           </ul>
         </nav>
       </div>

--- a/components/Layout/index.spec.tsx
+++ b/components/Layout/index.spec.tsx
@@ -1,8 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import {
-  FeatureFlagProvider,
-  FeatureSet,
-} from '../../lib/feature-flags/feature-flags';
+import { FeatureFlagProvider } from '../../lib/feature-flags/feature-flags';
 import { useAuth } from 'components/UserContext/UserContext';
 import { mockedUser, mockedUserInWorkflowsPilot } from 'factories/users';
 import Layout from './index';
@@ -21,12 +18,6 @@ jest.mock('components/UserContext/UserContext');
   user: mockedUser,
 });
 
-const features: FeatureSet = {
-  'workflows-pilot': {
-    isActive: false,
-  },
-};
-
 describe('Layout component', () => {
   it('should render properly', () => {
     (useAuth as jest.Mock).mockReturnValue({
@@ -34,7 +25,7 @@ describe('Layout component', () => {
     });
 
     const { asFragment } = render(
-      <FeatureFlagProvider features={features}>
+      <FeatureFlagProvider features={{}}>
         <Layout goBackButton={false} noLayout={false}>
           <p>I am the children</p>
         </Layout>
@@ -51,7 +42,7 @@ describe('Layout component', () => {
 
     expect(() => {
       render(
-        <FeatureFlagProvider features={features}>
+        <FeatureFlagProvider features={{}}>
           <Layout goBackButton={false} noLayout={false}>
             <p>I am the children</p>
           </Layout>
@@ -60,85 +51,43 @@ describe('Layout component', () => {
     }).not.toThrowError(TypeError);
   });
 
-  describe('when workflows pilot feature flag is on', () => {
-    it('displays the onboarding dialog if user is in workflows pilot', () => {
-      (useAuth as jest.Mock).mockReturnValue({
-        user: mockedUserInWorkflowsPilot,
-      });
-
-      render(
-        <FeatureFlagProvider
-          features={{
-            'workflows-pilot': {
-              isActive: true,
-            },
-          }}
-        >
-          <Layout goBackButton={false} noLayout={false}>
-            <p>I am the children</p>
-          </Layout>
-        </FeatureFlagProvider>
-      );
-
-      expect(
-        screen.queryByText(
-          "Good news! You're part of the brand new workflow pilot."
-        )
-      ).toBeVisible();
+  it('displays the onboarding dialog if user is in workflows pilot', () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: mockedUserInWorkflowsPilot,
     });
 
-    it("doesn't display the onboarding dialog if user is not in workflows pilot", () => {
-      (useAuth as jest.Mock).mockReturnValue({
-        user: mockedUser,
-      });
+    render(
+      <FeatureFlagProvider features={{}}>
+        <Layout goBackButton={false} noLayout={false}>
+          <p>I am the children</p>
+        </Layout>
+      </FeatureFlagProvider>
+    );
 
-      render(
-        <FeatureFlagProvider
-          features={{
-            'workflows-pilot': {
-              isActive: true,
-            },
-          }}
-        >
-          <Layout goBackButton={false} noLayout={false}>
-            <p>I am the children</p>
-          </Layout>
-        </FeatureFlagProvider>
-      );
-
-      expect(
-        screen.queryByText(
-          "Good news! You're part of the brand new workflow pilot."
-        )
-      ).not.toBeInTheDocument();
-    });
+    expect(
+      screen.queryByText(
+        "Good news! You're part of the brand new workflow pilot."
+      )
+    ).toBeVisible();
   });
 
-  describe('when workflows pilot feature flag is off', () => {
-    it("doesn't display the onboarding dialog", () => {
-      (useAuth as jest.Mock).mockReturnValue({
-        user: mockedUser,
-      });
-
-      render(
-        <FeatureFlagProvider
-          features={{
-            'workflows-pilot': {
-              isActive: false,
-            },
-          }}
-        >
-          <Layout goBackButton={false} noLayout={false}>
-            <p>I am the children</p>
-          </Layout>
-        </FeatureFlagProvider>
-      );
-
-      expect(
-        screen.queryByText(
-          "Good news! You're part of the brand new workflow pilot."
-        )
-      ).not.toBeInTheDocument();
+  it("doesn't display the onboarding dialog if user is not in workflows pilot", () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: mockedUser,
     });
+
+    render(
+      <FeatureFlagProvider features={{}}>
+        <Layout goBackButton={false} noLayout={false}>
+          <p>I am the children</p>
+        </Layout>
+      </FeatureFlagProvider>
+    );
+
+    expect(
+      screen.queryByText(
+        "Good news! You're part of the brand new workflow pilot."
+      )
+    ).not.toBeInTheDocument();
   });
 });

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -5,7 +5,6 @@ import PhaseBanner from './PhaseBanner/PhaseBanner';
 import BackButton from './BackButton/BackButton';
 import Footer from './Footer/Footer';
 import OnboardingDialog from 'components/OnboardingDialog';
-import { ConditionalFeature } from 'lib/feature-flags/feature-flags';
 import { User } from 'types';
 import { useAuth } from 'components/UserContext/UserContext';
 
@@ -40,9 +39,7 @@ const Layout = ({
         </main>
       </div>
 
-      <ConditionalFeature name="workflows-pilot">
-        {user?.isInWorkflowsPilot && <OnboardingDialog />}
-      </ConditionalFeature>
+      {user?.isInWorkflowsPilot && <OnboardingDialog />}
 
       <Footer />
     </>

--- a/components/NewPersonView/Layout.spec.tsx
+++ b/components/NewPersonView/Layout.spec.tsx
@@ -10,17 +10,11 @@ import {
 import * as relationshipsAPI from 'utils/api/relationships';
 import Layout from './Layout';
 import 'next/router';
-
-import {
-  FeatureFlagProvider,
-  FeatureSet,
-} from 'lib/feature-flags/feature-flags';
-
+import { FeatureFlagProvider } from 'lib/feature-flags/feature-flags';
 import {
   mockedRelationshipData,
   mockedExistingRelationship,
 } from 'factories/relationships';
-
 import { AppConfigProvider } from 'lib/appConfig';
 
 const mockedUseRouter = {
@@ -33,12 +27,6 @@ jest.mock('next/router', () => ({
   useRouter: () => mockedUseRouter,
 }));
 
-const features: FeatureSet = {
-  'workflows-pilot': {
-    isActive: false,
-  },
-};
-
 describe('Layout', () => {
   it('renders children, navigation and a primary action', () => {
     render(
@@ -46,7 +34,7 @@ describe('Layout', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedUser}>
-          <FeatureFlagProvider features={features}>
+          <FeatureFlagProvider features={{}}>
             <Layout person={mockedResident}>Foo</Layout>
           </FeatureFlagProvider>
         </AuthProvider>
@@ -64,7 +52,7 @@ describe('Layout', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedUser}>
-          <FeatureFlagProvider features={features}>
+          <FeatureFlagProvider features={{}}>
             <Layout person={mockedResident}>Foo</Layout>
           </FeatureFlagProvider>
         </AuthProvider>
@@ -113,7 +101,7 @@ describe('Layout', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedOnlyChildUser}>
-          <FeatureFlagProvider features={features}>
+          <FeatureFlagProvider features={{}}>
             <Layout person={mockedResident}>Foo</Layout>
           </FeatureFlagProvider>
         </AuthProvider>
@@ -140,7 +128,7 @@ describe('Layout', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedOnlyChildUser}>
-          <FeatureFlagProvider features={features}>
+          <FeatureFlagProvider features={{}}>
             <Layout person={mockedResident}>Foo</Layout>
           </FeatureFlagProvider>
         </AuthProvider>
@@ -157,7 +145,7 @@ describe('Layout', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedOnlyChildUser}>
-          <FeatureFlagProvider features={features}>
+          <FeatureFlagProvider features={{}}>
             <Layout person={mockedResident}>Foo</Layout>
           </FeatureFlagProvider>
         </AuthProvider>
@@ -172,7 +160,7 @@ describe('Layout', () => {
         appConfig={{ workflowsPilotUrl: 'http://example.com' }}
       >
         <AuthProvider user={mockedOnlyAdultUser}>
-          <FeatureFlagProvider features={features}>
+          <FeatureFlagProvider features={{}}>
             <Layout
               person={{
                 ...mockedResident,
@@ -199,7 +187,7 @@ describe('Layout', () => {
             hasUnrestrictedPermissions: true,
           }}
         >
-          <FeatureFlagProvider features={features}>
+          <FeatureFlagProvider features={{}}>
             <Layout
               person={{
                 ...mockedResident,
@@ -215,134 +203,83 @@ describe('Layout', () => {
     expect(screen.queryByText('This person is restricted')).toBeNull();
   });
 
-  describe('when workflows pilot feature flag is on', () => {
-    it('displays link to start a workflow if user is in workflows pilot', () => {
-      render(
-        <AppConfigProvider
-          appConfig={{ workflowsPilotUrl: 'http://example.com' }}
-        >
-          <AuthProvider user={mockedUserInWorkflowsPilot}>
-            <FeatureFlagProvider
-              features={{
-                'workflows-pilot': {
-                  isActive: true,
-                },
+  it('displays link to start a workflow if user is in workflows pilot', () => {
+    render(
+      <AppConfigProvider
+        appConfig={{ workflowsPilotUrl: 'http://example.com' }}
+      >
+        <AuthProvider user={mockedUserInWorkflowsPilot}>
+          <FeatureFlagProvider features={{}}>
+            <Layout
+              person={{
+                ...mockedResident,
+                id: 123456789,
+                restricted: 'Y',
               }}
             >
-              <Layout
-                person={{
-                  ...mockedResident,
-                  id: 123456789,
-                  restricted: 'Y',
-                }}
-              >
-                Foo
-              </Layout>
-            </FeatureFlagProvider>
-          </AuthProvider>
-        </AppConfigProvider>
-      );
+              Foo
+            </Layout>
+          </FeatureFlagProvider>
+        </AuthProvider>
+      </AppConfigProvider>
+    );
 
-      expect(screen.queryByText('Start workflow')).toBeVisible();
-      expect(screen.queryByText('Start workflow')).toHaveAttribute(
-        'href',
-        'http://example.com/workflows/new?social_care_id=123456789'
-      );
-    });
-
-    it("doesn't display link to start a workflow if user is in not workflows pilot", () => {
-      render(
-        <AppConfigProvider
-          appConfig={{ workflowsPilotUrl: 'http://example.com' }}
-        >
-          <AuthProvider user={mockedUser}>
-            <FeatureFlagProvider
-              features={{
-                'workflows-pilot': {
-                  isActive: true,
-                },
-              }}
-            >
-              <Layout
-                person={{
-                  ...mockedResident,
-                  id: 123456789,
-                  restricted: 'Y',
-                }}
-              >
-                Foo
-              </Layout>
-            </FeatureFlagProvider>
-          </AuthProvider>
-        </AppConfigProvider>
-      );
-
-      expect(screen.queryByText('Start workflow')).not.toBeInTheDocument();
-    });
-
-    it('displays link to the workflows for the person', () => {
-      render(
-        <AppConfigProvider
-          appConfig={{ workflowsPilotUrl: 'http://example.com' }}
-        >
-          <AuthProvider user={mockedUser}>
-            <FeatureFlagProvider
-              features={{
-                'workflows-pilot': {
-                  isActive: true,
-                },
-              }}
-            >
-              <Layout
-                person={{
-                  ...mockedResident,
-                  id: 123456789,
-                  restricted: 'Y',
-                }}
-              >
-                Foo
-              </Layout>
-            </FeatureFlagProvider>
-          </AuthProvider>
-        </AppConfigProvider>
-      );
-
-      expect(screen.queryByText('Workflows')).toBeVisible();
-      expect(screen.queryByText('Workflows')).toHaveAttribute(
-        'href',
-        'http://example.com/residents/123456789'
-      );
-    });
+    expect(screen.queryByText('Start workflow')).toBeVisible();
+    expect(screen.queryByText('Start workflow')).toHaveAttribute(
+      'href',
+      'http://example.com/workflows/new?social_care_id=123456789'
+    );
   });
 
-  describe('when workflows pilot feature flag is off', () => {
-    it('does not display to start a workflow', () => {
-      render(
-        <AppConfigProvider
-          appConfig={{ workflowsPilotUrl: 'http://example.com' }}
-        >
-          <AuthProvider user={mockedUser}>
-            <FeatureFlagProvider
-              features={{
-                'workflows-pilot': {
-                  isActive: false,
-                },
+  it("doesn't display link to start a workflow if user is in not workflows pilot", () => {
+    render(
+      <AppConfigProvider
+        appConfig={{ workflowsPilotUrl: 'http://example.com' }}
+      >
+        <AuthProvider user={mockedUser}>
+          <FeatureFlagProvider features={{}}>
+            <Layout
+              person={{
+                ...mockedResident,
+                id: 123456789,
+                restricted: 'Y',
               }}
             >
-              <Layout
-                person={{
-                  ...mockedResident,
-                  restricted: 'Y',
-                }}
-              >
-                Foo
-              </Layout>
-            </FeatureFlagProvider>
-          </AuthProvider>
-        </AppConfigProvider>
-      );
+              Foo
+            </Layout>
+          </FeatureFlagProvider>
+        </AuthProvider>
+      </AppConfigProvider>
+    );
 
-      expect(screen.queryByText('Start workflow')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByText('Start workflow')).not.toBeInTheDocument();
+  });
+
+  it('displays link to the workflows for the person', () => {
+    render(
+      <AppConfigProvider
+        appConfig={{ workflowsPilotUrl: 'http://example.com' }}
+      >
+        <AuthProvider user={mockedUser}>
+          <FeatureFlagProvider features={{}}>
+            <Layout
+              person={{
+                ...mockedResident,
+                id: 123456789,
+                restricted: 'Y',
+              }}
+            >
+              Foo
+            </Layout>
+          </FeatureFlagProvider>
+        </AuthProvider>
+      </AppConfigProvider>
+    );
+
+    expect(screen.queryByText('Workflows')).toBeVisible();
+    expect(screen.queryByText('Workflows')).toHaveAttribute(
+      'href',
+      'http://example.com/residents/123456789'
+    );
   });
 });

--- a/components/NewPersonView/Layout.tsx
+++ b/components/NewPersonView/Layout.tsx
@@ -207,15 +207,13 @@ const Layout = ({ person, children }: Props): React.ReactElement => {
                 </NavLink>
               ))}
 
-              <ConditionalFeature name="workflows-pilot">
-                <NavLink
-                  href={`${
-                    getConfigValue('workflowsPilotUrl') as string
-                  }/residents/${person.id}`}
-                >
-                  Workflows
-                </NavLink>
-              </ConditionalFeature>
+              <NavLink
+                href={`${
+                  getConfigValue('workflowsPilotUrl') as string
+                }/residents/${person.id}`}
+              >
+                Workflows
+              </NavLink>
             </ul>
 
             <ul className={`lbh-list ${s.secondaryNav}`}>
@@ -230,20 +228,18 @@ const Layout = ({ person, children }: Props): React.ReactElement => {
                 </li>
               ))}
 
-              <ConditionalFeature name="workflows-pilot">
-                {user.isInWorkflowsPilot && (
-                  <li>
-                    <a
-                      href={`${getConfigValue(
-                        'workflowsPilotUrl'
-                      )}/workflows/new?social_care_id=${person.id}`}
-                      className="lbh-link lbh-body-s lbh-link--no-visited-state"
-                    >
-                      Start workflow
-                    </a>
-                  </li>
-                )}
-              </ConditionalFeature>
+              {user.isInWorkflowsPilot && (
+                <li>
+                  <a
+                    href={`${getConfigValue(
+                      'workflowsPilotUrl'
+                    )}/workflows/new?social_care_id=${person.id}`}
+                    className="lbh-link lbh-body-s lbh-link--no-visited-state"
+                  >
+                    Start workflow
+                  </a>
+                </li>
+              )}
             </ul>
           </nav>
         </div>

--- a/features.ts
+++ b/features.ts
@@ -29,10 +29,6 @@ export const getFeatureFlags = ({
       isActive:
         environmentName === 'development' || user?.hasAdminPermissions || false,
     },
-    // FEATURE-FLAG-EXPIRES [2022-01-31]: workflows-pilot
-    'workflows-pilot': {
-      isActive: ['development', 'production'].includes(environmentName),
-    },
     /*
       The feature-flags-implementation-proof has been setup to have an expiry date in the far future.
       The FEATURE-FLAG-EXPIRES comment above will cause ESLint errors once the date in the square brackets has passed.


### PR DESCRIPTION
**What**  

Remove the workflows pilot feature flag.

**Why**  

In preparation of pilot launch, we created the feature flag. We're now post-pilot so the feature flag is always active and no longer valuable.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
