### PR TITLE
fix: Sentry issue - jira sct-1669 - unhandled promise 

### DIFF
--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -69,6 +69,9 @@ let routerReplace: jest.Mock<any, any>;
 const newError = new Error();
 newError.message = 'HI1';
 
+// Regression test for sct-1669
+// https://hackney.atlassian.net/browse/SCT-1669
+// UnhandledRejection Non-Error promise rejection captured with value: routeChange aborted.
 describe('Case note page', () => {
   beforeAll(() => {
     useRouterMock.mockReturnValue(mockRouter);

--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -136,9 +136,11 @@ describe('Case note page', () => {
     // act(() => {
     const { getByText } = render(<CaseNote {...mockedNewSubmission} />);
 
-    await waitFor(() => {
-      fireEvent.click(getByText('Save and finish'));
-    });
+    await expect(useRouterMock().replace).rejects.toThrow(newError);
+
+    // await waitFor(() => {
+    //   fireEvent.click(getByText('Save and finish'));
+    // });
     // warningBanner = getByRole('alert');
     // });
     // expect(await screen.getByRole('alert')).toBeVisible;
@@ -147,9 +149,12 @@ describe('Case note page', () => {
     expect(warningMessage).not.toBeNull();
 
     expect(useRouterMock).toHaveBeenCalled();
+
     expect(useRouterMock().replace).toHaveBeenCalled();
+
     expect(warningBanner).not.toBeNull();
     expect(consoleSpy).toHaveBeenCalled();
+
     // expect(consoleSpy).toHaveErrorMessage();
     // expect(consoleLogSpy).toHaveBeenCalled();
   });

--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -5,28 +5,54 @@ import { mockedWorker } from 'factories/workers';
 import { SubmissionState } from 'data/flexibleForms/forms.types';
 import { useRouter } from 'next/router';
 
-jest.mock('next/router');
-const useRouterMock = useRouter as jest.MockedFunction<typeof useRouter>;
+// jest.mock('next/router');
+// const useRouterMock = useRouter as jest.MockedFunction<typeof useRouter>;
 // const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 let eventName;
 let routeChangeHandler;
 
-useRouterMock.mockImplementation(() => {
-  return {
-    BaseRouter: { pathname: '/', route: '/', query: {}, asPath: '/' },
-    events: {
-      on: jest.fn((event, callback) => {
-        eventName = event;
-        routeChangeHandler = callback;
-      }),
-      off: jest.fn((event, callback) => {
-        eventName = event;
-        routeChangeHandler = callback;
-      }),
-    },
-  };
-});
+// useRouterMock.mockImplementation(() => {
+//   return {
+//     BaseRouter: { pathname: '/', route: '/', query: {}, asPath: '/' },
+// events: {
+//   on: jest.fn((event, callback) => {
+//     eventName = event;
+//     routeChangeHandler = callback;
+//   }),
+//   off: jest.fn((event, callback) => {
+//     eventName = event;
+//     routeChangeHandler = callback;
+//   }),
+// },
+//   };
+// });
+
+jest.mock('next/router', () => ({
+  useRouter() {
+    return {
+      basePath: '/',
+      pathname: '/',
+      route: '/',
+      query: {},
+      asPath: '/',
+      push: jest.fn(() => Promise.resolve(true)),
+      replace: jest.fn(() => Promise.resolve(true)),
+      reload: jest.fn(() => Promise.resolve(true)),
+      prefetch: jest.fn(() => Promise.resolve()),
+      back: jest.fn(() => Promise.resolve(true)),
+      beforePopState: jest.fn(() => Promise.resolve(true)),
+      isFallback: false,
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+        emit: jest.fn(),
+      },
+    };
+  },
+}));
+
+// const spyOnReplace = jest.spyOn(useRouter, 'replace');
 
 const mockedResident = residentFactory.build();
 
@@ -60,12 +86,12 @@ const mockedNewSubmission = {
 
 describe('Case note page', () => {
   it('catches an unhandled promise', () => {
-    (useRouter().replace as jest.Mock).mockRejectedValue(new Error());
+    // (useRouter().replace as jest.Mock).mockRejectedValue(new Error());
     // const router = useRouter();
     // router.query = { submissionId: '' };
 
     const { getByText } = render(<CaseNote {...mockedNewSubmission} />);
 
-    expect(useRouter().replace).toHaveBeenCalled();
+    expect(useRouter.useRouter).toHaveBeenCalled();
   });
 });

--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -77,9 +77,8 @@ describe('Case note page', () => {
     const newError = new Error();
     (useRouterMock().replace as jest.Mock).mockRejectedValue(newError);
 
-    await render(<CaseNote {...mockedNewSubmission} />);
+    render(<CaseNote {...mockedNewSubmission} />);
     await expect(useRouterMock().replace).rejects.toThrow(newError);
-    // await expect(useRouterMock().replace).rejects.toEqual(newError);
 
     expect(useRouterMock).toHaveBeenCalled();
     expect(useRouterMock().replace).toHaveBeenCalled();
@@ -95,7 +94,6 @@ describe('Case note page', () => {
     await expect(useRouterMock().replace).rejects.toThrow(newError);
 
     const warningMessage = getByText('There was a problem');
-    console.log('warning message', warningMessage);
     expect(warningMessage).not.toBeNull();
   });
 });

--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -5,8 +5,28 @@ import { mockedWorker } from 'factories/workers';
 import { SubmissionState } from 'data/flexibleForms/forms.types';
 import { useRouter } from 'next/router';
 
-// jest.mock('next/router');
+jest.mock('next/router');
+const useRouterMock = useRouter as jest.MockedFunction<typeof useRouter>;
 // const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+let eventName;
+let routeChangeHandler;
+
+useRouterMock.mockImplementation(() => {
+  return {
+    BaseRouter: { pathname: '/', route: '/', query: {}, asPath: '/' },
+    events: {
+      on: jest.fn((event, callback) => {
+        eventName = event;
+        routeChangeHandler = callback;
+      }),
+      off: jest.fn((event, callback) => {
+        eventName = event;
+        routeChangeHandler = callback;
+      }),
+    },
+  };
+});
 
 const mockedResident = residentFactory.build();
 

--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -19,7 +19,7 @@ const mockRouter = {
   query: {},
   asPath: '/',
   push: jest.fn(() => Promise.resolve(true)),
-  replace: jest.fn(() => Promise.resolve(false)),
+  replace: jest.fn(() => Promise.resolve(true)),
   reload: jest.fn(() => Promise.resolve(true)),
   prefetch: jest.fn(() => Promise.resolve()),
   back: jest.fn(() => Promise.resolve(true)),
@@ -65,41 +65,35 @@ const mockedNewSubmission = {
   params: { id: '1234' },
 };
 
+let routerReplace: jest.Mock<any, any>;
+const newError = new Error();
+newError.message = 'HI1';
+
 describe('Case note page', () => {
-  beforeEach(() => {
+  beforeAll(() => {
     useRouterMock.mockReturnValue(mockRouter);
+    routerReplace = (useRouterMock().replace as jest.Mock).mockRejectedValue(
+      newError
+    );
   });
-  afterEach(() => {
-    consoleErrorMock.mockReset();
+  afterAll(() => {
     useRouterMock.mockReset();
   });
   it('catches an unhandled promise', async () => {
-    const newError = new Error();
-    const routerReplace = (
-      useRouterMock().replace as jest.Mock
-    ).mockRejectedValue(newError);
-
     render(<CaseNote {...mockedNewSubmission} />);
     await expect(routerReplace).rejects.toEqual(newError);
 
     expect(useRouterMock).toHaveBeenCalled();
     expect(routerReplace).toHaveBeenCalled();
     expect(consoleErrorMock).toHaveBeenCalled();
-    routerReplace.mockReset();
   });
 
   it('displays an alert banner when router.replace fails', async () => {
-    const newError = new Error();
-    newError.message = 'HI1';
-    const routerReplace = (
-      useRouterMock().replace as jest.Mock
-    ).mockRejectedValue(newError);
-
     const { getByText } = render(<CaseNote {...mockedNewSubmission} />);
     await expect(routerReplace).rejects.toEqual(newError);
 
     const warningMessage = getByText('There was a problem');
     expect(warningMessage).not.toBeNull();
-    routerReplace.mockReset();
+    expect(consoleErrorMock).toHaveBeenCalled();
   });
 });

--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -1,5 +1,5 @@
 import CaseNote from '../../../pages/people/[id]/case-note';
-import { screen, render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { residentFactory } from 'factories/residents';
 import { mockedWorker } from 'factories/workers';
 import { SubmissionState } from 'data/flexibleForms/forms.types';
@@ -142,19 +142,13 @@ describe('Case note page', () => {
     // warningBanner = getByRole('alert');
     // });
     // expect(await screen.getByRole('alert')).toBeVisible;
-    const warningMessage = getByText(
-      'There was a problem finishing the submission'
-    );
+    const warningMessage = getByText('There was a problem');
 
     expect(warningMessage).not.toBeNull();
 
     expect(useRouterMock).toHaveBeenCalled();
     expect(useRouterMock().replace).toHaveBeenCalled();
     expect(warningBanner).not.toBeNull();
-    // expect(() => {
-    //   consoleSpy;
-    // }).toThrowError();
-
     expect(consoleSpy).toHaveBeenCalled();
     // expect(consoleSpy).toHaveErrorMessage();
     // expect(consoleLogSpy).toHaveBeenCalled();

--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -1,0 +1,51 @@
+import CaseNote from '../../../pages/people/[id]/case-note';
+import { render } from '@testing-library/react';
+import { residentFactory } from 'factories/residents';
+import { mockedWorker } from 'factories/workers';
+import { SubmissionState } from 'data/flexibleForms/forms.types';
+import { useRouter } from 'next/router';
+
+// jest.mock('next/router');
+// const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockedResident = residentFactory.build();
+
+const mockedNewSubmission = {
+  submissionId: '',
+  formId: 'foo',
+  residents: [mockedResident],
+  createdBy: mockedWorker,
+  createdAt: '2021-06-21T12:00:00.000Z',
+  submittedBy: mockedWorker,
+  submittedAt: '2021-07-21T12:00:00.000Z',
+  approvedBy: null,
+  approvedAt: null,
+  panelApprovedBy: null,
+  panelApprovedAt: null,
+  workers: [mockedWorker],
+  editHistory: [
+    {
+      worker: mockedWorker,
+      editTime: '2021-06-21T12:00:00.000Z',
+    },
+  ],
+  submissionState: SubmissionState.InProgress,
+  formAnswers: {},
+  lastEdited: '2021-06-21T12:00:00.000Z',
+  completedSteps: 0,
+  isImported: false,
+  deleted: false,
+  params: { id: '1234' },
+};
+
+describe('Case note page', () => {
+  it('catches an unhandled promise', () => {
+    (useRouter().replace as jest.Mock).mockRejectedValue(new Error());
+    // const router = useRouter();
+    // router.query = { submissionId: '' };
+
+    const { getByText } = render(<CaseNote {...mockedNewSubmission} />);
+
+    expect(useRouter().replace).toHaveBeenCalled();
+  });
+});

--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -3,15 +3,21 @@ import { render } from '@testing-library/react';
 import { residentFactory } from 'factories/residents';
 import { mockedWorker } from 'factories/workers';
 import { SubmissionState } from 'data/flexibleForms/forms.types';
-import { NextRouter, useRouter } from 'next/router';
-import { act } from 'react-dom/test-utils';
+import { useRouter } from 'next/router';
+// import { act } from 'react-dom/test-utils';
 
 jest.mock('next/router');
 const useRouterMock = useRouter as jest.MockedFunction<typeof useRouter>;
 // const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-let eventName;
-let routeChangeHandler;
+const consoleSpy = jest.spyOn(console, 'error').mockImplementation((error) => {
+  console.log(error.message);
+});
+const consoleLogSpy = jest.spyOn(global.console, 'log');
+// .mockImplementation(() => jest.fn());
+
+// let eventName;
+// let routeChangeHandler;
 
 // useRouterMock.mockImplementation(() => {
 //   return {
@@ -54,7 +60,7 @@ let routeChangeHandler;
 //   },
 // });
 
-const mockRouter: NextRouter = {
+const mockRouter = {
   basePath: '/',
   pathname: '/',
   route: '/',
@@ -110,18 +116,32 @@ const mockedNewSubmission = {
 };
 
 describe('Case note page', () => {
+  // beforeEach(() => {
+  //   consoleSpy.mockClear();
+  //   consoleLogSpy.mockClear();
+  // });
+  afterEach(() => {
+    consoleSpy.mockReset();
+  });
   it('catches an unhandled promise', () => {
     // (useRouter().replace as jest.Mock).mockRejectedValue(new Error());
     // const router = useRouter();
     // router.query = { submissionId: '' };
     useRouterMock.mockReturnValue(mockRouter);
-    // (useRouterMock().replace as jest.Mock).mockRejectedValue(new Error());
+    const newError = new Error();
+    newError.message = 'HI1';
+    (useRouterMock().replace as jest.Mock).mockRejectedValue(newError);
 
-    act(() => {
-      render(<CaseNote {...mockedNewSubmission} />);
-    });
+    render(<CaseNote {...mockedNewSubmission} />);
 
     expect(useRouterMock).toHaveBeenCalled();
     expect(useRouterMock().replace).toHaveBeenCalled();
+    // expect(() => {
+    //   consoleSpy;
+    // }).toThrowError();
+
+    expect(consoleSpy).toHaveBeenCalledWith(newError);
+    // expect(consoleSpy).toHaveErrorMessage();
+    expect(consoleLogSpy).toHaveBeenCalled();
   });
 });

--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -3,10 +3,10 @@ import { render } from '@testing-library/react';
 import { residentFactory } from 'factories/residents';
 import { mockedWorker } from 'factories/workers';
 import { SubmissionState } from 'data/flexibleForms/forms.types';
-import { useRouter } from 'next/router';
+import { NextRouter, useRouter } from 'next/router';
 
 // jest.mock('next/router');
-// const useRouterMock = useRouter as jest.MockedFunction<typeof useRouter>;
+const useRouterMock = useRouter as jest.MockedFunction<typeof useRouter>;
 // const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 let eventName;
@@ -28,29 +28,53 @@ let routeChangeHandler;
 //   };
 // });
 
-jest.mock('next/router', () => ({
-  useRouter() {
-    return {
-      basePath: '/',
-      pathname: '/',
-      route: '/',
-      query: {},
-      asPath: '/',
-      push: jest.fn(() => Promise.resolve(true)),
-      replace: jest.fn(() => Promise.resolve(true)),
-      reload: jest.fn(() => Promise.resolve(true)),
-      prefetch: jest.fn(() => Promise.resolve()),
-      back: jest.fn(() => Promise.resolve(true)),
-      beforePopState: jest.fn(() => Promise.resolve(true)),
-      isFallback: false,
-      events: {
-        on: jest.fn(),
-        off: jest.fn(),
-        emit: jest.fn(),
-      },
-    };
+jest.mock('next/router');
+// const useRouterMock = () => ({
+//   useRouter() {
+//     return {
+//       basePath: '/',
+//       pathname: '/',
+//       route: '/',
+//       query: {},
+//       asPath: '/',
+//       push: jest.fn(() => Promise.resolve(true)),
+//       replace: jest.fn(() => Promise.resolve(true)),
+//       reload: jest.fn(() => Promise.resolve(true)),
+//       prefetch: jest.fn(() => Promise.resolve()),
+//       back: jest.fn(() => Promise.resolve(true)),
+//       beforePopState: jest.fn(() => Promise.resolve(true)),
+//       isFallback: false,
+//       events: {
+//         on: jest.fn(),
+//         off: jest.fn(),
+//         emit: jest.fn(),
+//       },
+//     };
+//   },
+// });
+
+const mockRouter: NextRouter = {
+  basePath: '/',
+  pathname: '/',
+  route: '/',
+  query: {},
+  asPath: '/',
+  push: jest.fn(() => Promise.resolve(true)),
+  replace: jest.fn(() => Promise.resolve(true)),
+  reload: jest.fn(() => Promise.resolve(true)),
+  prefetch: jest.fn(() => Promise.resolve()),
+  back: jest.fn(() => Promise.resolve(true)),
+  beforePopState: jest.fn(() => Promise.resolve(true)),
+  isFallback: false,
+  events: {
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
   },
-}));
+  isReady: true,
+  isPreview: false,
+  isLocaleDomain: true,
+};
 
 // const spyOnReplace = jest.spyOn(useRouter, 'replace');
 
@@ -89,9 +113,10 @@ describe('Case note page', () => {
     // (useRouter().replace as jest.Mock).mockRejectedValue(new Error());
     // const router = useRouter();
     // router.query = { submissionId: '' };
+    useRouterMock.mockReturnValue(mockRouter);
 
     const { getByText } = render(<CaseNote {...mockedNewSubmission} />);
 
-    expect(useRouter.useRouter).toHaveBeenCalled();
+    expect(useRouterMock).toHaveBeenCalled();
   });
 });

--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -4,8 +4,9 @@ import { residentFactory } from 'factories/residents';
 import { mockedWorker } from 'factories/workers';
 import { SubmissionState } from 'data/flexibleForms/forms.types';
 import { NextRouter, useRouter } from 'next/router';
+import { act } from 'react-dom/test-utils';
 
-// jest.mock('next/router');
+jest.mock('next/router');
 const useRouterMock = useRouter as jest.MockedFunction<typeof useRouter>;
 // const mockedAxios = axios as jest.Mocked<typeof axios>;
 
@@ -28,7 +29,7 @@ let routeChangeHandler;
 //   };
 // });
 
-jest.mock('next/router');
+// jest.mock('next/router');
 // const useRouterMock = () => ({
 //   useRouter() {
 //     return {
@@ -60,7 +61,7 @@ const mockRouter: NextRouter = {
   query: {},
   asPath: '/',
   push: jest.fn(() => Promise.resolve(true)),
-  replace: jest.fn(() => Promise.resolve(true)),
+  replace: jest.fn(() => Promise.resolve(false)),
   reload: jest.fn(() => Promise.resolve(true)),
   prefetch: jest.fn(() => Promise.resolve()),
   back: jest.fn(() => Promise.resolve(true)),
@@ -114,9 +115,13 @@ describe('Case note page', () => {
     // const router = useRouter();
     // router.query = { submissionId: '' };
     useRouterMock.mockReturnValue(mockRouter);
+    // (useRouterMock().replace as jest.Mock).mockRejectedValue(new Error());
 
-    const { getByText } = render(<CaseNote {...mockedNewSubmission} />);
+    act(() => {
+      render(<CaseNote {...mockedNewSubmission} />);
+    });
 
     expect(useRouterMock).toHaveBeenCalled();
+    expect(useRouterMock().replace).toHaveBeenCalled();
   });
 });

--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -1,5 +1,5 @@
 import CaseNote from '../../../pages/people/[id]/case-note';
-import { render } from '@testing-library/react';
+import { screen, render, fireEvent, waitFor } from '@testing-library/react';
 import { residentFactory } from 'factories/residents';
 import { mockedWorker } from 'factories/workers';
 import { SubmissionState } from 'data/flexibleForms/forms.types';
@@ -123,7 +123,7 @@ describe('Case note page', () => {
   afterEach(() => {
     consoleSpy.mockReset();
   });
-  it('catches an unhandled promise', () => {
+  it('catches an unhandled promise', async () => {
     // (useRouter().replace as jest.Mock).mockRejectedValue(new Error());
     // const router = useRouter();
     // router.query = { submissionId: '' };
@@ -132,16 +132,31 @@ describe('Case note page', () => {
     newError.message = 'HI1';
     (useRouterMock().replace as jest.Mock).mockRejectedValue(newError);
 
-    render(<CaseNote {...mockedNewSubmission} />);
+    let warningBanner;
+    // act(() => {
+    const { getByText } = render(<CaseNote {...mockedNewSubmission} />);
+
+    await waitFor(() => {
+      fireEvent.click(getByText('Save and finish'));
+    });
+    // warningBanner = getByRole('alert');
+    // });
+    // expect(await screen.getByRole('alert')).toBeVisible;
+    const warningMessage = getByText(
+      'There was a problem finishing the submission'
+    );
+
+    expect(warningMessage).not.toBeNull();
 
     expect(useRouterMock).toHaveBeenCalled();
     expect(useRouterMock().replace).toHaveBeenCalled();
+    expect(warningBanner).not.toBeNull();
     // expect(() => {
     //   consoleSpy;
     // }).toThrowError();
 
-    expect(consoleSpy).toHaveBeenCalledWith(newError);
+    expect(consoleSpy).toHaveBeenCalled();
     // expect(consoleSpy).toHaveErrorMessage();
-    expect(consoleLogSpy).toHaveBeenCalled();
+    // expect(consoleLogSpy).toHaveBeenCalled();
   });
 });

--- a/components/Cases/CaseRecap/case-note.spec.tsx
+++ b/components/Cases/CaseRecap/case-note.spec.tsx
@@ -75,25 +75,31 @@ describe('Case note page', () => {
   });
   it('catches an unhandled promise', async () => {
     const newError = new Error();
-    (useRouterMock().replace as jest.Mock).mockRejectedValue(newError);
+    const routerReplace = (
+      useRouterMock().replace as jest.Mock
+    ).mockRejectedValue(newError);
 
     render(<CaseNote {...mockedNewSubmission} />);
-    await expect(useRouterMock().replace).rejects.toThrow(newError);
+    await expect(routerReplace).rejects.toEqual(newError);
 
     expect(useRouterMock).toHaveBeenCalled();
-    expect(useRouterMock().replace).toHaveBeenCalled();
+    expect(routerReplace).toHaveBeenCalled();
     expect(consoleErrorMock).toHaveBeenCalled();
+    routerReplace.mockReset();
   });
 
   it('displays an alert banner when router.replace fails', async () => {
     const newError = new Error();
     newError.message = 'HI1';
-    (useRouterMock().replace as jest.Mock).mockRejectedValue(newError);
+    const routerReplace = (
+      useRouterMock().replace as jest.Mock
+    ).mockRejectedValue(newError);
 
     const { getByText } = render(<CaseNote {...mockedNewSubmission} />);
-    await expect(useRouterMock().replace).rejects.toThrow(newError);
+    await expect(routerReplace).rejects.toEqual(newError);
 
     const warningMessage = getByText('There was a problem');
     expect(warningMessage).not.toBeNull();
+    routerReplace.mockReset();
   });
 });

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -43,7 +43,7 @@ const CaseNote = ({
 
   const router = useRouter();
   const [finished, setFinished] = useState<boolean>(false);
-  // const [state, setState] = useState<string>();
+  const [state, setState] = useState<boolean>();
 
   // put the submission id on the url if it doesn't already exist
   useEffect(() => {
@@ -57,7 +57,7 @@ const CaseNote = ({
           console.log('HEREEEEE');
           console.error(error);
 
-          // setState(error.message);
+          setState(true);
         });
     }
   }, [router, submissionId, params.id]);
@@ -84,6 +84,7 @@ const CaseNote = ({
 
   return (
     <>
+      {console.log('state', state)}
       <Head>
         <title>Add a case note | Social care | Hackney Council</title>
       </Head>
@@ -107,10 +108,11 @@ const CaseNote = ({
             >
               {({ touched, errors, values, isSubmitting, status, isValid }) => (
                 <Form>
-                  {status && (
+                  {(status || state) && (
                     <Banner
                       title="There was a problem finishing the submission"
                       className="lbh-page-announcement--warning"
+                      data-testid={'warning-banner'}
                     >
                       <p>Please refresh the page or try again later.</p>
                       <p className="lbh-body-xs">{status}</p>

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -43,7 +43,7 @@ const CaseNote = ({
 
   const router = useRouter();
   const [finished, setFinished] = useState<boolean>(false);
-  const [state, setState] = useState<boolean>();
+  const [error, setError] = useState<string>();
 
   // put the submission id on the url if it doesn't already exist
   useEffect(() => {
@@ -57,7 +57,7 @@ const CaseNote = ({
           console.log('HEREEEEE');
           console.error(error);
 
-          setState(true);
+          setError(error.message);
         });
     }
   }, [router, submissionId, params.id]);
@@ -84,7 +84,7 @@ const CaseNote = ({
 
   return (
     <>
-      {console.log('state', state)}
+      {console.log('error', error)}
       <Head>
         <title>Add a case note | Social care | Hackney Council</title>
       </Head>
@@ -108,7 +108,7 @@ const CaseNote = ({
             >
               {({ touched, errors, values, isSubmitting, status, isValid }) => (
                 <Form>
-                  {(status || state) && (
+                  {status && (
                     <Banner
                       title="There was a problem finishing the submission"
                       className="lbh-page-announcement--warning"
@@ -116,6 +116,16 @@ const CaseNote = ({
                     >
                       <p>Please refresh the page or try again later.</p>
                       <p className="lbh-body-xs">{status}</p>
+                    </Banner>
+                  )}
+                  {error != undefined && !status && (
+                    <Banner
+                      title="There was a problem"
+                      className="lbh-page-announcement--warning"
+                      data-testid={'warning-banner'}
+                    >
+                      <p>Please refresh the page or try again later.</p>
+                      <p className="lbh-body-xs">{error}</p>
                     </Banner>
                   )}
 

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -43,14 +43,20 @@ const CaseNote = ({
 
   const router = useRouter();
   const [finished, setFinished] = useState<boolean>(false);
+  const [state, setState] = useState<string>();
 
   // put the submission id on the url if it doesn't already exist
   useEffect(() => {
     if (!router.query.submissionId)
-      router.replace({
-        pathname: router.asPath,
-        query: { submissionId },
-      });
+      router
+        .replace({
+          pathname: router.asPath,
+          query: { submissionId },
+        })
+        .catch((error) => {
+          console.error(error);
+          setState(error.message);
+        });
   }, [router, submissionId, params.id]);
 
   const handleSubmit = async (

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -47,7 +47,8 @@ const CaseNote = ({
 
   // put the submission id on the url if it doesn't already exist
   useEffect(() => {
-    if (!router.query.submissionId)
+    if (!router.query.submissionId) {
+      console.log('HEREEEEE');
       router
         .replace({
           pathname: router.asPath,
@@ -57,6 +58,7 @@ const CaseNote = ({
           console.error(error);
           setState(error.message);
         });
+    }
   }, [router, submissionId, params.id]);
 
   const handleSubmit = async (

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -54,7 +54,6 @@ const CaseNote = ({
           query: { submissionId },
         })
         .catch((error) => {
-          console.log('HEREEEEE');
           console.error(error);
 
           setError(error.message);
@@ -84,7 +83,6 @@ const CaseNote = ({
 
   return (
     <>
-      {console.log('error', error)}
       <Head>
         <title>Add a case note | Social care | Hackney Council</title>
       </Head>

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -43,20 +43,21 @@ const CaseNote = ({
 
   const router = useRouter();
   const [finished, setFinished] = useState<boolean>(false);
-  const [state, setState] = useState<string>();
+  // const [state, setState] = useState<string>();
 
   // put the submission id on the url if it doesn't already exist
   useEffect(() => {
     if (!router.query.submissionId) {
-      console.log('HEREEEEE');
       router
         .replace({
           pathname: router.asPath,
           query: { submissionId },
         })
         .catch((error) => {
+          console.log('HEREEEEE');
           console.error(error);
-          setState(error.message);
+
+          // setState(error.message);
         });
     }
   }, [router, submissionId, params.id]);


### PR DESCRIPTION
**What**  
This event was noted as in issue in Sentry


Event [8650ca2af60e4d44a754f25390321201](https://sentry.io/organizations/london-borough-of-hackney/issues/2963254096/events/8650ca2af60e4d44a754f25390321201/)
Feb 1, 2022 12:18:02 PM UTC

Affects: 24 users
Number of events: 36

Location: lbh-social-care-frontend/pages/people/[id]/case-note.tsx
Regression tests: components/Cases/CaseRecap/case-note.spec.tsx

**Why**  
Tried to implement code to catch the error being thrown

Checked in with Jaye regards the correct behaviour around throwing an error when this type of error occurs.
they said this is the desired behaviour and perhaps to ignore these type of issues in Sentry.
Jaye's code is here:

[lbh-social-care-frontend/useWarnUnsavedChanges.ts](https://github.com/LBHackney-IT/lbh-social-care-frontend/blob/main/hooks/useWarnUnsavedChanges.ts#L20) 
 
[lbh-social-care-frontend/useWarnUnsavedChanges.test.tsx](https://github.com/LBHackney-IT/lbh-social-care-frontend/blob/main/hooks/useWarnUnsavedChanges.test.tsx#L18) 

We decided that the errors being thrown and recorded in Sentry were in fact what we want to see and would expect.
Perhaps we ignore these types of errors in Sentry going forward.

**Anything else?**
The .catch() added in the useEffect() hook in **pages/people/[id]/case-note.tsx** has proven tricky to set up the mocks to test properly.
It's been suggested that this ticket be moved to Tech Debt as it is not affecting users in a serious way.
