### PR TITLE
Adding functionality to 'cancel' button on MASH forms

### DIFF
--- a/components/MashForms/ContactForm.spec.tsx
+++ b/components/MashForms/ContactForm.spec.tsx
@@ -94,4 +94,11 @@ describe('#ContactDecisionForm', () => {
       expect(screen.getByText(errorMessage));
     });
   });
+
+  it('should trigger history back on click of the cancel button', () => {
+    const mockHandler = jest.fn();
+    global.history.back = mockHandler;
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(history.back).toHaveBeenCalled();
+  });
 });

--- a/components/MashForms/ContactForm.tsx
+++ b/components/MashForms/ContactForm.tsx
@@ -144,6 +144,7 @@ const ContactForm = ({ referral, workerEmail }: Props): React.ReactElement => {
           <Link href="#">
             <a
               className={`lbh-link lbh-link--no-visited-state govuk-!-margin-left-3`}
+              onClick={() => window.history.back()}
             >
               Cancel
             </a>

--- a/components/MashForms/FinalDecisionForm.spec.tsx
+++ b/components/MashForms/FinalDecisionForm.spec.tsx
@@ -99,4 +99,11 @@ describe('#FinalDecisionForm', () => {
       expect(screen.getByText(errorMessage));
     });
   });
+
+  it('should trigger history back on click of the cancel button', () => {
+    const mockHandler = jest.fn();
+    global.history.back = mockHandler;
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(history.back).toHaveBeenCalled();
+  });
 });

--- a/components/MashForms/FinalDecisionForm.tsx
+++ b/components/MashForms/FinalDecisionForm.tsx
@@ -177,6 +177,7 @@ const FinalDecisionForm = ({
           <a
             href="#"
             className={`lbh-link lbh-link--no-visited-state govuk-!-margin-left-3`}
+            onClick={() => window.history.back()}
           >
             Cancel
           </a>

--- a/components/MashForms/InitialDecisionForm.spec.tsx
+++ b/components/MashForms/InitialDecisionForm.spec.tsx
@@ -99,4 +99,10 @@ describe('#InitialDecisionForm', () => {
       expect(screen.getByText(errorMessage));
     });
   });
+  it('should trigger history back on click of the cancel button', () => {
+    const mockHandler = jest.fn();
+    global.history.back = mockHandler;
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(history.back).toHaveBeenCalled();
+  });
 });

--- a/components/MashForms/InitialDecisionForm.tsx
+++ b/components/MashForms/InitialDecisionForm.tsx
@@ -175,6 +175,7 @@ const InitialDecisionForm = ({
           <a
             href="#"
             className={`lbh-link lbh-link--no-visited-state govuk-!-margin-left-3`}
+            onClick={() => window.history.back()}
           >
             Cancel
           </a>

--- a/components/MashForms/ScreeningDecisionForm.spec.tsx
+++ b/components/MashForms/ScreeningDecisionForm.spec.tsx
@@ -97,4 +97,11 @@ describe('#ScreeningDecisionForm', () => {
       expect(screen.getByText(errorMessage));
     });
   });
+
+  it('should trigger history back on click of the cancel button', () => {
+    const mockHandler = jest.fn();
+    global.history.back = mockHandler;
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(history.back).toHaveBeenCalled();
+  });
 });

--- a/components/MashForms/ScreeningDecisionForm.tsx
+++ b/components/MashForms/ScreeningDecisionForm.tsx
@@ -163,6 +163,7 @@ const ScreeningDecisionForm = ({
           <a
             href="#"
             className={`lbh-link lbh-link--no-visited-state govuk-!-margin-left-3`}
+            onClick={() => window.history.back()}
           >
             Cancel
           </a>


### PR DESCRIPTION
**What**  
Added the 'back/cancel' functionality to the cancel button on the MASH forms. Along with additions to the tests for the forms.

**Why**  
This allows practitioners to go back/cancel whist on a form 
