### PR TITLE
fix: resolve issue with date in review warning note tests

### DIFF
--- a/components/WarningNotes/ReviewWarningNoteForm/ReviewWarningNoteForm.spec.tsx
+++ b/components/WarningNotes/ReviewWarningNoteForm/ReviewWarningNoteForm.spec.tsx
@@ -6,7 +6,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import React from 'react';
-import { addYears, subMonths, addMonths } from 'date-fns';
+import { addYears, subMonths, subDays, addMonths, addDays } from 'date-fns';
 import Router from 'next/router';
 
 import { residentFactory } from 'factories/residents';
@@ -211,8 +211,8 @@ describe('<ReviewWarningNoteForm />', () => {
         })
       );
 
-      setDateFieldValue('reviewDate', new Date('2021-01-01'));
-      setDateFieldValue('nextReviewDate', new Date('2022-01-02')); // One year and one day later
+      setDateFieldValue('reviewDate', subDays(new Date(), 1)); // Yesterday
+      setDateFieldValue('nextReviewDate', addDays(addYears(new Date(), 1), 1)); // One year and one day later
 
       fireEvent.submit(screen.getByRole('form'));
 


### PR DESCRIPTION
We had a bug with a test that used a date of Jan 2nd 2022, which worked until the world ticked past Jan 2nd 2022, then it started failing.

This switches that test to use a dynamically generated date instead!