### PR TITLE
refactor: run E2E tests and OWASP scan in parallel of unit tests in pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ workflows:
                 - main
       - build:
           requires:
-            - unit-tests
+            - install-dependencies
       - e2e:
           requires:
             - build


### PR DESCRIPTION
**What**  

Update our pipeline so unit tests and the E2E tests and OWASP scan run in parallel.

**Why**  

Should speed ⚡ the pipeline up as we don't have to wait for the unit tests to finish before doing the build then E2E tests and security scan.

- Before this change, running the pipeline for a PR takes approximately 10 minutes. 
- After this change, running the pipeline for a PR takes approximately 8 minutes. 

![image](https://user-images.githubusercontent.com/42817036/146021638-423ec2fb-2f00-4ea5-af01-3571798d7628.png)

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
