### PR TITLE
fix: Revision Timeline tests

### DIFF
--- a/components/RevisionTimeline/RevisionTimeline.spec.tsx
+++ b/components/RevisionTimeline/RevisionTimeline.spec.tsx
@@ -82,13 +82,13 @@ describe('RevisionTimeline', () => {
     expect(screen.getByText('28 Jul 2021', { exact: false }));
   });
 
-  it('correctly renders a deleted approval', () => {
+  it.only('correctly renders a deleted approval', () => {
     mockSubmission.deleted = true;
     mockSubmission.deletionDetails = {
-      deletedAt: '2021-07-28T11:00:00.000Z',
+      deletedAt: '2022-01-01T11:00:00.000Z',
       deleteReason: 'Reason',
-      deletedBy: 'Jack Musajo',
-      deleteRequestedBy: 'jack.musajo@hackney.gov.uk',
+      deletedBy: `${mockedWorker.firstName} ${mockedWorker.lastName}`,
+      deleteRequestedBy: mockedWorker.email,
     };
     render(
       <RevisionTimeline
@@ -100,9 +100,13 @@ describe('RevisionTimeline', () => {
       />
     );
 
-    expect(screen.queryByText(/Deleted record/));
-    expect(screen.queryByText(/Deleted by jack.musajo@hackney.gov.uk/));
-    expect(screen.queryByText(/28 Jun 2021/));
+    expect(
+      screen.getByText(
+        `Deleted by ${mockedWorker.firstName} ${mockedWorker.lastName}`,
+        { exact: false }
+      )
+    );
+    expect(screen.getByText('1 Jan 2022 11.00 am', { exact: false }));
   });
 
   it('correctly renders a panel approval', () => {

--- a/components/RevisionTimeline/RevisionTimeline.spec.tsx
+++ b/components/RevisionTimeline/RevisionTimeline.spec.tsx
@@ -123,6 +123,6 @@ describe('RevisionTimeline', () => {
     expect(
       screen.getByText(`Approved on behalf of panel by ${mockedWorker.email}`)
     );
-    expect(screen.queryByText(/28 Jun 2021/));
+    expect(screen.getByText('28 Jul 2021', { exact: false }));
   });
 });

--- a/components/RevisionTimeline/RevisionTimeline.spec.tsx
+++ b/components/RevisionTimeline/RevisionTimeline.spec.tsx
@@ -82,7 +82,7 @@ describe('RevisionTimeline', () => {
     expect(screen.getByText('28 Jul 2021', { exact: false }));
   });
 
-  it.only('correctly renders a deleted approval', () => {
+  it('correctly renders a deleted approval', () => {
     mockSubmission.deleted = true;
     mockSubmission.deletionDetails = {
       deletedAt: '2022-01-01T11:00:00.000Z',


### PR DESCRIPTION
Better test for Revision Timeline deleted record

**What**  
-Edited a test so it's cleaner / neater

**Why**  
The `queryByText` function with some parameters were not testing the correct items, but tests were passing anyways.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
