### PR TITLE
chore: added redirects to root for all team assignment calls

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,16 @@ module.exports = withSentryConfig(
     target: 'server',
     poweredByHeader: false,
 
+    async redirects() {
+      return [
+        {
+          source: '/team-assignments',
+          destination: '/',
+          permanent: true,
+        },
+      ];
+    },
+
     async headers() {
       const headers = [
         {


### PR DESCRIPTION
**What**  
We want to preserve the code and redirect calls from team assignment pages to root.

**Why**  
Mash referrals are cancelled. 
