### PR TITLE
fix: Serverless ssm parameters

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,8 +1,9 @@
 service: lbh-social-care
 
+variablesResolutionMode: 20210326
+
 provider:
   name: aws
-  variablesResolutionMode: 20210326
   runtime: nodejs14.x
   versionFunctions: false
   region: eu-west-2

--- a/serverless.yml
+++ b/serverless.yml
@@ -37,7 +37,7 @@ functions:
       subnetIds: ${self:custom.subnets.${self:provider.stage}}
     environment:
       NEXT_PUBLIC_ENV: ${opt:stage}
-      AWS_KEY: ${ssm:/lbh-social-care/${self:provider.stage}/aws-key~true}
+      AWS_KEY: ${ssm:/lbh-social-care/${self:provider.stage}/aws-key}
       ENDPOINT_API: ${ssm:/lbh-social-care/${self:provider.stage}/endpoint-case-viewer}
       GSSO_URL: ${ssm:/lbh-social-care/${self:provider.stage}/gsso-url}
       GSSO_TOKEN_NAME: ${ssm:/lbh-social-care/${self:provider.stage}/gsso-token-name}
@@ -50,11 +50,11 @@ functions:
       AUTHORISED_UNRESTRICTED_GROUP: ${ssm:/lbh-social-care/${self:provider.stage}/authorised-unrestricted-group}
       AUTHORISED_AUDITABLE_GROUP: ${ssm:/lbh-social-care/${self:provider.stage}/authorised-auditable-group}
       POSTCODE_LOOKUP_URL: ${ssm:/lbh-social-care/${self:provider.stage}/postcode-lookup-url}
-      POSTCODE_LOOKUP_APIKEY: ${ssm:/lbh-social-care/${self:provider.stage}/postcode-lookup-apikey~true}
+      POSTCODE_LOOKUP_APIKEY: ${ssm:/lbh-social-care/${self:provider.stage}/postcode-lookup-apikey}
       NEXT_PUBLIC_FEEDBACK_LINK: ${ssm:/lbh-social-care/${self:provider.stage}/next-public-feedback-link}
       REDIRECT_URL: ${ssm:/lbh-social-care/${self:provider.stage}/redirect_url}
       NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: ${ssm:/lbh-social-care/${self:provider.stage}/next_public_google_analytics_id}
-      NOTIFY_API_KEY: ${ssm:/lbh-social-care/${self:provider.stage}/notify-api-key~true}
+      NOTIFY_API_KEY: ${ssm:/lbh-social-care/${self:provider.stage}/notify-api-key}
       NOTIFY_APPROVER_TEMPLATE_ID: ${ssm:/lbh-social-care/${self:provider.stage}/notify-approver-template-id}
       NOTIFY_RETURN_FOR_EDITS_TEMPLATE_ID: ${ssm:/lbh-social-care/${self:provider.stage}/notify-return-for-edits-template-id}
       WORKFLOWS_PILOT_URL: ${ssm:/lbh-social-care/${self:provider.stage}/workflows-pilot-url}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,8 +1,8 @@
 service: lbh-social-care
 
 provider:
-  variablesResolutionMode: 20210326
   name: aws
+  variablesResolutionMode: 20210326
   runtime: nodejs14.x
   versionFunctions: false
   region: eu-west-2

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,6 +1,7 @@
 service: lbh-social-care
 
 provider:
+  variablesResolutionMode: 20210326
   name: aws
   runtime: nodejs14.x
   versionFunctions: false


### PR DESCRIPTION
**What**  
-Removed "~true" from variable ssm link
-added "variablesResolutionMode" parameter set to `20210326`

**Why**  
Serverless recently returned this error:
```
Serverless: Checking Stack update progress...
....... 
 Serverless Error ----------------------------------------
 
  The security token included in the request is expired
 
  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com
 
  Your Environment Information ---------------------------
     Operating System:          linux
     Node Version:              14.17.5
     Framework Version:         2.69.1
     Plugin Version:            5.5.1
     SDK Version:               4.3.0
     Components Version:        3.18.1
 
Serverless: Deprecation warning: Syntax for referencing SSM parameters was upgraded with automatic type detection and there's no need to add "~true" or "~split" postfixes to variable references.
            Drop those postfixes and set "variablesResolutionMode: 20210326" in your service config to adapt to a new behavior.
            Starting with next major release, this will be communicated with a thrown error.
            
            More Info: https://www.serverless.com/framework/docs/deprecations/#NEW_VARIABLES_RESOLVER

Exited with code exit status 1
```

**Anything else?**

[Documentation for variablesResolutionMode parameter](https://www.serverless.com/framework/docs/providers/aws/guide/variables)