### PR TITLE
feat: custom phone address editors

### DIFF
--- a/components/ResidentPage/CaseNoteDialog.module.scss
+++ b/components/ResidentPage/CaseNoteDialog.module.scss
@@ -9,7 +9,6 @@
     all: unset;
     text-decoration: underline;
     cursor: pointer;
-    color: lbh-colour('lbh-secondary-text');
     @include lbh-link;
     @include govuk-link-style-muted;
     color: lbh-colour('lbh-secondary-text');

--- a/components/ResidentPage/CustomAddressEditor.module.scss
+++ b/components/ResidentPage/CustomAddressEditor.module.scss
@@ -1,0 +1,90 @@
+@import 'lbh-frontend/lbh/base';
+
+.form {
+  * + * {
+    margin-top: 1rem;
+  }
+
+  label {
+    display: block;
+    @include lbh-body-s;
+  }
+
+  p {
+    @include lbh-body-s;
+  }
+
+  label + input,
+  p + input {
+    margin-top: 0.25rem;
+  }
+}
+
+p.hint {
+  @include lbh-body-xs;
+  color: lbh-colour('lbh-secondary-text');
+  margin-top: 0;
+}
+
+.secondaryActions {
+  button:disabled {
+    color: lbh-colour('lbh-grey-2');
+    cursor: not-allowed;
+    // pointer-events: none;
+  }
+
+  button {
+    margin-right: 0.5rem;
+
+    @include lbh-rem(font-size, 13);
+    @include lbh-rem(line-height, 19);
+    @include govuk-media-query($from: tablet) {
+      @include lbh-rem(font-size, 16);
+      @include lbh-rem(line-height, 24);
+    }
+
+    // &:nth-of-type(2) {
+    //   @include lbh-link;
+    //   @include govuk-link-style-muted;
+    //   color: lbh-colour('lbh-secondary-text');
+    // }
+  }
+}
+
+.primaryActions {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin-bottom: 0.5rem;
+
+  button {
+    margin-top: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 5px 0px;
+    width: 25px;
+    margin-left: 5px;
+
+    &:focus {
+      outline: none;
+      svg path {
+        fill: lbh-colour('lbh-primary-focus');
+      }
+    }
+
+    svg {
+      margin-top: 0;
+    }
+
+    &:first-of-type:hover svg path {
+      fill: lbh-colour('lbh-secondary-text');
+    }
+    &:last-of-type:hover svg path {
+      fill: lbh-colour('lbh-primary-hover');
+    }
+  }
+}

--- a/components/ResidentPage/CustomAddressEditor.spec.tsx
+++ b/components/ResidentPage/CustomAddressEditor.spec.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { mockedResident } from 'factories/residents';
+import CustomAddressEditor from './CustomAddressEditor';
+import axios from 'axios';
+import userEvent from '@testing-library/user-event';
+
+const mockClose = jest.fn();
+
+jest.mock('axios');
+
+(global.fetch as jest.Mock) = jest.fn(() => ({
+  status: 200,
+}));
+
+describe('CustomAddressEditor', () => {
+  it('can be closed correctly', () => {
+    render(
+      <CustomAddressEditor
+        name="address"
+        label="Address"
+        onClose={mockClose}
+        resident={mockedResident}
+      />
+    );
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(mockClose).toBeCalled();
+  });
+
+  it('responds to the ESC key', () => {
+    render(
+      <CustomAddressEditor
+        name="address"
+        label="Address"
+        onClose={mockClose}
+        resident={mockedResident}
+      />
+    );
+
+    fireEvent.keyUp(screen.getByRole('group'), { key: 'Escape' });
+    expect(mockClose).toBeCalled();
+  });
+
+  it('shows the existing address, when it exists ', () => {
+    render(
+      <CustomAddressEditor
+        name="address"
+        label="Address"
+        onClose={mockClose}
+        resident={mockedResident}
+      />
+    );
+    expect(screen.queryByText('Enter manually')).toBeNull();
+  });
+
+  it("doesn't show the fields for manual address entry if they're blank", () => {
+    render(
+      <CustomAddressEditor
+        name="address"
+        label="Address"
+        onClose={mockClose}
+        resident={{
+          ...mockedResident,
+          address: undefined,
+        }}
+      />
+    );
+    expect(screen.getByText('Enter manually'));
+  });
+
+  it('can search for a postcode', async () => {
+    render(
+      <CustomAddressEditor
+        name="address"
+        label="Address"
+        onClose={mockClose}
+        resident={{
+          ...mockedResident,
+          address: undefined,
+        }}
+      />
+    );
+
+    userEvent.type(screen.getByLabelText('Building number or name'), '1');
+    userEvent.type(screen.getByLabelText('Postcode'), 'Town St');
+    await waitFor(() => fireEvent.click(screen.getByText('Find address')));
+    expect(axios.get).toBeCalledWith('/api/postcode/Town St?buildingNumber=1');
+    expect(screen.getAllByLabelText('Postcode').length).toBe(2);
+  });
+
+  it('allows manual entry of an address', () => {
+    render(
+      <CustomAddressEditor
+        name="address"
+        label="Address"
+        onClose={mockClose}
+        resident={{
+          ...mockedResident,
+          address: undefined,
+        }}
+      />
+    );
+    fireEvent.click(screen.getByText('Enter manually'));
+    expect(screen.getAllByLabelText('Postcode').length).toBe(2);
+    expect(screen.queryByText('Enter manually')).toBeNull();
+  });
+
+  it('submits an address correctly', async () => {
+    render(
+      <CustomAddressEditor
+        name="address"
+        label="Address"
+        onClose={mockClose}
+        resident={mockedResident}
+      />
+    );
+    await waitFor(() => fireEvent.click(screen.getByText('Save')));
+    expect(global.fetch).toBeCalledWith('/api/residents/1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...mockedResident,
+        address: {
+          ...mockedResident.address,
+          uprn: null,
+        },
+      }),
+    });
+  });
+});

