### PR TITLE
feat(SCT-1687): update ssl cert arn for mosaic production

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -125,7 +125,7 @@ custom:
   certificate-arn:
     staging: arn:aws:acm:us-east-1:715003523189:certificate/d2860eaf-cd6a-46e8-a171-2edc3450a51c
     production: arn:aws:acm:us-east-1:153306643385:certificate/71728a39-cd3e-4570-a440-e87f84ef9a0d
-    mosaic-prod: arn:aws:acm:us-east-1:267112830674:certificate/dae4d0be-8f3a-4512-ba9c-fb80366e77f7
+    mosaic-prod: arn:aws:acm:us-east-1:267112830674:certificate/cd4307e5-2a24-450b-b5cf-06a8e2d57057
   securityGroups:
     staging:
       - sg-048f0fb9620e30710


### PR DESCRIPTION
**What**  
Update SSL certificate ARN used for mosaic-production account

**Why**  
This will update the production site to use the new SSL certifcate that was generated to replace the current and soon to be expiring wildcard certificate.
