### PR TITLE
chore(SCT-1279): Remove SENTRY_RELEASE from circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
       - *attach_workspace
       - run:
           name: deploy
-          command: SENTRY_RELEASE=$CIRCLE_SHA1 yarn --frozen-lockfile --production=true && sudo npm i -g serverless && sls deploy --stage staging
+          command: yarn --frozen-lockfile --production=true && sudo npm i -g serverless && sls deploy --stage staging
 
   build-deploy-mosaic-production:
     executor: aws-cli/default
@@ -134,7 +134,7 @@ jobs:
       - *attach_workspace
       - run:
           name: deploy
-          command: SENTRY_RELEASE=$CIRCLE_SHA1 yarn --frozen-lockfile --production=true && sudo npm i -g serverless && sls deploy -s mosaic-prod
+          command: yarn --frozen-lockfile --production=true && sudo npm i -g serverless && sls deploy -s mosaic-prod
 
   generate-draft-github-release:
     executor: aws-cli/default


### PR DESCRIPTION
**What**  
Small PR to remove SENTRY_RELEASE from the circleci config file

**Why**  
This is the final step to revert the Sentry changes on the main branch