--- a/components/ResidentPage/CustomAddressEditor.tsx
+++ b/components/ResidentPage/CustomAddressEditor.tsx
@@ -8,7 +8,6 @@ import { DataRow } from './DataBlock';
 import s from './CustomAddressEditor.module.scss';
 
 interface Props extends DataRow {
-  value: string | number;
   onClose: () => void;
   resident: Resident;
 }
@@ -24,12 +23,7 @@ interface FormValues {
 const CustomAddressEditor = ({
   onClose,
   resident,
-}: // name,
-// type,
-// beforeEdit,
-// beforeSave,
-// required,
-Props): React.ReactElement => {
+}: Props): React.ReactElement => {
   const addressExists = !!(
     resident.address?.address || resident.address?.postcode
   );
@@ -43,7 +37,6 @@ Props): React.ReactElement => {
   useWarnUnsavedChanges(true);
 
   const onSubmit = async (data: FormValues) => {
-    console.log(data);
     const res = await fetch(`/api/residents/${resident.id}`, {
       headers: {
         'Content-Type': 'application/json',
@@ -66,6 +59,7 @@ Props): React.ReactElement => {
 
   const handleKeyup: KeyboardEventHandler = (e) => {
     if (e.key === 'Escape') onClose();
+    if (e.key === 'Enter') handleSubmit(onSubmit);
   };
 
   useEffect(() => {
@@ -73,14 +67,6 @@ Props): React.ReactElement => {
       if (ref.current && e.target && !ref.current.contains(e.target as Node))
         onClose();
     };
-
-    // if (ref.current) {
-    //   // move focus to input or select as soon as it appears
-    //   ref.current.querySelector('input')?.focus();
-    //   ref.current.querySelector('select')?.focus();
-    //   // handle outside clicks
-    //   document.addEventListener('click', handleClickOutside, true);
-    // }
 
     return () =>
       document.removeEventListener('click', handleClickOutside, true);
@@ -133,6 +119,8 @@ Props): React.ReactElement => {
         className="govuk-input lbh-input govuk-input--width-10"
       />
 
+      {JSON.stringify()}
+
       <div className={s.secondaryActions}>
         <button
           type="button"
@@ -153,40 +141,42 @@ Props): React.ReactElement => {
         )}
       </div>
 
-      <fieldset className={open ? '' : 'govuk-visually-hidden'}>
-        <label htmlFor="address">Address</label>
-        <input
-          name="address"
-          id="address"
-          placeholder="Address"
-          defaultValue={resident.address?.address}
-          ref={register}
-          className="govuk-input lbh-input"
-        />
+      {open && (
+        <fieldset>
+          <label htmlFor="address">Address</label>
+          <input
+            name="address"
+            id="address"
+            placeholder="Address"
+            defaultValue={resident.address?.address}
+            ref={register()}
+            className="govuk-input lbh-input"
+          />
 
-        <label htmlFor="postcode">Postcode</label>
-        <input
-          name="postcode"
-          id="postcode"
-          ref={register}
-          placeholder="Postcode"
-          defaultValue={resident.address?.postcode}
-          className="govuk-input lbh-input govuk-input--width-10"
-        />
+          <label htmlFor="postcode">Postcode</label>
+          <input
+            name="postcode"
+            id="postcode"
+            ref={register()}
+            placeholder="Postcode"
+            defaultValue={resident.address?.postcode}
+            className="govuk-input lbh-input govuk-input--width-10"
+          />
 
-        <label htmlFor="uprn">Unique property reference number</label>
-        <p className={s.hint} id="uprn-hint">
-          Also called UPRN
-        </p>
-        <input
-          name="uprn"
-          id="uprn"
-          aria-describedby="uprn-hint"
-          defaultValue={resident.address?.uprn}
-          ref={register}
-          className="govuk-input lbh-input govuk-input--width-10"
-        />
-      </fieldset>
+          <label htmlFor="uprn">Unique property reference number</label>
+          <p className={s.hint} id="uprn-hint">
+            Also called UPRN
+          </p>
+          <input
+            name="uprn"
+            id="uprn"
+            aria-describedby="uprn-hint"
+            defaultValue={resident.address?.uprn}
+            ref={register()}
+            className="govuk-input lbh-input govuk-input--width-10"
+          />
+        </fieldset>
+      )}
 
       <div className={s.primaryActions}>
         <button type="button" onClick={onClose} title="Cancel">

--- a/components/ResidentPage/CustomAddressEditor.tsx
+++ b/components/ResidentPage/CustomAddressEditor.tsx
@@ -119,8 +119,6 @@ const CustomAddressEditor = ({
         className="govuk-input lbh-input govuk-input--width-10"
       />
 
-      {JSON.stringify()}
-
       <div className={s.secondaryActions}>
         <button
           type="button"

--- a/components/ResidentPage/CustomAddressEditor.tsx
+++ b/components/ResidentPage/CustomAddressEditor.tsx
@@ -1,0 +1,222 @@
+import axios from 'axios';
+import useWarnUnsavedChanges from 'hooks/useWarnUnsavedChanges';
+import { KeyboardEventHandler, useEffect, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Resident } from 'types';
+import { useResident } from 'utils/api/residents';
+import { DataRow } from './DataBlock';
+import s from './CustomAddressEditor.module.scss';
+
+interface Props extends DataRow {
+  value: string | number;
+  onClose: () => void;
+  resident: Resident;
+}
+
+interface FormValues {
+  numberSearch: string;
+  postcodeSearch: string;
+  address: string;
+  postcode: string;
+  uprn: string;
+}
+
+const CustomAddressEditor = ({
+  onClose,
+  resident,
+}: // name,
+// type,
+// beforeEdit,
+// beforeSave,
+// required,
+Props): React.ReactElement => {
+  const addressExists = !!(
+    resident.address?.address || resident.address?.postcode
+  );
+
+  const ref = useRef<HTMLFormElement>(null);
+  const [open, setOpen] = useState<boolean>(addressExists);
+  const { register, handleSubmit, getValues, setValue, watch } = useForm();
+
+  const { mutate } = useResident(resident.id);
+
+  useWarnUnsavedChanges(true);
+
+  const onSubmit = async (data: FormValues) => {
+    console.log(data);
+    const res = await fetch(`/api/residents/${resident.id}`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'PATCH',
+      body: JSON.stringify({
+        ...resident,
+        address: {
+          address: data.address,
+          postcode: data.postcode,
+          uprn: parseInt(data.uprn),
+        },
+      } as Resident),
+    });
+    mutate(); // give it a kick
+    if (res.status === 200) {
+      onClose();
+    }
+  };
+
+  const handleKeyup: KeyboardEventHandler = (e) => {
+    if (e.key === 'Escape') onClose();
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && e.target && !ref.current.contains(e.target as Node))
+        onClose();
+    };
+
+    // if (ref.current) {
+    //   // move focus to input or select as soon as it appears
+    //   ref.current.querySelector('input')?.focus();
+    //   ref.current.querySelector('select')?.focus();
+    //   // handle outside clicks
+    //   document.addEventListener('click', handleClickOutside, true);
+    // }
+
+    return () =>
+      document.removeEventListener('click', handleClickOutside, true);
+  }, [onClose]);
+
+  const handleSearch = async () => {
+    try {
+      const { numberSearch, postcodeSearch } = getValues([
+        'numberSearch',
+        'postcodeSearch',
+      ]);
+
+      const { data } = await axios.get(
+        `/api/postcode/${postcodeSearch}?buildingNumber=${numberSearch}`
+      );
+      const result = data?.address?.[0];
+      setValue('address', result['line1']);
+      setValue('postcode', result['postcode']);
+      setValue('uprn', result['UPRN']);
+      setOpen(true);
+    } catch (e) {
+      setOpen(true);
+    }
+  };
+
+  const canSearch = watch('postcodeSearch') && watch('numberSearch');
+
+  return (
+    <form
+      className={s.form}
+      onSubmit={handleSubmit(onSubmit)}
+      onKeyUp={handleKeyup}
+      ref={ref}
+    >
+      <label htmlFor="numberSearch">Building number or name</label>
+      <input
+        name="numberSearch"
+        id="numberSearch"
+        max="30"
+        ref={register}
+        className="govuk-input lbh-input govuk-input--width-5"
+      />
+
+      <label htmlFor="postcodeSearch">Postcode</label>
+      <input
+        name="postcodeSearch"
+        id="postcodeSearch"
+        max="10"
+        ref={register}
+        className="govuk-input lbh-input govuk-input--width-10"
+      />
+
+      <div className={s.secondaryActions}>
+        <button
+          type="button"
+          onClick={handleSearch}
+          className="lbh-link"
+          disabled={!canSearch}
+        >
+          Find address
+        </button>
+        {!open && (
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="lbh-link"
+          >
+            Enter manually
+          </button>
+        )}
+      </div>
+
+      <fieldset className={open ? '' : 'govuk-visually-hidden'}>
+        <label htmlFor="address">Address</label>
+        <input
+          name="address"
+          id="address"
+          placeholder="Address"
+          defaultValue={resident.address?.address}
+          ref={register}
+          className="govuk-input lbh-input"
+        />
+
+        <label htmlFor="postcode">Postcode</label>
+        <input
+          name="postcode"
+          id="postcode"
+          ref={register}
+          placeholder="Postcode"
+          defaultValue={resident.address?.postcode}
+          className="govuk-input lbh-input govuk-input--width-10"
+        />
+
+        <label htmlFor="uprn">Unique property reference number</label>
+        <p className={s.hint} id="uprn-hint">
+          Also called UPRN
+        </p>
+        <input
+          name="uprn"
+          id="uprn"
+          aria-describedby="uprn-hint"
+          defaultValue={resident.address?.uprn}
+          ref={register}
+          className="govuk-input lbh-input govuk-input--width-10"
+        />
+      </fieldset>
+
+      <div className={s.primaryActions}>
+        <button type="button" onClick={onClose} title="Cancel">
+          <span className="govuk-visually-hidden">Cancel</span>
+          <svg width="18" height="18" viewBox="0 0 18 18">
+            <path
+              d="M-0.0695801 1.88831L1.88856 -0.0698242L17.5538 15.5953L15.5955 17.5534L-0.0695801 1.88831Z"
+              fill="#6F777B"
+            />
+            <path
+              d="M15.5955 -0.0696411L17.5538 1.8885L1.88856 17.5536L-0.0695801 15.5955L15.5955 -0.0696411Z"
+              fill="#6F777B"
+            />
+          </svg>
+        </button>
+
+        <button title="Save">
+          <span className="govuk-visually-hidden">Save</span>
+          <svg width="24" height="19" viewBox="0 0 24 19">
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M23.5608 3.06065L8.50011 18.1213L0.939453 10.5607L3.06077 8.43933L8.50011 13.8787L21.4395 0.939331L23.5608 3.06065Z"
+              fill="#00664F"
+            />
+          </svg>
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default CustomAddressEditor;

--- a/components/ResidentPage/CustomPhoneNumberEditor.module.scss
+++ b/components/ResidentPage/CustomPhoneNumberEditor.module.scss
@@ -1,0 +1,116 @@
+@import 'lbh-frontend/lbh/base';
+
+.form {
+  * + * {
+    margin-top: 1rem;
+  }
+
+  label {
+    display: block;
+    @include lbh-body-s;
+  }
+
+  p {
+    @include lbh-body-s;
+  }
+
+  label + input,
+  p + input {
+    margin-top: 0.25rem;
+  }
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 2fr 3fr 1fr;
+  gap: 10px;
+  align-items: flex-end;
+
+  div {
+    margin-top: 0;
+  }
+
+  button {
+    padding: 10px 0px;
+    @include lbh-rem(font-size, 13);
+    @include lbh-rem(line-height, 19);
+    @include govuk-media-query($from: tablet) {
+      @include lbh-rem(font-size, 16);
+      @include lbh-rem(line-height, 24);
+    }
+  }
+
+  margin-top: 0rem;
+
+  &:not(:first-of-type) {
+    margin-top: 0.5rem;
+
+    label {
+      position: absolute;
+      font-size: 0;
+      opacity: 0;
+    }
+  }
+}
+
+p.hint {
+  @include lbh-body-xs;
+  color: lbh-colour('lbh-secondary-text');
+  margin-top: 0;
+}
+
+.secondaryActions {
+  button:disabled {
+    color: lbh-colour('lbh-grey-2');
+    cursor: not-allowed;
+  }
+
+  button {
+    margin-right: 0.5rem;
+
+    @include lbh-rem(font-size, 13);
+    @include lbh-rem(line-height, 19);
+    @include govuk-media-query($from: tablet) {
+      @include lbh-rem(font-size, 16);
+      @include lbh-rem(line-height, 24);
+    }
+  }
+}
+
+.primaryActions {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin-bottom: 0.5rem;
+
+  button {
+    margin-top: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 5px 0px;
+    width: 25px;
+    margin-left: 5px;
+
+    &:focus {
+      outline: none;
+      svg path {
+        fill: lbh-colour('lbh-primary-focus');
+      }
+    }
+
+    svg {
+      margin-top: 0;
+    }
+
+    &:first-of-type:hover svg path {
+      fill: lbh-colour('lbh-secondary-text');
+    }
+    &:last-of-type:hover svg path {
+      fill: lbh-colour('lbh-primary-hover');
+    }
+  }
+}

--- a/components/ResidentPage/CustomPhoneNumberEditor.spec.tsx
+++ b/components/ResidentPage/CustomPhoneNumberEditor.spec.tsx
@@ -128,15 +128,7 @@ describe('CustomPhoneNumberEditor', () => {
     expect(global.fetch).toBeCalledWith('/api/residents/1', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        ...mockedResident,
-        phoneNumbers: [
-          {
-            type: '',
-            number: '',
-          },
-        ],
-      }),
+      body: JSON.stringify(mockedResident),
     });
   });
 });

