### PR TITLE
chore: new resident view respects restricted

### DIFF
--- a/components/ResidentPage/CaseNoteGrid.spec.tsx
+++ b/components/ResidentPage/CaseNoteGrid.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { mockedCaseNote } from 'factories/cases';
+import { mockedResident } from 'factories/residents';
 import CaseNoteGrid from './CaseNoteGrid';
 
 const mockSetSize = jest.fn();
@@ -13,14 +14,28 @@ const mockCases = [
 
 describe('CaseNoteGrid', () => {
   it('shows a list of case notes', () => {
-    render(<CaseNoteGrid cases={mockCases} size={1} setSize={mockSetSize} />);
+    render(
+      <CaseNoteGrid
+        resident={mockedResident}
+        cases={mockCases}
+        size={1}
+        setSize={mockSetSize}
+      />
+    );
     expect(screen.getByRole('list'));
     expect(screen.getAllByRole('listitem').length).toBe(4);
     expect(screen.getAllByText('foorm').length).toBe(4);
   });
 
   it('can load earlier notes', () => {
-    render(<CaseNoteGrid cases={mockCases} size={1} setSize={mockSetSize} />);
+    render(
+      <CaseNoteGrid
+        resident={mockedResident}
+        cases={mockCases}
+        size={1}
+        setSize={mockSetSize}
+      />
+    );
     fireEvent.click(screen.getByText('Load more'));
     expect(mockSetSize).toBeCalledWith(2);
   });

--- a/components/ResidentPage/CaseNoteGrid.tsx
+++ b/components/ResidentPage/CaseNoteGrid.tsx
@@ -1,43 +1,63 @@
-import { Case } from 'types';
+import { Case, Resident } from 'types';
 import s from './CaseNoteGrid.module.scss';
 import Link from 'next/link';
 import CaseNoteTile from './CaseNoteTile';
+import { canManageCases } from 'lib/permissions';
+import { useAuth } from 'components/UserContext/UserContext';
 
 interface Props {
   cases: Case[];
   size?: number;
   setSize?: (newSize: number) => void;
+  resident: Resident;
 }
 
-const CaseNoteGrid = ({ cases, size, setSize }: Props): React.ReactElement => (
-  <>
-    <ul className={s.grid}>
-      {cases?.map((c) => (
-        <CaseNoteTile key={c.recordId} c={c} />
-      ))}
-    </ul>
+const CaseNoteGrid = ({
+  cases,
+  size,
+  setSize,
+  resident,
+}: Props): React.ReactElement => {
+  const { user } = useAuth();
 
-    {size && setSize && (
-      <footer className={s.footer}>
-        <button
-          onClick={() => setSize(size + 1)}
-          className="govuk-button lbh-button"
-        >
-          Load more
-        </button>
-        <p className="lbh-body-s">
-          Looking for something specific? Try{' '}
-          <Link href="/search">
-            <a className="lbh-link lbh-link--no-visited-state">
-              searching for it
-            </a>
-          </Link>
-          .
-        </p>
-      </footer>
-    )}
-  </>
-);
+  if (user && !canManageCases(user, resident))
+    return (
+      <p>
+        You don&apos;t have permission to see this resident&apos;s case notes
+        and records.
+      </p>
+    );
+
+  return (
+    <>
+      <ul className={s.grid}>
+        {cases?.map((c) => (
+          <CaseNoteTile key={c.recordId} c={c} />
+        ))}
+      </ul>
+
+      {size && setSize && (
+        <footer className={s.footer}>
+          <button
+            onClick={() => setSize(size + 1)}
+            className="govuk-button lbh-button"
+          >
+            Load more
+          </button>
+          <p className="lbh-body-s">
+            Looking for something specific? Try{' '}
+            <Link href="/search">
+              <a className="lbh-link lbh-link--no-visited-state">
+                searching for it
+              </a>
+            </Link>
+            .
+          </p>
+        </footer>
+      )}
+    </>
+  );
+};
 
 const CaseTileSkeleton = () => (
   <div className={s.tileSkeleton}>

--- a/components/ResidentPage/Collapsible.module.scss
+++ b/components/ResidentPage/Collapsible.module.scss
@@ -16,7 +16,8 @@
   justify-content: space-between;
 
   // properly space the case note tile grid when presented inside a collapsible
-  & + ul {
+  & + ul,
+  & + p {
     margin-top: 1rem;
   }
 

--- a/components/ResidentPage/WorkflowTree.spec.tsx
+++ b/components/ResidentPage/WorkflowTree.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { mockedResident } from 'factories/residents';
 import { mockWorkflow } from 'fixtures/workflows';
 import WorkflowTree from './WorkflowTree';
 
@@ -25,7 +26,7 @@ const mockTree = [
 
 describe('WorkflowTree', () => {
   it('shows workflows and their children', () => {
-    render(<WorkflowTree workflows={mockTree} socialCareId={1} />);
+    render(<WorkflowTree workflows={mockTree} resident={mockedResident} />);
     expect(screen.getAllByRole('list').length).toBe(3);
     expect(screen.getAllByRole('listitem').length).toBe(4);
     expect(screen.getAllByRole('link').length).toBe(4);
@@ -41,7 +42,9 @@ describe('WorkflowTree', () => {
   });
 
   it('summarises the workflow chain when asked', () => {
-    render(<WorkflowTree workflows={mockTree} socialCareId={1} summarise />);
+    render(
+      <WorkflowTree workflows={mockTree} resident={mockedResident} summarise />
+    );
     expect(screen.getByText('4 workflows started over over 1 year'));
   });
 });

--- a/components/ResidentPage/WorkflowTree.tsx
+++ b/components/ResidentPage/WorkflowTree.tsx
@@ -5,10 +5,13 @@ import s from './WorkflowTree.module.scss';
 import { formatDate } from 'utils/date';
 import { prettyStatus } from 'lib/workflows/status';
 import { formatDistanceToNow } from 'date-fns';
+import { useAuth } from 'components/UserContext/UserContext';
+import { canManageCases } from 'lib/permissions';
+import { Resident } from 'types';
 
 interface Props {
   workflows: Workflow[];
-  socialCareId: number;
+  resident: Resident;
   summarise?: boolean;
 }
 
@@ -73,9 +76,11 @@ const Node = ({ w }: { w: WorkflowWithChildren }) => {
 
 const WorkflowTree = ({
   workflows,
-  socialCareId,
+  resident,
   summarise,
 }: Props): React.ReactElement => {
+  const { user } = useAuth();
+
   const reverseChronological = workflows.sort(
     (a, b) => new Date(b.createdAt).valueOf() - new Date(a.createdAt).valueOf()
   );
@@ -86,6 +91,13 @@ const WorkflowTree = ({
     () => convertWorkflowsToTree(reverseChronological),
     [reverseChronological]
   );
+
+  if (user && !canManageCases(user, resident))
+    return (
+      <p>
+        You don&apos;t have permission to see this resident&apos;s workflows.
+      </p>
+    );
 
   if (summarise)
     return (
@@ -103,7 +115,7 @@ const WorkflowTree = ({
           <p className="lbh-body-xs govuk-!-margin-top-1">
             <a
               className="lbh-link lbh-link--no-visited-state"
-              href={`${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}?quick_filter=all&social_care_id=${socialCareId}&touched_by_me=true`}
+              href={`${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}?quick_filter=all&social_care_id=${resident.id}&touched_by_me=true`}
             >
               See on planner
             </a>

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -36,7 +36,6 @@ export const canManageCases = (
   user: User,
   person: Pick<Resident, 'restricted' | 'contextFlag'>
 ): boolean => {
-  return false;
   const isPersonRestricted = person.restricted === 'Y';
 
   if (user.hasAdminPermissions || user.hasDevPermissions) {

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -36,6 +36,7 @@ export const canManageCases = (
   user: User,
   person: Pick<Resident, 'restricted' | 'contextFlag'>
 ): boolean => {
+  return false;
   const isPersonRestricted = person.restricted === 'Y';
 
   if (user.hasAdminPermissions || user.hasDevPermissions) {

--- a/pages/residents/[id]/case-notes.tsx
+++ b/pages/residents/[id]/case-notes.tsx
@@ -31,7 +31,12 @@ const RelationshipsPage = ({ resident }: Props): React.ReactElement => {
         {!data && !error ? (
           <CaseNoteGridSkeleton />
         ) : casesToShow ? (
-          <CaseNoteGrid cases={cases} size={size} setSize={setSize} />
+          <CaseNoteGrid
+            cases={cases}
+            size={size}
+            setSize={setSize}
+            resident={resident}
+          />
         ) : error ? (
           <ErrorMessage />
         ) : (

--- a/pages/residents/[id]/index.tsx
+++ b/pages/residents/[id]/index.tsx
@@ -256,7 +256,7 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
           </Link>
         }
       >
-        <>{cases && <CaseNoteGrid cases={cases} />}</>
+        <>{cases && <CaseNoteGrid cases={cases} resident={resident} />}</>
       </Collapsible>
 
       <Collapsible
@@ -269,7 +269,7 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
       >
         <>
           {workflows && (
-            <WorkflowTree socialCareId={resident.id} workflows={workflows} />
+            <WorkflowTree resident={resident} workflows={workflows} />
           )}
           <p className=" lbh-body-xs">
             <Link href={`/residents/${resident.id}/workflows`}>

--- a/pages/residents/[id]/workflows.tsx
+++ b/pages/residents/[id]/workflows.tsx
@@ -24,7 +24,7 @@ const WorkflowsPage = ({ resident }: Props): React.ReactElement => {
         {!data && !error ? (
           <WorkflowTreeSkeleton />
         ) : workflowsToShow ? (
-          <WorkflowTree workflows={data.workflows} socialCareId={resident.id} />
+          <WorkflowTree workflows={data.workflows} resident={resident} />
         ) : error ? (
           <ErrorMessage />
         ) : (

--- a/zap-baseline.conf
+++ b/zap-baseline.conf
@@ -40,6 +40,8 @@
 10056	FAIL	(X-Debug-Token Information Leak)
 10057	FAIL	(Username Hash Found)
 10061	FAIL	(X-AspNet-Version Response Header)
+# getting false positives: https://github.com/LBHackney-IT/lbh-social-care-frontend/pull/844
+10062	OUTOFSCOPE	.*\/_next\/static\/.*\/_buildManifest.js
 10062	FAIL	(PII Disclosure)
 10096	FAIL	(Timestamp Disclosure)
 10097	FAIL	(Hash Disclosure)


### PR DESCRIPTION
the new resident view now respects the `restricted` flag on a resident, like the current live person view.

also, `restricted` is extended to treat workflows the same way, not just case notes/records.