### PR TITLE
chore: Push todo expiry dates

### DIFF
--- a/features.ts
+++ b/features.ts
@@ -25,12 +25,12 @@ export const getFeatureFlags = ({
       isActive:
         environmentName === 'development' || user?.hasDevPermissions || false,
     },
-    // FEATURE-FLAG-EXPIRES [2022-01-31]: case-notes-deletion
+    // FEATURE-FLAG-EXPIRES [2022-06-31]: case-notes-deletion
     'case-notes-deletion': {
       isActive:
         environmentName === 'development' || user?.hasDevPermissions || false,
     },
-    // FEATURE-FLAG-EXPIRES [2022-01-31]: case-status
+    // FEATURE-FLAG-EXPIRES [2022-06-31]: case-status
     'case-status': {
       isActive:
         environmentName === 'development' || user?.hasAdminPermissions || false,


### PR DESCRIPTION
**What**  
Have extended the todo expiry dates that are set on two of the feature flags

**Why**  
The expiry date on these items had passed but we still want these feature flags in place. Since the todo date has passed our linting fails
