### PR TITLE
feat: case note dialogs

### DIFF
--- a/components/Dialog/Dialog.tsx
+++ b/components/Dialog/Dialog.tsx
@@ -7,6 +7,7 @@ interface Props {
   children: React.ReactChild | React.ReactChild[];
   title: string;
   showCloseButton?: boolean;
+  onKeyUp: unknown;
 }
 
 const Dialog = ({

--- a/components/Dialog/Dialog.tsx
+++ b/components/Dialog/Dialog.tsx
@@ -7,7 +7,7 @@ interface Props {
   children: React.ReactChild | React.ReactChild[];
   title: string;
   showCloseButton?: boolean;
-  onKeyUp: KeyboardEventHandler<HTMLDivElement>;
+  onKeyUp?: KeyboardEventHandler<HTMLDivElement>;
 }
 
 const Dialog = ({

--- a/components/Dialog/Dialog.tsx
+++ b/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { KeyboardEventHandler } from 'react';
 import { Dialog as ReachDialog } from '@reach/dialog';
 
 interface Props {
@@ -7,7 +7,7 @@ interface Props {
   children: React.ReactChild | React.ReactChild[];
   title: string;
   showCloseButton?: boolean;
-  onKeyUp: unknown;
+  onKeyUp: KeyboardEventHandler<HTMLDivElement>;
 }
 
 const Dialog = ({
@@ -16,6 +16,7 @@ const Dialog = ({
   children,
   title,
   showCloseButton = true,
+  onKeyUp,
   ...props
 }: Props): React.ReactElement => (
   <ReachDialog
@@ -23,6 +24,7 @@ const Dialog = ({
     onDismiss={onDismiss}
     aria-label={title}
     className="lbh-dialog lbh-dialog--light"
+    onKeyUp={onKeyUp}
     {...props}
   >
     <h2 className="lbh-heading-h2 lbh-dialog__title govuk-!-margin-bottom-6">

--- a/components/FlexibleAnswers/FlexibleAnswers.tsx
+++ b/components/FlexibleAnswers/FlexibleAnswers.tsx
@@ -101,7 +101,7 @@ const FlexibleAnswersStep = ({
         aria-expanded={open}
         className="lbh-collapsible__button"
       >
-        <h2 className="lbh-heading-h2 lbh-collapsible__heading">{stepName}</h2>
+        <h2 className="lbh-heading-h4 lbh-collapsible__heading">{stepName}</h2>
         <DownArrow />
       </button>
 

--- a/components/FlexibleAnswers/FlexibleAnswers.tsx
+++ b/components/FlexibleAnswers/FlexibleAnswers.tsx
@@ -39,10 +39,10 @@ const RepeaterGroupAnswers = ({
 }: {
   answers: (string | RepeaterGroupAnswerT)[];
 }): React.ReactElement => (
-  <ul className="govuk-list lbh-list">
+  <ul className="govuk-list lbh-list lbh-body-s">
     {answers.length > 0 &&
       answers.map((item, i) => (
-        <li key={i}>
+        <li key={i} className="govuk-!-margin-top-1">
           {typeof item === 'string' ? (
             item
           ) : (
@@ -63,8 +63,10 @@ const SummaryList = ({
       ([questionName, answerGroup]) =>
         shouldShow(answerGroup) && (
           <div className="govuk-summary-list__row" key={questionName}>
-            <dt className="govuk-summary-list__key">{questionName}</dt>
-            <dd className={`govuk-summary-list__value ${s.dd}`}>
+            <dt className="govuk-summary-list__key lbh-body-s">
+              {questionName}
+            </dt>
+            <dd className={`govuk-summary-list__value lbh-body-s ${s.dd}`}>
               {typeof answerGroup === 'string' ? (
                 answerGroup
               ) : isTimetableAnswer(

--- a/components/ResidentPage/CaseNoteDialog.module.scss
+++ b/components/ResidentPage/CaseNoteDialog.module.scss
@@ -4,15 +4,18 @@
   margin-top: 0.5rem;
   margin-bottom: 1.5rem;
 
-  button {
+  button,
+  a {
     all: unset;
     text-decoration: underline;
     cursor: pointer;
     color: lbh-colour('lbh-secondary-text');
     @include lbh-link;
+    @include govuk-link-style-muted;
+    color: lbh-colour('lbh-secondary-text');
   }
 
-  button:first-of-type {
+  .deleteButton {
     color: lbh-colour('lbh-error');
     &:hover {
       color: lbh-colour('lbh-f01');
@@ -21,11 +24,6 @@
     &:active {
       color: lbh-colour('lbh-text');
     }
-  }
-
-  button:last-of-type {
-    @include govuk-link-style-muted;
-    color: lbh-colour('lbh-secondary-text');
   }
 }
 

--- a/components/ResidentPage/CaseNoteDialog.module.scss
+++ b/components/ResidentPage/CaseNoteDialog.module.scss
@@ -1,0 +1,56 @@
+@import 'lbh-frontend/lbh/base';
+
+.actions {
+  margin-top: 0.5rem;
+  margin-bottom: 1.5rem;
+
+  button {
+    all: unset;
+    text-decoration: underline;
+    cursor: pointer;
+    color: lbh-colour('lbh-secondary-text');
+    @include lbh-link;
+  }
+
+  button:first-of-type {
+    color: lbh-colour('lbh-error');
+    &:hover {
+      color: lbh-colour('lbh-f01');
+    }
+    &:focus,
+    &:active {
+      color: lbh-colour('lbh-text');
+    }
+  }
+
+  button:last-of-type {
+    @include govuk-link-style-muted;
+    color: lbh-colour('lbh-secondary-text');
+  }
+}
+
+.keyboardMessage {
+  text-align: center;
+
+  p {
+    color: lbh-colour('lbh-secondary-text');
+  }
+
+  span {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    color: lbh-colour('lbh-grey-1');
+    background: darken(lbh-colour('lbh-grey-4'), 3);
+    border: 1px solid darken(lbh-colour('lbh-grey-4'), 5);
+    border-radius: 3px;
+    width: 20px;
+    height: 20px;
+    box-shadow: 0px 1px 0px 0px lbh-colour('lbh-grey-2');
+    margin-top: 0.5rem;
+
+    & + span {
+      margin-left: 0.5rem;
+    }
+  }
+}

--- a/components/ResidentPage/CaseNoteDialog.spec.tsx
+++ b/components/ResidentPage/CaseNoteDialog.spec.tsx
@@ -200,6 +200,10 @@ describe('CaseNoteDialog', () => {
     );
   });
 
+  it.skip('only shows "Printable version" on records that have a full page version to go to', () => {
+    expect(screen.queryByText('Printable version')).toBeNull();
+  });
+
   it.skip('can be pinned to the top', () => {
     render(<CaseNoteDialog socialCareId={123} caseNotes={[mockedCaseNote]} />);
     fireEvent.click(screen.getByText('Pin to top'));

--- a/components/ResidentPage/CaseNoteDialog.spec.tsx
+++ b/components/ResidentPage/CaseNoteDialog.spec.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { mockedCaseNote } from 'factories/cases';
+import { mockSubmission } from 'factories/submissions';
+import CaseNoteDialog from './CaseNoteDialog';
+import { useRouter } from 'next/router';
+import { useCase } from 'utils/api/cases';
+import { useSubmission } from 'utils/api/submissions';
+
+jest.mock('next/router');
+jest.mock('utils/api/cases');
+jest.mock('utils/api/submissions');
+
+(useRouter as jest.Mock).mockReturnValue({
+  query: {},
+});
+(useCase as jest.Mock).mockReturnValue({
+  data: mockedCaseNote,
+});
+(useSubmission as jest.Mock).mockReturnValue({
+  data: {
+    ...mockSubmission,
+    id: mockedCaseNote.recordId,
+    answers: {
+      foo: 'bar',
+      one: 'two',
+    },
+  },
+});
+
+describe('CaseNoteDialog', () => {
+  it('renders nothing when there is no matching record ID in the URL query', () => {
+    render(<CaseNoteDialog caseNotes={[mockedCaseNote]} />);
+    expect(screen.queryByText('Close')).toBeNull();
+    expect(screen.queryByRole('heading')).toBeNull();
+  });
+
+  it('renders an old-style case note (record/case) correctly', () => {
+    (useRouter as jest.Mock).mockReturnValueOnce({
+      query: {
+        case_note: mockedCaseNote.recordId,
+      },
+    });
+
+    render(<CaseNoteDialog caseNotes={[mockedCaseNote]} />);
+
+    expect(screen.getByText('foorm'));
+    expect(screen.getByText('Added 25 Oct 2020 by Fname.Lname@hackney.gov.uk'));
+    expect(screen.getByText('Remove'));
+    expect(screen.getByText('Pin to top'));
+
+    expect(screen.getAllByRole('term').length).toBe(11);
+    expect(screen.getAllByRole('definition').length).toBe(11);
+  });
+
+  it('renders a new-style case note (submission/flexible-form) correctly', () => {
+    (useRouter as jest.Mock).mockReturnValueOnce({
+      query: {
+        case_note: mockedCaseNote.recordId,
+      },
+    });
+
+    render(
+      <CaseNoteDialog
+        caseNotes={[
+          {
+            ...mockedCaseNote,
+            formType: 'flexible-form',
+          },
+        ]}
+      />
+    );
+
+    screen.debug();
+
+    expect(screen.getByText('Form'));
+    expect(screen.getByText('Added 25 Oct 2020 by Fname.Lname@hackney.gov.uk'));
+    expect(screen.getByText('Remove'));
+    expect(screen.getByText('Pin to top'));
+
+    // expect(screen.getAllByRole('term').length).toBe(11);
+    // expect(screen.getAllByRole('definition').length).toBe(11);
+  });
+
+  //   it('can be navigated by keyboard', () => {
+  //     render(<CaseNoteDialog caseNotes={[mockedCaseNote]} />);
+  //     screen.debug();
+  //   });
+
+  //   it('updates the url when closed', () => {
+  //     render(<CaseNoteDialog caseNotes={[mockedCaseNote]} />);
+  //     screen.debug();
+  //   });
+
+  it.skip('can be removed/deleted', () => {
+    render(<CaseNoteDialog caseNotes={[mockedCaseNote]} />);
+    fireEvent.click(screen.getByText('Remove'));
+  });
+
+  it.skip('can be pinned to the top', () => {
+    render(<CaseNoteDialog caseNotes={[mockedCaseNote]} />);
+    fireEvent.click(screen.getByText('Pin to top'));
+  });
+});

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -1,0 +1,126 @@
+import Dialog from 'components/Dialog/Dialog';
+import {
+  prettyCaseDate,
+  prettyCaseTitle,
+  prettyWorkerName,
+} from 'lib/formatters';
+import { useRouter } from 'next/router';
+import { Case } from 'types';
+import { useWorker } from 'utils/api/workers';
+import SummaryList, { SummaryListSkeleton } from './SummaryList';
+import s from './CaseNoteDialog.module.scss';
+import { useCase } from 'utils/api/cases';
+import { useSubmission } from 'utils/api/submissions';
+import FlexibleAnswers from 'components/FlexibleAnswers/FlexibleAnswers';
+
+interface SubmissionContentProps {
+  submissionId: string;
+}
+
+const SubmissionContent = ({ submissionId }: SubmissionContentProps) => {
+  const { data } = useSubmission(submissionId);
+
+  if (data) return <FlexibleAnswers answers={data.formAnswers} />;
+
+  return <SummaryListSkeleton />;
+};
+
+interface CaseContentProps {
+  recordId: string;
+  socialCareId: number;
+}
+
+const CaseContent = ({ recordId, socialCareId }: CaseContentProps) => {
+  const { data } = useCase(recordId, socialCareId);
+
+  if (data)
+    return (
+      <SummaryList
+        rows={Object.fromEntries(
+          Object.entries(data.caseFormData || data).map(([key, value]) => [
+            key,
+            JSON.stringify(value),
+          ])
+        )}
+      />
+    );
+
+  return <SummaryListSkeleton />;
+};
+
+interface Props {
+  caseNotes: Case[];
+}
+
+const CaseNoteDialog = ({ caseNotes }: Props): React.ReactElement | null => {
+  const { query, replace } = useRouter();
+
+  const handleClose = () =>
+    replace(window.location.pathname, undefined, {
+      scroll: false,
+    });
+
+  const selectedId = query['case_note'];
+  const i = caseNotes.findIndex((c) => c.recordId === selectedId);
+  const note = caseNotes[i];
+
+  const { data: workerData } = useWorker({
+    email: note?.officerEmail || '',
+  });
+  const worker = workerData?.[0];
+
+  const handleKeyboardNav = (e: KeyboardEvent) => {
+    let newId;
+    if (e.key === 'ArrowLeft') {
+      newId = caseNotes?.[i - 1]?.recordId; // previous/newer note
+    }
+    if (e.key === 'ArrowRight') {
+      if (caseNotes.length > i) {
+        newId = caseNotes?.[i + 1]?.recordId; // next/older note
+      }
+    }
+    if (newId)
+      replace(`${window.location.pathname}?case_note=${newId}`, undefined, {
+        scroll: false,
+      });
+  };
+
+  if (note)
+    return (
+      <Dialog
+        title={prettyCaseTitle(note)}
+        isOpen={!!query['case_note']}
+        onDismiss={handleClose}
+        onKeyUp={handleKeyboardNav}
+      >
+        <p className="lbh-body-s">
+          Added {prettyCaseDate(note)} by{' '}
+          {worker ? prettyWorkerName(worker) : note.officerEmail}
+        </p>
+
+        <p className={`lbh-body-s ${s.actions}`}>
+          <button className="lbh-link lbh-link--danger">Remove</button> ·{' '}
+          <button className="lbh-link lbh-link--muted">Pin to top</button>
+        </p>
+
+        {note.formType === 'flexible-form' ? (
+          <SubmissionContent submissionId={note.recordId} />
+        ) : (
+          <CaseContent recordId={note.recordId} socialCareId={note.personId} />
+        )}
+
+        <div className={s.keyboardMessage}>
+          <p className="lbh-body-s">
+            Use <strong>arrow keys</strong> to move through case notes and
+            records.
+          </p>
+          <span>←</span>
+          <span>→</span>
+        </div>
+      </Dialog>
+    );
+
+  return null;
+};
+
+export default CaseNoteDialog;

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -55,7 +55,7 @@ interface CaseContentProps {
 }
 
 const prettyKey = (key: string): string =>
-  key?.replaceAll('_', ' ')?.replace(/^\w/, (char) => char.toUpperCase());
+  key?.replaceAll(/_/g, ' ')?.replace(/^\w/, (char) => char.toUpperCase());
 
 const CaseContent = ({ recordId, socialCareId }: CaseContentProps) => {
   const { data } = useCase(recordId, socialCareId);

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -15,6 +15,7 @@ import FlexibleAnswers from 'components/FlexibleAnswers/FlexibleAnswers';
 import Link from 'next/link';
 import { KeyboardEventHandler, useState } from 'react';
 import RemoveCaseNoteDialog from './RemoveCaseNoteDialog';
+import { generateInternalLink } from 'utils/urls';
 
 interface SubmissionContentProps {
   submissionId: string;
@@ -85,6 +86,15 @@ const CaseNoteDialog = ({
 }: Props): React.ReactElement | null => {
   const { query, replace } = useRouter();
 
+  const generateCaseLink = (c: Case): string => {
+    if (c.formType === 'flexible-form')
+      return `/people/${c.personId}/submissions/${c.recordId}`;
+    if (c.caseFormUrl) return c.caseFormUrl;
+    const intLink = generateInternalLink(c);
+
+    return intLink || '';
+  };
+
   const [deleting, setDeleting] = useState<boolean>(false);
 
   const handleClose = () =>
@@ -117,7 +127,9 @@ const CaseNoteDialog = ({
       });
   };
 
-  if (note)
+  if (note) {
+    const link = generateCaseLink(note);
+
     return (
       <Dialog
         title={prettyCaseTitle(note)}
@@ -131,10 +143,16 @@ const CaseNoteDialog = ({
         </p>
 
         <p className={`lbh-body-xs ${s.actions}`}>
-          <button className="lbh-link">Pin to top</button> ·{' '}
-          <Link href="#">
-            <a className="lbh-link">Printable version</a>
-          </Link>
+          <button className="lbh-link">Pin to top</button>
+          {link && (
+            <>
+              {' '}
+              ·{' '}
+              <Link href={link}>
+                <a className="lbh-link">Printable version</a>
+              </Link>
+            </>
+          )}
           {note.formType === 'flexible-form' && (
             <>
               {' '}
@@ -174,6 +192,7 @@ const CaseNoteDialog = ({
         </div>
       </Dialog>
     );
+  }
 
   return null;
 };

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -50,6 +50,7 @@ const CaseContent = ({ recordId, socialCareId }: CaseContentProps) => {
 
 interface Props {
   caseNotes: Case[];
+  socialCareId: number;
 }
 
 const CaseNoteDialog = ({ caseNotes }: Props): React.ReactElement | null => {

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -55,7 +55,7 @@ interface CaseContentProps {
 }
 
 const prettyKey = (key: string): string =>
-  key.replaceAll('_', ' ').replace(/^\w/, (char) => char.toUpperCase());
+  key?.replaceAll('_', ' ')?.replace(/^\w/, (char) => char.toUpperCase());
 
 const CaseContent = ({ recordId, socialCareId }: CaseContentProps) => {
   const { data } = useCase(recordId, socialCareId);

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -55,7 +55,7 @@ interface CaseContentProps {
 }
 
 const prettyKey = (key: string): string =>
-  key?.replaceAll(/_/g, ' ')?.replace(/^\w/, (char) => char.toUpperCase());
+  key?.replace(/_/g, ' ')?.replace(/^\w/, (char) => char.toUpperCase());
 
 const CaseContent = ({ recordId, socialCareId }: CaseContentProps) => {
   const { data } = useCase(recordId, socialCareId);
@@ -66,7 +66,7 @@ const CaseContent = ({ recordId, socialCareId }: CaseContentProps) => {
         rows={Object.fromEntries(
           Object.entries(data.caseFormData || data).map(([key, value]) => [
             prettyKey(key),
-            JSON.stringify(value).replaceAll('"', ''),
+            JSON.stringify(value).replace(/"/g, ''),
           ])
         )}
       />

--- a/components/ResidentPage/CaseNoteGrid.spec.tsx
+++ b/components/ResidentPage/CaseNoteGrid.spec.tsx
@@ -20,14 +20,28 @@ const mockCases = [
 
 describe('CaseNoteGrid', () => {
   it('shows a list of case notes', () => {
-    render(<CaseNoteGrid cases={mockCases} size={1} setSize={mockSetSize} />);
+    render(
+      <CaseNoteGrid
+        socialCareId={1}
+        cases={mockCases}
+        size={1}
+        setSize={mockSetSize}
+      />
+    );
     expect(screen.getByRole('list'));
     expect(screen.getAllByRole('listitem').length).toBe(4);
     expect(screen.getAllByText('foorm').length).toBe(4);
   });
 
   it('can load earlier notes', () => {
-    render(<CaseNoteGrid cases={mockCases} size={1} setSize={mockSetSize} />);
+    render(
+      <CaseNoteGrid
+        socialCareId={1}
+        cases={mockCases}
+        size={1}
+        setSize={mockSetSize}
+      />
+    );
     fireEvent.click(screen.getByText('Load more'));
     expect(mockSetSize).toBeCalledWith(2);
   });

--- a/components/ResidentPage/CaseNoteGrid.spec.tsx
+++ b/components/ResidentPage/CaseNoteGrid.spec.tsx
@@ -1,6 +1,13 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { mockedCaseNote } from 'factories/cases';
 import CaseNoteGrid from './CaseNoteGrid';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router');
+
+(useRouter as jest.Mock).mockReturnValue({
+  query: {},
+});
 
 const mockSetSize = jest.fn();
 

--- a/components/ResidentPage/CaseNoteGrid.tsx
+++ b/components/ResidentPage/CaseNoteGrid.tsx
@@ -1,0 +1,70 @@
+import { Case } from 'types';
+import s from './CaseNoteGrid.module.scss';
+import Link from 'next/link';
+import CaseNoteTile from './CaseNoteTile';
+import CaseNoteDialog from './CaseNoteDialog';
+
+interface Props {
+  cases: Case[];
+  size?: number;
+  setSize?: (newSize: number) => void;
+  socialCareId: number;
+}
+
+const CaseNoteGrid = ({
+  cases,
+  size,
+  setSize,
+  socialCareId,
+}: Props): React.ReactElement => (
+  <>
+    <ul className={s.grid}>
+      {cases?.map((c) => (
+        <CaseNoteTile key={c.recordId} c={c} />
+      ))}
+    </ul>
+
+    {size && setSize && (
+      <footer className={s.footer}>
+        <button
+          onClick={() => setSize(size + 1)}
+          className="govuk-button lbh-button"
+        >
+          Load more
+        </button>
+        <p className="lbh-body-s">
+          Looking for something specific? Try{' '}
+          <Link href="/search">
+            <a className="lbh-link lbh-link--no-visited-state">
+              searching for it
+            </a>
+          </Link>
+          .
+        </p>
+      </footer>
+    )}
+
+    <CaseNoteDialog socialCareId={socialCareId} caseNotes={cases} />
+  </>
+);
+
+const CaseTileSkeleton = () => (
+  <div className={s.tileSkeleton}>
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+);
+
+export const CaseNoteGridSkeleton = (): React.ReactElement => (
+  <div className={s.grid} aria-label="Loading...">
+    <CaseTileSkeleton />
+    <CaseTileSkeleton />
+    <CaseTileSkeleton />
+    <CaseTileSkeleton />
+    <CaseTileSkeleton />
+    <CaseTileSkeleton />
+  </div>
+);
+
+export default CaseNoteGrid;

--- a/components/ResidentPage/CaseNoteTile.spec.tsx
+++ b/components/ResidentPage/CaseNoteTile.spec.tsx
@@ -21,7 +21,7 @@ describe('CaseNoteTile', () => {
     render(<CaseNoteTile c={mockedCaseNote} />);
 
     expect((screen.getByRole('link') as HTMLAnchorElement).href).toContain(
-      '/people/123/records/4'
+      '?case_note=4'
     );
   });
 });

--- a/components/ResidentPage/CaseNoteTile.tsx
+++ b/components/ResidentPage/CaseNoteTile.tsx
@@ -8,20 +8,11 @@ import s from './CaseNoteGrid.module.scss';
 import Link from 'next/link';
 import { truncate } from 'lib/utils';
 import React from 'react';
-import { generateInternalLink } from 'utils/urls';
 import { useWorker } from 'utils/api/workers';
 
 interface TileProps {
   c: Case;
 }
-
-const generateCaseLink = (c: Case): string => {
-  if (c.formType === 'flexible-form')
-    return `/people/${c.personId}/submissions/${c.recordId}`;
-  if (c.caseFormUrl) return c.caseFormUrl;
-  const intLink = generateInternalLink(c);
-  return intLink || '';
-};
 
 const CaseNoteTile = ({ c }: TileProps): React.ReactElement => {
   const { data } = useWorker({
@@ -38,7 +29,6 @@ const CaseNoteTile = ({ c }: TileProps): React.ReactElement => {
           href={`${window.location.pathname}?case_note=${c.recordId}`}
           scroll={false}
         >
-          {/* <Link href={generateCaseLink(c)}> */}
           <a className="lbh-link lbh-link--no-visited-state">
             {prettyCaseTitle(c)}
           </a>

--- a/components/ResidentPage/CaseNoteTile.tsx
+++ b/components/ResidentPage/CaseNoteTile.tsx
@@ -1,0 +1,60 @@
+import {
+  prettyCaseDate,
+  prettyCaseTitle,
+  prettyWorkerName,
+} from 'lib/formatters';
+import { Case } from 'types';
+import s from './CaseNoteGrid.module.scss';
+import Link from 'next/link';
+import { truncate } from 'lib/utils';
+import React from 'react';
+import { generateInternalLink } from 'utils/urls';
+import { useWorker } from 'utils/api/workers';
+
+interface TileProps {
+  c: Case;
+}
+
+const generateCaseLink = (c: Case): string => {
+  if (c.formType === 'flexible-form')
+    return `/people/${c.personId}/submissions/${c.recordId}`;
+  if (c.caseFormUrl) return c.caseFormUrl;
+  const intLink = generateInternalLink(c);
+  return intLink || '';
+};
+
+const CaseNoteTile = ({ c }: TileProps): React.ReactElement => {
+  const { data } = useWorker({
+    email: c.officerEmail || '',
+  });
+
+  const worker = data?.[0];
+
+  return (
+    <li key={c.recordId} className={s.tile}>
+      <p className="lbh-body-xs">{prettyCaseDate(c)}</p>
+      <h2 className="lbh-heading-h4">
+        <Link
+          href={`${window.location.pathname}?case_note=${c.recordId}`}
+          scroll={false}
+        >
+          {/* <Link href={generateCaseLink(c)}> */}
+          <a className="lbh-link lbh-link--no-visited-state">
+            {prettyCaseTitle(c)}
+          </a>
+        </Link>
+      </h2>
+
+      <div aria-hidden="true" className={s.preview}>
+        {c?.caseFormData?.case_note_description &&
+          truncate(c.caseFormData.case_note_description || '', 20)}
+      </div>
+
+      <p className="lbh-body-xs">
+        By {worker ? prettyWorkerName(worker) : c.officerEmail}
+      </p>
+    </li>
+  );
+};
+
+export default CaseNoteTile;

--- a/components/ResidentPage/RemoveCaseNoteDialog.tsx
+++ b/components/ResidentPage/RemoveCaseNoteDialog.tsx
@@ -1,0 +1,61 @@
+import Dialog from 'components/Dialog/Dialog';
+import { useAuth } from 'components/UserContext/UserContext';
+import { useRouter } from 'next/router';
+import { useCases } from 'utils/api/cases';
+import { deleteSubmission } from 'utils/api/submissions';
+
+const DELETE_REASONS = [
+  'Submitted prematurely',
+  'Manager requested amendments',
+  'Incorrect date',
+  'Incorrect information/details (i.e, visit type selected incorrectly)',
+  'Duplicate records',
+  'Further information received',
+  'Wrong person',
+  'Client requested deletion',
+];
+
+interface Props {
+  submissionId: string;
+  isOpen: boolean;
+  socialCareId: number;
+  onClose: () => void;
+}
+
+const RemoveCaseNoteDialog = ({
+  submissionId,
+  socialCareId,
+  isOpen,
+  onClose,
+}: Props): React.ReactElement => {
+  const { user } = useAuth();
+  const { mutate } = useCases({ mosaic_id: socialCareId });
+  const { replace } = useRouter();
+
+  const remove = async () => {
+    if (user)
+      await deleteSubmission(submissionId, DELETE_REASONS[3], user?.name);
+    onClose(); // close this dialog
+    mutate(); // give it a kick
+    replace(window.location.pathname); // and close case note dialog
+  };
+
+  return (
+    <Dialog
+      title="Are you sure you want to remove this case note or record?"
+      onDismiss={onClose}
+      isOpen={isOpen}
+    >
+      <div className="lbh-dialog__actions">
+        <button className="govuk-button lbh-button" onClick={remove}>
+          Yes, remove
+        </button>
+        <button className="lbh-link" onClick={onClose}>
+          No, do nothing
+        </button>
+      </div>
+    </Dialog>
+  );
+};
+
+export default RemoveCaseNoteDialog;

--- a/components/ResidentPage/WorkflowTree.tsx
+++ b/components/ResidentPage/WorkflowTree.tsx
@@ -1,0 +1,141 @@
+import Link from 'next/link';
+import { Workflow, WorkflowType } from 'components/ResidentPage/types';
+import { useMemo } from 'react';
+import s from './WorkflowTree.module.scss';
+import { formatDate } from 'utils/date';
+import { prettyStatus } from 'lib/workflows/status';
+import { formatDistanceToNow } from 'date-fns';
+
+interface Props {
+  workflows: Workflow[];
+  socialCareId: number;
+  summarise?: boolean;
+}
+
+interface WorkflowWithChildren extends Workflow {
+  children?: WorkflowWithChildren[];
+}
+
+const gatherChildren = (
+  workflow: Workflow,
+  workflows: Workflow[]
+): WorkflowWithChildren => {
+  return {
+    ...workflow,
+    children: workflows
+      .filter((w) => w.workflowId === workflow.id)
+      .map((x) => gatherChildren(x, workflows)),
+  };
+};
+
+const convertWorkflowsToTree = (
+  workflows: Workflow[]
+): WorkflowWithChildren[] => {
+  const topLevel = workflows.filter((w) => !w.workflowId);
+  return topLevel.map((w) => gatherChildren(w, workflows));
+};
+
+const Node = ({ w }: { w: WorkflowWithChildren }) => {
+  const hasChildren = w?.children && w?.children?.length > 0;
+
+  return (
+    <li className={hasChildren ? s.nodeWithChildren : s.node}>
+      {hasChildren && (
+        <ul>
+          {w.children?.map((c) => (
+            <Node key={c.id} w={c} />
+          ))}
+        </ul>
+      )}
+
+      <Link
+        href={`${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}/workflows/${w.id}`}
+      >
+        {w?.form?.name || w.formId}
+      </Link>
+
+      {w.type === WorkflowType.Reassessment && (
+        <span className="govuk-tag lbh-tag">Reassessment</span>
+      )}
+
+      <p className="lbh-body-xs">
+        Started {formatDate(w.createdAt.toString())} · {prettyStatus(w)}
+      </p>
+
+      <p className="lbh-body-xs">
+        {w.assignee
+          ? `Assigned to ${w.assignee.name || w.assignee.email}`
+          : 'Unassigned'}
+      </p>
+    </li>
+  );
+};
+
+const WorkflowTree = ({
+  workflows,
+  socialCareId,
+  summarise,
+}: Props): React.ReactElement => {
+  const reverseChronological = workflows?.sort(
+    (a, b) => new Date(b.createdAt).valueOf() - new Date(a.createdAt).valueOf()
+  );
+  const workflowsBegan =
+    reverseChronological?.[reverseChronological.length - 1]?.createdAt;
+
+  const tree = useMemo(
+    () => convertWorkflowsToTree(reverseChronological),
+    [reverseChronological]
+  );
+
+  if (summarise)
+    return (
+      <div className="govuk-grid-row">
+        <ul className={`govuk-grid-column-three-quarters ${s.tree}`}>
+          {tree?.map((w) => (
+            <Node w={w} key={w.id} />
+          ))}
+        </ul>
+        <aside className={`govuk-grid-column-one-quarter ${s.summaryPanel}`}>
+          <p className="lbh-body-xs">
+            {workflows.length} workflows started over{' '}
+            {formatDistanceToNow(new Date(workflowsBegan))}
+          </p>
+          <p className="lbh-body-xs govuk-!-margin-top-1">
+            <a
+              className="lbh-link lbh-link--no-visited-state"
+              href={`${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}?quick_filter=all&social_care_id=${socialCareId}&touched_by_me=true`}
+            >
+              See on planner
+            </a>
+          </p>
+        </aside>
+      </div>
+    );
+
+  return (
+    <ul className={s.tree}>
+      {tree?.map((w) => (
+        <Node w={w} key={w.id} />
+      ))}
+    </ul>
+  );
+};
+
+export default WorkflowTree;
+
+export const WorkflowNodeSkeleton = (): React.ReactElement => (
+  <div className={s.nodeSkeleton} aria-hidden="true">
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+);
+
+export const WorkflowTreeSkeleton = (): React.ReactElement => (
+  <div aria-label="Loading...">
+    <WorkflowNodeSkeleton />
+    <WorkflowNodeSkeleton />
+    <WorkflowNodeSkeleton />
+    <WorkflowNodeSkeleton />
+  </div>
+);

--- a/pages/residents/[id]/case-notes.tsx
+++ b/pages/residents/[id]/case-notes.tsx
@@ -1,0 +1,85 @@
+import CaseNoteGrid, {
+  CaseNoteGridSkeleton,
+} from 'components/ResidentPage/CaseNoteGrid';
+import Layout from 'components/ResidentPage/Layout';
+import { getResident } from 'lib/residents';
+import { GetServerSideProps } from 'next';
+import { Case, Resident } from 'types';
+import { useCases } from 'utils/api/cases';
+import { isAuthorised } from 'utils/auth';
+import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
+
+interface Props {
+  resident: Resident;
+}
+
+const RelationshipsPage = ({ resident }: Props): React.ReactElement => {
+  const { data, setSize, size, error } = useCases({
+    mosaic_id: resident.id,
+  });
+
+  let cases: Case[] = [];
+  data?.map((page) => {
+    if (page.cases) cases = cases.concat(page?.cases);
+  });
+
+  const casesToShow = cases.length > 0;
+
+  return (
+    <Layout resident={resident} title="Case notes">
+      <>
+        {!data && !error ? (
+          <CaseNoteGridSkeleton />
+        ) : casesToShow ? (
+          <CaseNoteGrid
+            cases={cases}
+            size={size}
+            setSize={setSize}
+            socialCareId={resident.id}
+          />
+        ) : error ? (
+          <ErrorMessage />
+        ) : (
+          <p className="lbh-body">This resident has no case notes yet.</p>
+        )}
+      </>
+    </Layout>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async ({
+  params,
+  req,
+}) => {
+  const user = isAuthorised(req);
+
+  // redirect unauthorised users to login
+  if (!user) {
+    return {
+      props: {},
+      redirect: {
+        destination: `/login`,
+      },
+    };
+  }
+
+  const resident = await getResident(Number(params?.id), user);
+
+  // does the resident exist?
+  if (!resident.id) {
+    return {
+      props: {},
+      redirect: {
+        destination: `/404`,
+      },
+    };
+  }
+
+  return {
+    props: {
+      resident,
+    },
+  };
+};
+
+export default RelationshipsPage;

--- a/pages/residents/[id]/index.tsx
+++ b/pages/residents/[id]/index.tsx
@@ -256,7 +256,9 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
           </Link>
         }
       >
-        <>{cases && <CaseNoteGrid cases={cases} />}</>
+        <>
+          {cases && <CaseNoteGrid cases={cases} socialCareId={resident.id} />}
+        </>
       </Collapsible>
 
       <Collapsible


### PR DESCRIPTION
at the moment, users hate how slow it is to navigate through case notes. they have to open new tabs and painstakingly move through them to find what they need.

something they've asked for several times is previous/next navigation on notes.

this refactors the case note interface into dialogs that users can "peek" into quickly, with:

- the open note represented in the url so it can be shared
- left/right keyboard navigation for skipping through notes quickly
- a link to the existing, full-page "printable version" if the user wants
- 
works well with:

- modern case notes (submissions)
- traditional case notes (records)
- google form submissions
- audit trail events

one limitation of this approach is that it can only skip through the portion of case note/record data that's been loaded by the user. it cannot "load more". ideally we'd fix this api-side eventually by adding either the links or ids to the surrounding notes. nonetheless, this is a massive improvement over the current experience

<img width="517" alt="Screenshot 2022-02-04 at 16 23 32" src="https://user-images.githubusercontent.com/14189497/152754617-126e2d5b-7449-4387-801e-a1fb69c9ded2.png">