--- a/components/ResidentPage/CustomPhoneNumberEditor.spec.tsx
+++ b/components/ResidentPage/CustomPhoneNumberEditor.spec.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { mockedResident } from 'factories/residents';
+import CustomPhoneNumberEditor from './CustomPhoneNumberEditor';
+
+const mockClose = jest.fn();
+
+jest.mock('axios');
+
+(global.fetch as jest.Mock) = jest.fn(() => ({
+  status: 200,
+}));
+
+describe('CustomPhoneNumberEditor', () => {
+  it('can be closed correctly', () => {
+    render(
+      <CustomPhoneNumberEditor
+        onClose={mockClose}
+        resident={mockedResident}
+        label="Phone numbers"
+        name="phoneNumbers"
+      />
+    );
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(mockClose).toBeCalled();
+  });
+
+  it('responds to the ESC key', () => {
+    render(
+      <CustomPhoneNumberEditor
+        onClose={mockClose}
+        resident={mockedResident}
+        label="Phone numbers"
+        name="phoneNumbers"
+      />
+    );
+
+    fireEvent.keyUp(screen.getByRole('group'), { key: 'Escape' });
+    expect(mockClose).toBeCalled();
+  });
+
+  it('shows an existing phone number if set', () => {
+    render(
+      <CustomPhoneNumberEditor
+        onClose={mockClose}
+        resident={{
+          ...mockedResident,
+          phoneNumbers: [
+            {
+              type: 'Foo',
+              number: '07777',
+            },
+          ],
+        }}
+        label="Phone numbers"
+        name="phoneNumbers"
+      />
+    );
+
+    expect(screen.getByDisplayValue('Foo'));
+    expect(screen.getByDisplayValue('07777'));
+  });
+
+  it('shows empty initial fields if not', () => {
+    render(
+      <CustomPhoneNumberEditor
+        onClose={mockClose}
+        resident={mockedResident}
+        label="Phone numbers"
+        name="phoneNumbers"
+      />
+    );
+    expect(screen.getAllByRole('textbox').length).toBe(1);
+    expect(screen.getAllByRole('combobox').length).toBe(1);
+    expect(screen.getAllByText('Remove').length).toBe(1);
+    expect(screen.getByText('+ Add another'));
+  });
+
+  it('allows the first number to be removed', () => {
+    render(
+      <CustomPhoneNumberEditor
+        onClose={mockClose}
+        resident={mockedResident}
+        label="Phone numbers"
+        name="phoneNumbers"
+      />
+    );
+    fireEvent.click(screen.getByText('Remove'));
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.queryByRole('combobox')).toBeNull();
+    expect(screen.queryByText('Remove')).toBeNull();
+    expect(screen.getByText('+ Add first phone number'));
+  });
+
+  it('allows multiple numbers to be added', async () => {
+    render(
+      <CustomPhoneNumberEditor
+        onClose={mockClose}
+        resident={mockedResident}
+        label="Phone numbers"
+        name="phoneNumbers"
+      />
+    );
+    fireEvent.change(screen.getByLabelText('Label'), {
+      target: { value: 'Foo' },
+    });
+    fireEvent.change(screen.getByLabelText('Number'), {
+      target: { value: 'Bar' },
+    });
+    fireEvent.click(screen.getByText('+ Add another'));
+    fireEvent.change(screen.getAllByLabelText('Label')[1], {
+      target: { value: 'One' },
+    });
+    fireEvent.change(screen.getAllByLabelText('Number')[1], {
+      target: { value: 'Two' },
+    });
+  });
+
+  it('saves correctly', async () => {
+    render(
+      <CustomPhoneNumberEditor
+        onClose={mockClose}
+        resident={mockedResident}
+        label="Phone numbers"
+        name="phoneNumbers"
+      />
+    );
+    await waitFor(() => fireEvent.click(screen.getByText('Save')));
+    expect(global.fetch).toBeCalledWith('/api/residents/1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...mockedResident,
+        phoneNumbers: [
+          {
+            type: '',
+            number: '',
+          },
+        ],
+      }),
+    });
+  });
+});

