### PR TITLE
chore: use an explicit session expiration time

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,5 +1,5 @@
 const dotenvPlugin = require('cypress-dotenv');
 module.exports = (on, config) => {
-  config = dotenvPlugin(config);
+  config = dotenvPlugin(config, {});
   return config;
 };

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -12,7 +12,7 @@ const makeToken = ({
 }) =>
   sign(
     { sub, email, iss, name, groups, iat: dateToUnix(iat) },
-    Cypress.env('HACKNEY_AUTH_TOKEN_SECRET')
+    Cypress.env('HACKNEY_JWT_SECRET')
   );
 
 export enum AuthRoles {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -26,35 +26,21 @@ export enum AuthRoles {
   AdminDevGroup = 'AdminDevGroup',
 }
 
-type RoleConfig = {
-  tokenValue: string;
-};
-
-const roleConfigurations: Record<AuthRoles, RoleConfig> = {
-  ChildrensGroup: {
-    tokenValue: Cypress.env('TEST_KEY_CHILDREN_GROUP'),
-  },
-  ChildrensSafeguardingReviewingGroup: {
-    tokenValue: Cypress.env('TEST_KEY_CHILDREN_SAFEGUARDING_REVIEWING_GROUP'),
-  },
-  ChildrensPlacementManagmenetGroup: {
-    tokenValue: Cypress.env('TEST_KEY_CHILDREN_PLACEMENT_MANAGEMENT_GROUP'),
-  },
-  ChildrensUnrestrictedGroup: {
-    tokenValue: Cypress.env('TEST_KEY_CHILDREN_UNRESTRICTED_GROUP'),
-  },
-  AdultsGroup: {
-    tokenValue: Cypress.env('TEST_KEY_ADULT_GROUP'),
-  },
-  AdultsAllocatorGroup: {
-    tokenValue: Cypress.env('TEST_KEY_ADULT_ALLOCATOR_GROUP'),
-  },
-  AdultsUnrestrictedGroup: {
-    tokenValue: Cypress.env('TEST_KEY_ADULT_UNRESTRICTED_GROUP'),
-  },
-  AdminDevGroup: {
-    tokenValue: Cypress.env('TEST_KEY_ADMIN_DEV'),
-  },
+const roleConfigurations: Record<AuthRoles, Array<string>> = {
+  ChildrensGroup: [Cypress.env('AUTHORISED_CHILD_GROUP')],
+  ChildrensSafeguardingReviewingGroup: [Cypress.env('AUTHORISED_CHILD_GROUP')],
+  ChildrensPlacementManagmenetGroup: [Cypress.env('AUTHORISED_CHILD_GROUP')],
+  ChildrensUnrestrictedGroup: [
+    Cypress.env('AUTHORISED_CHILD_GROUP'),
+    Cypress.env('AUTHORISED_UNRESTRICTED_GROUP'),
+  ],
+  AdultsGroup: [Cypress.env('AUTHORISED_ADULT_GROUP')],
+  AdultsAllocatorGroup: [
+    Cypress.env('AUTHORISED_ADULT_GROUP'),
+    Cypress.env('AUTHORISED_ALLOCATORS_GROUP'),
+  ],
+  AdultsUnrestrictedGroup: [Cypress.env('AUTHORISED_ADULT_GROUP')],
+  AdminDevGroup: [Cypress.env('AUTHORISED_DEV_GROUP')],
 };
 
 declare global {
@@ -85,19 +71,17 @@ const visitAs = (
   role: AuthRoles,
   options?: Partial<Cypress.VisitOptions>
 ) => {
-  // const config = roleConfigurations[role];
-
   cy.setCookie(
     'hackneyToken',
     makeToken({
-      groups: [role],
+      groups: roleConfigurations[role],
     })
   );
   cy.getCookie('hackneyToken').should(
     'have.property',
     'value',
     makeToken({
-      groups: [role],
+      groups: roleConfigurations[role],
     })
   );
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -28,8 +28,14 @@ export enum AuthRoles {
 
 const roleConfigurations: Record<AuthRoles, Array<string>> = {
   ChildrensGroup: [Cypress.env('AUTHORISED_CHILD_GROUP')],
-  ChildrensSafeguardingReviewingGroup: [Cypress.env('AUTHORISED_CHILD_GROUP')],
-  ChildrensPlacementManagmenetGroup: [Cypress.env('AUTHORISED_CHILD_GROUP')],
+  ChildrensSafeguardingReviewingGroup: [
+    Cypress.env('AUTHORISED_CHILD_GROUP'),
+    Cypress.env('AUTHORISED_SAFEGUARDING_REVIEWING_GROUP'),
+  ],
+  ChildrensPlacementManagmenetGroup: [
+    Cypress.env('AUTHORISED_CHILD_GROUP'),
+    Cypress.env('AUTHORISED_PLACEMENT_MANAGEMENT_UNIT_GROUP'),
+  ],
   ChildrensUnrestrictedGroup: [
     Cypress.env('AUTHORISED_CHILD_GROUP'),
     Cypress.env('AUTHORISED_UNRESTRICTED_GROUP'),
@@ -39,7 +45,10 @@ const roleConfigurations: Record<AuthRoles, Array<string>> = {
     Cypress.env('AUTHORISED_ADULT_GROUP'),
     Cypress.env('AUTHORISED_ALLOCATORS_GROUP'),
   ],
-  AdultsUnrestrictedGroup: [Cypress.env('AUTHORISED_ADULT_GROUP')],
+  AdultsUnrestrictedGroup: [
+    Cypress.env('AUTHORISED_ADULT_GROUP'),
+    Cypress.env('AUTHORISED_UNRESTRICTED_GROUP'),
+  ],
   AdminDevGroup: [Cypress.env('AUTHORISED_DEV_GROUP')],
 };
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,3 +1,20 @@
+import { sign } from 'jsonwebtoken';
+
+const dateToUnix = (date: Date): number => Math.floor(date.getTime() / 1000);
+
+const makeToken = ({
+  sub = '49516349857314',
+  email = 'test@example.com',
+  iss = 'Hackney',
+  name = 'example user',
+  groups = ['test-group'],
+  iat = new Date(),
+}) =>
+  sign(
+    { sub, email, iss, name, groups, iat: dateToUnix(iat) },
+    Cypress.env('HACKNEY_AUTH_TOKEN_SECRET')
+  );
+
 export enum AuthRoles {
   ChildrensGroup = 'ChildrensGroup',
   ChildrensUnrestrictedGroup = 'ChildrensUnrestrictedGroup',
@@ -68,13 +85,20 @@ const visitAs = (
   role: AuthRoles,
   options?: Partial<Cypress.VisitOptions>
 ) => {
-  const config = roleConfigurations[role];
+  // const config = roleConfigurations[role];
 
-  cy.setCookie('hackneyToken', config.tokenValue);
+  cy.setCookie(
+    'hackneyToken',
+    makeToken({
+      groups: [role],
+    })
+  );
   cy.getCookie('hackneyToken').should(
     'have.property',
     'value',
-    config.tokenValue
+    makeToken({
+      groups: [role],
+    })
   );
 
   cy.visit(url, options);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx && echo 'Lint complete.'",
     "format": "prettier '**/*.{js,jsx,ts,tsx,css,scss,md}' --write --list-different",
     "type-check": "tsc",
-    "e2e": "PORT=3000 start-server-and-test start http://localhost:3000 cy:run",
+    "e2e": "PORT=3000 HACKNEY_JWT_SECRET=test-secret start-server-and-test start http://localhost:3000 cy:run",
     "cy:run": "cypress run",
     "cy:open": "cypress open",
     "release": "release-it",

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -10,6 +10,8 @@ export const AUTH_WHITELIST = ['/login', '/access-denied'];
 
 const GSSO_TOKEN_NAME = process.env.GSSO_TOKEN_NAME;
 
+export const SESSION_EXPIRY = 14400;
+
 export const deleteSession = (
   res: NonNullable<NextPageContext['res']>
 ): void => {
@@ -73,7 +75,8 @@ export const isAuthorised = (
   const parsedToken = cookies[GSSO_TOKEN_NAME]
     ? (jsonwebtoken.verify(
         cookies[GSSO_TOKEN_NAME],
-        HACKNEY_JWT_SECRET
+        HACKNEY_JWT_SECRET,
+        {maxAge: SESSION_EXPIRY}
       ) as ParsedCookie)
     : null;
   if (!parsedToken) {

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -73,11 +73,9 @@ export const isAuthorised = (
 
   const cookies = cookie.parse(req.headers.cookie ?? '');
   const parsedToken = cookies[GSSO_TOKEN_NAME]
-    ? (jsonwebtoken.verify(
-        cookies[GSSO_TOKEN_NAME],
-        HACKNEY_JWT_SECRET,
-        {maxAge: SESSION_EXPIRY}
-      ) as ParsedCookie)
+    ? (jsonwebtoken.verify(cookies[GSSO_TOKEN_NAME], HACKNEY_JWT_SECRET, {
+        maxAge: SESSION_EXPIRY,
+      }) as ParsedCookie)
     : null;
   if (!parsedToken) {
     return;


### PR DESCRIPTION
**What**  
add an explicit session expiration time value of `14400` to auth config

**Why**  
using the same value as the core pathway app means that people will stay logged into both for the same amount of time. 

at the moment, core pathway app is stricter, so someone can be logged into the mainstream tool and be prompted to log in again to access core pathway data, which is confusing and frustrating.