### PR TITLE
Add unit test for deleted by scenario in RevisionTimeline component

### DIFF
--- a/components/RevisionTimeline/RevisionTimeline.spec.tsx
+++ b/components/RevisionTimeline/RevisionTimeline.spec.tsx
@@ -98,4 +98,24 @@ describe('RevisionTimeline', () => {
     );
     expect(screen.getByText('28 Jul 2021', { exact: false }));
   });
+
+  it.only('correctly renders a deleted by', () => {
+    render(
+      <RevisionTimeline
+        submission={{
+          ...mockSubmission,
+          deleted: true,
+          deletionDetails: {
+            deletedBy: mockedWorker.email,
+            deletedAt: '2021-07-29T10:00:00.000Z',
+            deleteReason: 'Submitted prematurely',
+            deleteRequestedBy: mockedWorker.email,
+          },
+        }}
+      />
+    );
+    expect(screen.getByText('History'));
+    expect(screen.getByText(`Deleted by ${mockedWorker.email}`));
+    expect(screen.getByText('29 Jul 2021', { exact: false }));
+  });
 });

--- a/components/RevisionTimeline/RevisionTimeline.tsx
+++ b/components/RevisionTimeline/RevisionTimeline.tsx
@@ -14,6 +14,26 @@ const RevisionTimeline = ({ submission }: Props): React.ReactElement | null => {
     <>
       <h2>History</h2>
       <ol className="lbh-timeline">
+        {submission.deleted && (
+          <li
+            className={`lbh-timeline__event lbh-timeline__event--minor && 'lbh-timeline__event--gap-below'
+            }`}
+            key={'deleted'}
+          >
+            <h3 className="lbh-body">
+              Deleted by {submission.deletionDetails?.deletedBy}
+            </h3>
+
+            {submission.deletionDetails?.deletedAt && (
+              <p className="lbh-body-xs">
+                {format(
+                  new Date(submission.deletionDetails?.deletedAt),
+                  'd MMM yyyy K.mm aaa'
+                )}
+              </p>
+            )}
+          </li>
+        )}
         {submission.panelApprovedAt && (
           <li className={`lbh-timeline__event ${s.approvalEvent}`}>
             <svg width="34" height="30" viewBox="0 0 34 30" fill="none">

--- a/cypress/integration/delete_case_note.ts
+++ b/cypress/integration/delete_case_note.ts
@@ -30,7 +30,7 @@ describe('Deleting case notes', () => {
       );
       cy.contains(/Delete record/).should('exist');
     });
-    it('should be possible to view a deleted case note', () => {
+    it('should be possible to view a deleted case note on the time line', () => {
       cy.visitAs(
         `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}`,
         AuthRoles.AdminDevGroup
@@ -40,6 +40,17 @@ describe('Deleting case notes', () => {
       cy.contains(/(deleted record)/).should('be.visible');
       cy.contains(/deleted 2 Dec 2021 1.51 pm/).should('be.visible');
       cy.contains(/requested by requester/).should('be.visible');
+    });
+    it('should be possible to view a specific deleted case note', () => {
+      cy.visitAs(
+        `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}`,
+        AuthRoles.AdminDevGroup
+      );
+      cy.contains(/Show deleted records/).click();
+      cy.contains(/(deleted record)/).click();
+      cy.contains(/Case note/).should('be.visible');
+      cy.contains(/(deleted record)/).should('be.visible');
+      cy.contains(/Deleted by/).should('be.visible');
     });
   });
 });


### PR DESCRIPTION
**What**  
A unit test that uses the deleted boolean set to true & 
the mocked deletion details of a worker, within a submission
to test whether the deleted by functionality correctly renders 
that the mocked worker deleted a case note.