--- a/components/ResidentPage/CustomPhoneNumberEditor.tsx
+++ b/components/ResidentPage/CustomPhoneNumberEditor.tsx
@@ -1,11 +1,12 @@
 import useWarnUnsavedChanges from 'hooks/useWarnUnsavedChanges';
-import { useRef } from 'react';
+import { KeyboardEventHandler, useEffect, useRef } from 'react';
+import { useFieldArray, useForm } from 'react-hook-form';
 import { PhoneNumber, Resident } from 'types';
 import { useResident } from 'utils/api/residents';
 import { DataRow } from './DataBlock';
+import s from './CustomPhoneNumberEditor.module.scss';
 
 interface Props extends DataRow {
-  value: string | number;
   onClose: () => void;
   resident: Resident;
 }
@@ -14,16 +15,142 @@ interface FormValues {
   phoneNumbers: PhoneNumber[];
 }
 
-const CustomPhoneNumberEditor = ({ resident }: Props): React.ReactElement => {
+const CustomPhoneNumberEditor = ({
+  onClose,
+  resident,
+}: Props): React.ReactElement => {
   const ref = useRef<HTMLFormElement>(null);
-  const { register, handleSubmit, getValues, setValue, watch } = useForm();
+  const { register, handleSubmit, control } = useForm({
+    defaultValues: {
+      phoneNumbers:
+        resident?.phoneNumbers?.length > 0
+          ? resident.phoneNumbers
+          : [
+              {
+                type: '',
+                number: '',
+              },
+            ],
+    },
+  });
+  const { append, remove, fields } = useFieldArray<PhoneNumber>({
+    name: 'phoneNumbers',
+    control,
+  });
 
   const { mutate } = useResident(resident.id);
 
   useWarnUnsavedChanges(true);
 
+  const onSubmit = async (data: FormValues) => {
+    const res = await fetch(`/api/residents/${resident.id}`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'PATCH',
+      body: JSON.stringify({
+        ...resident,
+        phoneNumbers: data?.phoneNumbers
+          ?.filter((n) => n.type || n.number)
+          ?.map((n) => ({
+            ...n,
+            number: n.number.replace(/\s/g, ''), // sanitise by removing spaces
+          })),
+      } as Resident),
+    });
+    mutate(); // give it a kick
+    if (res.status === 200) {
+      onClose();
+    }
+  };
+
+  const handleKeyup: KeyboardEventHandler = (e) => {
+    if (e.key === 'Escape') onClose();
+    if (e.key === 'Enter') handleSubmit(onSubmit);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && e.target && !ref.current.contains(e.target as Node))
+        onClose();
+    };
+
+    return () =>
+      document.removeEventListener('click', handleClickOutside, true);
+  }, [onClose]);
+
   return (
-    <form>
+    <form
+      className={s.form}
+      onSubmit={handleSubmit(onSubmit)}
+      onKeyUp={handleKeyup}
+      ref={ref}
+    >
+      <fieldset>
+        <legend className="govuk-visually-hidden">Phone numbers</legend>
+
+        <datalist id="type-hints">
+          <option value="Mobile">Mobile</option>
+          <option value="Home">Home</option>
+          <option value="Work/office">Work/office</option>
+        </datalist>
+
+        {fields.map((field, i) => (
+          <div key={field.id} className={s.row}>
+            <div>
+              <label htmlFor={`phoneNumbers[${i}].type`}>Label</label>
+              <input
+                name={`phoneNumbers[${i}].type`}
+                id={`phoneNumbers[${i}].type`}
+                max="10"
+                ref={register()}
+                className="govuk-input lbh-input"
+                list="type-hints"
+                placeholder={i === 0 ? 'eg. Mobile' : ''}
+                defaultValue={field.type}
+              />
+            </div>
+
+            <div>
+              <label htmlFor={`phoneNumbers[${i}].number`}>Number</label>
+              <input
+                name={`phoneNumbers[${i}].number`}
+                id={`phoneNumbers[${i}].number`}
+                max="15"
+                ref={register()}
+                className="govuk-input lbh-input"
+                placeholder={i === 0 ? 'eg. 0777 777 7777' : ''}
+                defaultValue={field.number}
+              />
+            </div>
+
+            <button
+              onClick={() => remove(i)}
+              title="Remove this number"
+              className="lbh-link"
+              type="button"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </fieldset>
+
+      <div className={s.secondaryActions}>
+        <button
+          type="button"
+          onClick={() =>
+            append({
+              type: '',
+              number: '',
+            })
+          }
+          className="lbh-link"
+        >
+          + Add {fields.length === 0 ? 'first phone number' : 'another'}
+        </button>
+      </div>
+
       <div className={s.primaryActions}>
         <button type="button" onClick={onClose} title="Cancel">
           <span className="govuk-visually-hidden">Cancel</span>

--- a/components/ResidentPage/CustomPhoneNumberEditor.tsx
+++ b/components/ResidentPage/CustomPhoneNumberEditor.tsx
@@ -1,0 +1,58 @@
+import useWarnUnsavedChanges from 'hooks/useWarnUnsavedChanges';
+import { useRef } from 'react';
+import { PhoneNumber, Resident } from 'types';
+import { useResident } from 'utils/api/residents';
+import { DataRow } from './DataBlock';
+
+interface Props extends DataRow {
+  value: string | number;
+  onClose: () => void;
+  resident: Resident;
+}
+
+interface FormValues {
+  phoneNumbers: PhoneNumber[];
+}
+
+const CustomPhoneNumberEditor = ({ resident }: Props): React.ReactElement => {
+  const ref = useRef<HTMLFormElement>(null);
+  const { register, handleSubmit, getValues, setValue, watch } = useForm();
+
+  const { mutate } = useResident(resident.id);
+
+  useWarnUnsavedChanges(true);
+
+  return (
+    <form>
+      <div className={s.primaryActions}>
+        <button type="button" onClick={onClose} title="Cancel">
+          <span className="govuk-visually-hidden">Cancel</span>
+          <svg width="18" height="18" viewBox="0 0 18 18">
+            <path
+              d="M-0.0695801 1.88831L1.88856 -0.0698242L17.5538 15.5953L15.5955 17.5534L-0.0695801 1.88831Z"
+              fill="#6F777B"
+            />
+            <path
+              d="M15.5955 -0.0696411L17.5538 1.8885L1.88856 17.5536L-0.0695801 15.5955L15.5955 -0.0696411Z"
+              fill="#6F777B"
+            />
+          </svg>
+        </button>
+
+        <button title="Save">
+          <span className="govuk-visually-hidden">Save</span>
+          <svg width="24" height="19" viewBox="0 0 24 19">
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M23.5608 3.06065L8.50011 18.1213L0.939453 10.5607L3.06077 8.43933L8.50011 13.8787L21.4395 0.939331L23.5608 3.06065Z"
+              fill="#00664F"
+            />
+          </svg>
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default CustomPhoneNumberEditor;

--- a/components/ResidentPage/DataBlock.tsx
+++ b/components/ResidentPage/DataBlock.tsx
@@ -10,7 +10,10 @@ import {
 import Collapsible from './Collapsible';
 import s from './DataBlock.module.scss';
 import ss from './SummaryList.module.scss';
-import DefaultInlineEditor, { InlineEditorOption } from './InlineEditor';
+import DefaultInlineEditor, {
+  InlineEditorOption,
+  InlineEditorProps,
+} from './InlineEditor';
 import { useResident } from 'utils/api/residents';
 
 /** what are the different kinds of data we might have to deal with? */
@@ -37,7 +40,7 @@ export interface DataRow {
   type?: HTMLInputTypeAttribute;
   required?: boolean;
   /** provide a custom component to render when the display or edit state is activated **/
-  render?: React.ReactNode;
+  render?: (props: InlineEditorProps) => React.ReactElement;
   /** HOOKS */
   /** pretty up a saved value before showing it to the user */
   beforeDisplay?: (value: SupportedData) => React.ReactElement | string;
@@ -77,12 +80,14 @@ const DataCell = ({ row, editing, setEditing, resident, i }: DataCellProps) => {
       return <PrettyValue value={value as string | React.ReactElement} />;
 
     return editing === i ? (
-      row.render({
-        value: value as string,
-        onClose: () => setEditing(null),
-        resident: resident,
-        ...row,
-      }) || (
+      row.render ? (
+        row.render({
+          value: value as string,
+          onClose: () => setEditing(null),
+          resident: resident,
+          ...row,
+        })
+      ) : (
         <DefaultInlineEditor
           value={value as string}
           onClose={() => setEditing(null)}

--- a/components/ResidentPage/DataBlock.tsx
+++ b/components/ResidentPage/DataBlock.tsx
@@ -37,7 +37,7 @@ export interface DataRow {
   type?: HTMLInputTypeAttribute;
   required?: boolean;
   /** provide a custom component to render when the display or edit state is activated **/
-  customEditor?: React.ReactElement;
+  render?: React.ReactNode;
   /** HOOKS */
   /** pretty up a saved value before showing it to the user */
   beforeDisplay?: (value: SupportedData) => React.ReactElement | string;
@@ -77,7 +77,12 @@ const DataCell = ({ row, editing, setEditing, resident, i }: DataCellProps) => {
       return <PrettyValue value={value as string | React.ReactElement} />;
 
     return editing === i ? (
-      row.customEditor || (
+      row.render({
+        value: value as string,
+        onClose: () => setEditing(null),
+        resident: resident,
+        ...row,
+      }) || (
         <DefaultInlineEditor
           value={value as string}
           onClose={() => setEditing(null)}

--- a/components/ResidentPage/InlineEditor.tsx
+++ b/components/ResidentPage/InlineEditor.tsx
@@ -11,7 +11,7 @@ export interface InlineEditorOption {
   value: string | number;
 }
 
-interface Props extends DataRow {
+export interface InlineEditorProps extends DataRow {
   value: string | number;
   onClose: () => void;
   resident: Resident;
@@ -30,7 +30,7 @@ const InlineEditor = ({
   beforeEdit,
   beforeSave,
   required,
-}: Props): React.ReactElement => {
+}: InlineEditorProps): React.ReactElement => {
   const ref = useRef<HTMLFormElement>(null);
   const { register, handleSubmit } = useForm();
 

--- a/pages/residents/[id]/index.tsx
+++ b/pages/residents/[id]/index.tsx
@@ -15,6 +15,7 @@ import languages from 'data/languages';
 import WorkflowTree from 'components/ResidentPage/WorkflowTree';
 import useWorkflows from 'hooks/useWorkflows';
 import CustomAddressEditor from 'components/ResidentPage/CustomAddressEditor';
+import CustomPhoneNumberEditor from 'components/ResidentPage/CustomPhoneNumberEditor';
 
 interface Props {
   resident: Resident;
@@ -175,10 +176,11 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
           {
             label: 'Phone numbers',
             name: 'phoneNumbers',
+            showInSummary: true,
             beforeDisplay: (val) => (
-              <ul className="lbh-list lbh-body-s">
+              <ul className="lbh-list lbh-body-s govuk-!-margin-bottom-2">
                 {(val as PhoneNumber[]).map((number, i) => (
-                  <li key={i}>
+                  <li key={i} className="govuk-!-margin-top-0">
                     <strong>{number.type}:</strong>{' '}
                     <a
                       className="lbh-link lbh-link--no-visited-state"
@@ -190,6 +192,7 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
                 ))}
               </ul>
             ),
+            render: CustomPhoneNumberEditor,
           },
 
           {

--- a/pages/residents/[id]/index.tsx
+++ b/pages/residents/[id]/index.tsx
@@ -14,6 +14,7 @@ import SEXUAL_ORIENTATIONS from 'data/orientation';
 import languages from 'data/languages';
 import WorkflowTree from 'components/ResidentPage/WorkflowTree';
 import useWorkflows from 'hooks/useWorkflows';
+import CustomAddressEditor from 'components/ResidentPage/CustomAddressEditor';
 
 interface Props {
   resident: Resident;
@@ -306,6 +307,7 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
                 </a>
               </div>
             ),
+            render: CustomAddressEditor,
           },
           // {
           //   label: 'Addresses',

--- a/types.ts
+++ b/types.ts
@@ -5,7 +5,7 @@ export type ErrorAPI = AxiosError;
 export interface Address {
   address: string;
   postcode: string;
-  uprn?: string;
+  uprn?: number;
 }
 
 export interface AddressWrapper {

--- a/types.ts
+++ b/types.ts
@@ -5,7 +5,7 @@ export type ErrorAPI = AxiosError;
 export interface Address {
   address: string;
   postcode: string;
-  uprn?: number;
+  uprn?: number | string;
 }
 
 export interface AddressWrapper {


### PR DESCRIPTION
the default in-place editor can cover text fields and select fields, but some more complicated fields need something special.

so, this adds two new components:

- `<CustomPhoneNumberEditor/>` with "add another" functionality
- `<CustomAddressEditor/>` with postcode search functionality

<img width="547" alt="Screenshot 2022-02-09 at 09 55 50" src="https://user-images.githubusercontent.com/14189497/153209252-f0fb174f-bb22-45cd-82ac-9dc5fbd4c549.png">
<img width="883" alt="Screenshot 2022-02-09 at 09 55 40" src="https://user-images.githubusercontent.com/14189497/153209256-3446217a-7338-4492-ac88-a8eea27d5e24.png">
