### PR TITLE
feat: use proper, declarative yup-based validation on the person view

### DIFF
--- a/components/NewPersonView/Layout.tsx
+++ b/components/NewPersonView/Layout.tsx
@@ -21,6 +21,7 @@ import {
 import CaseStatusFlag from 'components/CaseStatus/CaseStatusFlag/CaseStatusFlag';
 import { useAppConfig } from 'lib/appConfig';
 import ConfirmationBanner from 'components/ConfirmationBanner/ConfirmationBanner';
+import PreviewBanner from './PreviewBanner';
 
 interface NavLinkProps {
   href: string;
@@ -149,6 +150,8 @@ const Layout = ({ person, children }: Props): React.ReactElement => {
       ) : (
         <></>
       )}
+
+      <PreviewBanner socialCareId={person.id} />
 
       <WarningNotes id={person.id} />
 

--- a/components/NewPersonView/Layout.tsx
+++ b/components/NewPersonView/Layout.tsx
@@ -21,7 +21,6 @@ import {
 import CaseStatusFlag from 'components/CaseStatus/CaseStatusFlag/CaseStatusFlag';
 import { useAppConfig } from 'lib/appConfig';
 import ConfirmationBanner from 'components/ConfirmationBanner/ConfirmationBanner';
-import PreviewBanner from './PreviewBanner';
 
 interface NavLinkProps {
   href: string;
@@ -150,8 +149,6 @@ const Layout = ({ person, children }: Props): React.ReactElement => {
       ) : (
         <></>
       )}
-
-      <PreviewBanner socialCareId={person.id} />
 
       <WarningNotes id={person.id} />
 

--- a/components/NewPersonView/PreviewBanner.tsx
+++ b/components/NewPersonView/PreviewBanner.tsx
@@ -1,0 +1,35 @@
+import { useFeatureFlags } from 'lib/feature-flags/feature-flags';
+import Link from 'next/link';
+import React from 'react';
+
+const PreviewBanner = ({
+  socialCareId,
+}: {
+  socialCareId: number;
+}): React.ReactElement | null => {
+  const { isFeatureActive } = useFeatureFlags();
+
+  if (isFeatureActive('preview-new-resident-view'))
+    return (
+      <section
+        role="alert"
+        className="lbh-page-announcement lbh-page-announcement--orange"
+      >
+        <h4 className="lbh-page-announcement__title">
+          Try the faster, brand new resident view
+        </h4>
+        <div className="lbh-page-announcement__content">
+          <p className="lbh-body-s">
+            You can record much more information about a resident, see a
+            chronology of their workflows and browse case notes faster.
+          </p>
+          <p className="lbh-body-s govuk-!-margin-top-2">
+            <Link href={`/residents/${socialCareId}`}>Try it now</Link>
+          </p>
+        </div>
+      </section>
+    );
+  return null;
+};
+
+export default PreviewBanner;

--- a/components/ResidentPage/CustomAddressEditor.module.scss
+++ b/components/ResidentPage/CustomAddressEditor.module.scss
@@ -88,3 +88,11 @@ p.hint {
     }
   }
 }
+
+.error {
+  @include lbh-body-xs;
+  display: block;
+  color: lbh-colour('lbh-error');
+  margin-top: 0rem;
+  font-weight: 600;
+}

--- a/components/ResidentPage/CustomAddressEditor.spec.tsx
+++ b/components/ResidentPage/CustomAddressEditor.spec.tsx
@@ -113,7 +113,12 @@ describe('CustomAddressEditor', () => {
         resident={mockedResident}
       />
     );
+    fireEvent.change(screen.getAllByLabelText('Postcode')[1], {
+      target: { value: 'A1 1AA' },
+    });
     await waitFor(() => fireEvent.click(screen.getByText('Save')));
+
+    screen.debug();
     expect(global.fetch).toBeCalledWith('/api/residents/1', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -121,6 +126,7 @@ describe('CustomAddressEditor', () => {
         ...mockedResident,
         address: {
           ...mockedResident.address,
+          postcode: 'A1 1AA',
           uprn: null,
         },
       }),

--- a/components/ResidentPage/CustomPhoneNumberEditor.module.scss
+++ b/components/ResidentPage/CustomPhoneNumberEditor.module.scss
@@ -114,3 +114,14 @@ p.hint {
     }
   }
 }
+
+.error {
+  @include lbh-body-xs;
+  display: block;
+  color: lbh-colour('lbh-error');
+  margin-top: 0rem;
+  font-weight: 600;
+  & + input {
+    margin-top: 0.5rem;
+  }
+}

--- a/components/ResidentPage/CustomPhoneNumberEditor.spec.tsx
+++ b/components/ResidentPage/CustomPhoneNumberEditor.spec.tsx
@@ -124,11 +124,26 @@ describe('CustomPhoneNumberEditor', () => {
         name="phoneNumbers"
       />
     );
+    fireEvent.change(screen.getByLabelText('Label'), {
+      target: { value: 'One' },
+    });
+    fireEvent.change(screen.getByLabelText('Number'), {
+      target: { value: '0777' },
+    });
     await waitFor(() => fireEvent.click(screen.getByText('Save')));
+
     expect(global.fetch).toBeCalledWith('/api/residents/1', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(mockedResident),
+      body: JSON.stringify({
+        ...mockedResident,
+        phoneNumbers: [
+          {
+            type: 'One',
+            number: '0777',
+          },
+        ],
+      }),
     });
   });
 });

--- a/components/ResidentPage/DataBlock.spec.tsx
+++ b/components/ResidentPage/DataBlock.spec.tsx
@@ -70,25 +70,6 @@ describe('DataBlock', () => {
     fireEvent.click(screen.getByText('Close'));
   });
 
-  it('marks required data', () => {
-    render(
-      <DataBlock
-        title="example"
-        socialCareId={1}
-        list={[
-          {
-            label: 'First name',
-            name: 'firstName',
-            showInSummary: true,
-            required: true,
-          },
-        ]}
-      />
-    );
-
-    expect(screen.getByLabelText('required'));
-  });
-
   it('offers the option to edit in-place', () => {
     render(
       <DataBlock

--- a/components/ResidentPage/DataBlock.tsx
+++ b/components/ResidentPage/DataBlock.tsx
@@ -24,7 +24,8 @@ type SupportedData =
   | OtherName[]
   | PhoneNumber[]
   | Address
-  | LegacyAddress[];
+  | LegacyAddress[]
+  | null;
 
 /** an active, inline-editable row of data */
 export interface DataRow {
@@ -38,7 +39,8 @@ export interface DataRow {
   options?: InlineEditorOption[];
   /** override the input type eg. number, date, email */
   type?: HTMLInputTypeAttribute;
-  required?: boolean;
+  /** VISUALLY MARK a field as required (doesn't actually make it required) */
+  markAsRequired?: boolean;
   /** provide a custom component to render when the display or edit state is activated **/
   render?: (props: InlineEditorProps) => React.ReactElement;
   /** HOOKS */
@@ -121,7 +123,7 @@ const DataList = ({ list, resident }: DataListProps) => {
         <div key={row.name} className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">
             {row.label}
-            {row.required && (
+            {row.markAsRequired && (
               <span className={s.required} aria-label="required">
                 *
               </span>

--- a/components/ResidentPage/InlineEditor.module.scss
+++ b/components/ResidentPage/InlineEditor.module.scss
@@ -80,3 +80,16 @@
     }
   }
 }
+
+.error {
+  @include lbh-body-xs;
+  position: absolute;
+  bottom: -34px;
+  right: 0px;
+  color: lbh-colour('lbh-error');
+  font-weight: 600;
+  background: lighten(lbh-colour('lbh-error'), 45);
+  z-index: 2;
+  border: 1px solid transparentize(lbh-colour('lbh-error'), 0.9);
+  padding: 0px 4px;
+}

--- a/components/ResidentPage/InlineEditor.tsx
+++ b/components/ResidentPage/InlineEditor.tsx
@@ -1,6 +1,7 @@
+import { Field, Form, Formik } from 'formik';
 import useWarnUnsavedChanges from 'hooks/useWarnUnsavedChanges';
+import { residentSchema } from 'lib/validators';
 import { useEffect, useRef, KeyboardEvent } from 'react';
-import { useForm } from 'react-hook-form';
 import { Resident } from 'types';
 import { useResident } from 'utils/api/residents';
 import { DataRow } from './DataBlock';
@@ -29,16 +30,16 @@ const InlineEditor = ({
   type,
   beforeEdit,
   beforeSave,
-  required,
 }: InlineEditorProps): React.ReactElement => {
   const ref = useRef<HTMLFormElement>(null);
-  const { register, handleSubmit } = useForm();
+
+  const schema = residentSchema.pick([name]);
 
   const { mutate } = useResident(resident.id);
 
   useWarnUnsavedChanges(true);
 
-  const onSubmit = async (data: FormValues) => {
+  const handleSubmit = async (data: FormValues) => {
     const res = await fetch(`/api/residents/${resident.id}`, {
       headers: {
         'Content-Type': 'application/json',
@@ -82,68 +83,74 @@ const InlineEditor = ({
     : resident[name as keyof Resident];
 
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className={s.form}
-      onKeyUp={handleKeyup}
-      ref={ref}
+    <Formik
+      initialValues={
+        {
+          [name]: defaultValue,
+        } as FormValues
+      }
+      onSubmit={handleSubmit}
+      validationSchema={schema}
     >
-      <label className="govuk-visually-hidden" htmlFor={name}>
-        Editing {name}
-      </label>
+      {({ errors }) => (
+        <Form className={s.form} onKeyUp={handleKeyup} ref={ref}>
+          <label className="govuk-visually-hidden" htmlFor={name}>
+            Editing {name}
+          </label>
 
-      {options ? (
-        <select
-          id={name}
-          name={name}
-          defaultValue={defaultValue as string | number}
-          ref={register}
-        >
-          {options.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      ) : (
-        <input
-          id={name}
-          name={name}
-          defaultValue={defaultValue as string | number}
-          ref={register}
-          type={type}
-          required={required}
-        />
+          {options ? (
+            <Field as="select" id={name} name={name}>
+              {options.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </Field>
+          ) : (
+            <Field
+              id={name}
+              name={name}
+              defaultValue={defaultValue as string | number}
+              type={type}
+            />
+          )}
+
+          {errors[name] && (
+            <p className={s.error} role="alert">
+              {errors[name]?.toString()}
+            </p>
+          )}
+
+          <div>
+            <button type="button" onClick={onClose} title="Cancel">
+              <span className="govuk-visually-hidden">Cancel</span>
+              <svg width="18" height="18" viewBox="0 0 18 18">
+                <path
+                  d="M-0.0695801 1.88831L1.88856 -0.0698242L17.5538 15.5953L15.5955 17.5534L-0.0695801 1.88831Z"
+                  fill="#6F777B"
+                />
+                <path
+                  d="M15.5955 -0.0696411L17.5538 1.8885L1.88856 17.5536L-0.0695801 15.5955L15.5955 -0.0696411Z"
+                  fill="#6F777B"
+                />
+              </svg>
+            </button>
+
+            <button title="Save">
+              <span className="govuk-visually-hidden">Save</span>
+              <svg width="24" height="19" viewBox="0 0 24 19">
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M23.5608 3.06065L8.50011 18.1213L0.939453 10.5607L3.06077 8.43933L8.50011 13.8787L21.4395 0.939331L23.5608 3.06065Z"
+                  fill="#00664F"
+                />
+              </svg>
+            </button>
+          </div>
+        </Form>
       )}
-
-      <div>
-        <button type="button" onClick={onClose} title="Cancel">
-          <span className="govuk-visually-hidden">Cancel</span>
-          <svg width="18" height="18" viewBox="0 0 18 18">
-            <path
-              d="M-0.0695801 1.88831L1.88856 -0.0698242L17.5538 15.5953L15.5955 17.5534L-0.0695801 1.88831Z"
-              fill="#6F777B"
-            />
-            <path
-              d="M15.5955 -0.0696411L17.5538 1.8885L1.88856 17.5536L-0.0695801 15.5955L15.5955 -0.0696411Z"
-              fill="#6F777B"
-            />
-          </svg>
-        </button>
-
-        <button title="Save">
-          <span className="govuk-visually-hidden">Save</span>
-          <svg width="24" height="19" viewBox="0 0 24 19">
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M23.5608 3.06065L8.50011 18.1213L0.939453 10.5607L3.06077 8.43933L8.50011 13.8787L21.4395 0.939331L23.5608 3.06065Z"
-              fill="#00664F"
-            />
-          </svg>
-        </button>
-      </div>
-    </form>
+    </Formik>
   );
 };
 

--- a/components/ResidentPage/InlineEditor.tsx
+++ b/components/ResidentPage/InlineEditor.tsx
@@ -107,12 +107,7 @@ const InlineEditor = ({
               ))}
             </Field>
           ) : (
-            <Field
-              id={name}
-              name={name}
-              defaultValue={defaultValue as string | number}
-              type={type}
-            />
+            <Field id={name} name={name} type={type} />
           )}
 
           {errors[name] && (

--- a/components/ResidentPage/Mapping.spec.tsx
+++ b/components/ResidentPage/Mapping.spec.tsx
@@ -1,10 +1,17 @@
 import { mockedResident } from 'factories/residents';
 import { fireEvent, render, screen } from '@testing-library/react';
 import Mapping from './Mapping';
+import { useResident } from 'utils/api/residents';
+
+jest.mock('utils/api/residents');
+
+(useResident as jest.Mock).mockReturnValue({
+  data: mockedResident,
+});
 
 describe('Mapping', () => {
   it('can tab between street view and map', () => {
-    render(<Mapping resident={mockedResident} />);
+    render(<Mapping socialCareId={1} />);
 
     fireEvent.click(screen.getByText('Street view'));
     expect(
@@ -21,7 +28,7 @@ describe('Mapping', () => {
   });
 
   it('shows a street view and map', () => {
-    render(<Mapping resident={mockedResident} />);
+    render(<Mapping socialCareId={1} />);
     expect((screen.getAllByRole('img')[0] as HTMLImageElement).src).toContain(
       'https://maps.googleapis.com/maps/api/staticmap?size=360x360&return_error_code=true&markers=sjakdjlk,%20hdsadjk&zoom=15'
     );

--- a/components/ResidentPage/Mapping.tsx
+++ b/components/ResidentPage/Mapping.tsx
@@ -1,12 +1,12 @@
 import { prettyAddress } from 'lib/formatters';
 import { useState } from 'react';
-import { Resident } from 'types';
+import { useResident } from 'utils/api/residents';
 import s from './Mapping.module.scss';
 
 type TabState = 'map' | 'street-view';
 
 interface Props {
-  resident: Resident;
+  socialCareId: number;
 }
 
 interface TabProps {
@@ -45,15 +45,18 @@ const TabPanel = ({ active, value, children }: TabPanelProps) => (
   </section>
 );
 
-const Mapping = ({ resident }: Props): React.ReactElement => {
+const Mapping = ({ socialCareId }: Props): React.ReactElement | null => {
   const [active, setActive] = useState<TabState>('map');
+  const { data } = useResident(socialCareId);
+
+  if (!data) return null;
 
   const mapUrl = `https://maps.googleapis.com/maps/api/staticmap?size=360x360&return_error_code=true&markers=${prettyAddress(
-    resident
+    data
   )}&zoom=15&key=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_KEY}`;
 
   const streetViewUrl = `https://maps.googleapis.com/maps/api/streetview?size=360x360&return_error_code=true&location=${prettyAddress(
-    resident
+    data
   )}&key=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_KEY}`;
 
   return (
@@ -69,13 +72,13 @@ const Mapping = ({ resident }: Props): React.ReactElement => {
       </ul>
 
       <TabPanel active={active} value="map">
-        <a href={`https://www.google.com/maps?q=${prettyAddress(resident)}`}>
+        <a href={`https://www.google.com/maps?q=${prettyAddress(data)}`}>
           <img src={mapUrl} alt="Map view" />
         </a>
       </TabPanel>
 
       <TabPanel active={active} value="street-view">
-        <a href={`https://www.google.com/maps?q=${prettyAddress(resident)}`}>
+        <a href={`https://www.google.com/maps?q=${prettyAddress(data)}`}>
           <img src={streetViewUrl} alt="Street view" />
         </a>
       </TabPanel>

--- a/components/ResidentPage/WorkflowOverview.tsx
+++ b/components/ResidentPage/WorkflowOverview.tsx
@@ -22,26 +22,28 @@ const WorkflowOverview = ({
 
   return (
     <>
-      {mostRecent && (
-        <>
-          <h3 className="lbh-heading-h5">Most recent</h3>
-          <WorkflowChunk workflow={mostRecent} />
-        </>
-      )}
+      <div className="govuk-grid-row">
+        {inProgress && (
+          <div className="govuk-grid-column-one-half">
+            <h3 className="lbh-heading-h5">In progress</h3>
+            {inProgress.slice(0, 3)?.map((w) => (
+              <WorkflowChunk workflow={w} key={w.id} />
+            ))}
+            {inProgress.length > 3 && (
+              <p className="lbh-body-xs govuk-!-margin-top-2">
+                and {inProgress.length - 3} more
+              </p>
+            )}
+          </div>
+        )}
 
-      {inProgress && (
-        <>
-          <h3 className="lbh-heading-h5">In progress</h3>
-          {inProgress.slice(0, 3)?.map((w) => (
-            <WorkflowChunk workflow={w} key={w.id} />
-          ))}
-          {inProgress.length > 3 && (
-            <p className="lbh-body-xs govuk-!-margin-top-2">
-              and {inProgress.length - 3} more
-            </p>
-          )}
-        </>
-      )}
+        {mostRecent && (
+          <div className="govuk-grid-column-one-half">
+            <h3 className="lbh-heading-h5">Most recent</h3>
+            <WorkflowChunk workflow={mostRecent} />
+          </div>
+        )}
+      </div>
 
       {/* <h3 className="lbh-heading-h5">Review soon</h3> */}
 

--- a/cypress/integration/delete_case_note.ts
+++ b/cypress/integration/delete_case_note.ts
@@ -35,8 +35,10 @@ describe('Deleting case notes', () => {
         `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}`,
         AuthRoles.AdminDevGroup
       );
+
+      cy.get('.lbh-timeline').scrollIntoView();
       cy.contains(/Show deleted records/).click();
-      cy.contains(/Hide deleted records/).should('be.visible');
+      cy.contains(/Hide deleted records/);
       cy.contains(/(deleted record)/).should('be.visible');
       cy.contains(/deleted 2 Dec 2021 1.51 pm/).should('be.visible');
       cy.contains(/requested by requester/).should('be.visible');

--- a/features.ts
+++ b/features.ts
@@ -35,6 +35,11 @@ export const getFeatureFlags = ({
       isActive:
         environmentName === 'development' || user?.hasAdminPermissions || false,
     },
+    // FEATURE-FLAG-EXPIRES [2022-02-25]: case-status
+    'preview-new-resident-view': {
+      isActive:
+        environmentName === 'development' || user?.hasAdminPermissions || false,
+    },
     /*
       The feature-flags-implementation-proof has been setup to have an expiry date in the far future.
       The FEATURE-FLAG-EXPIRES comment above will cause ESLint errors once the date in the square brackets has passed.

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -2,6 +2,8 @@ import * as Yup from 'yup';
 import { Answer, Field } from 'data/flexibleForms/forms.types';
 import { ObjectShape, OptionalObjectSchema, TypeOfShape } from 'yup/lib/object';
 import { getTotalHours } from './utils';
+import languages from 'data/languages';
+import religions from 'data/religions';
 
 export const startSchema = Yup.object().shape({
   socialCareId: Yup.number()
@@ -199,3 +201,46 @@ export const generateFlexibleSchema = (
 
   return Yup.object().shape(shape);
 };
+
+export const residentSchema = Yup.object().shape({
+  /** basics */
+  id: Yup.number().required(),
+  title: Yup.string(),
+  firstName: Yup.string().required('You must give a first name'),
+  lastName: Yup.string().required('You must give a last name'),
+  otherNames: Yup.array().of(Yup.string()),
+  dateOfBirth: Yup.date()
+    .typeError('You must give a valid date')
+    .required('You must give a date of birth'),
+  dateOfDeath: Yup.date().typeError('You must give a valid date'),
+  /** medical */
+  nhsNumber: Yup.number().typeError('You must give only digits'),
+  /** extended biography */
+  ethnicity: Yup.string(),
+  religion: Yup.string().oneOf(religions),
+  sexualOrientation: Yup.string(),
+  gender: Yup.string().required(),
+  /** housing */
+  address: Yup.object({
+    address: Yup.string(),
+    postcode: Yup.string(),
+    uprn: Yup.string(),
+  }),
+  /** communication */
+  firstLanguage: Yup.string().oneOf(languages),
+  preferredMethodOfContact: Yup.string(),
+  phoneNumbers: Yup.array().of(
+    Yup.object().shape({
+      type: Yup.string().required(),
+      number: Yup.string().required(),
+    })
+  ),
+  emailAddress: Yup.string().email('You must give a valid email'),
+  /** metadata */
+  createdBy: Yup.string().email(),
+  restricted: Yup.string().oneOf(['Y', 'N']),
+  ageContext: Yup.string().oneOf(['A', 'C']),
+  /** @deprecated legacy */
+  contextFlag: Yup.string().oneOf(['A', 'C']),
+  addresses: Yup.array(),
+});

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -214,7 +214,10 @@ export const residentSchema = Yup.object().shape({
     .required('You must give a date of birth'),
   dateOfDeath: Yup.date().typeError('You must give a valid date'),
   /** medical */
-  nhsNumber: Yup.number().typeError('You must give only digits'),
+  nhsNumber: Yup.number()
+    .typeError('NHS numbers can only contain digits')
+    .positive('NHS numbers can only contain digits')
+    .integer('NHS numbers can only contain digits'),
   /** extended biography */
   ethnicity: Yup.string(),
   religion: Yup.string().oneOf(religions),
@@ -222,19 +225,35 @@ export const residentSchema = Yup.object().shape({
   gender: Yup.string().required(),
   /** housing */
   address: Yup.object({
-    address: Yup.string(),
-    postcode: Yup.string(),
-    uprn: Yup.string(),
+    address: Yup.string().required(
+      'You must give the first line of the address'
+    ),
+    postcode: Yup.string().matches(
+      /^[a-zA-Z]{1,2}([0-9]{1,2}|[0-9][a-zA-Z])\s*[0-9][a-zA-Z]{2}$/,
+      'You must give a valid postcode'
+    ),
+    uprn: Yup.number()
+      .typeError('UPRNs can only contain digits')
+      .integer('UPRNs can only contain digits')
+      .positive('UPRNs can only contain digits')
+      .max(999999999999, 'That UPRN is too long'),
   }),
   /** communication */
   firstLanguage: Yup.string().oneOf(languages),
   preferredMethodOfContact: Yup.string(),
-  phoneNumbers: Yup.array().of(
-    Yup.object().shape({
-      type: Yup.string().required(),
-      number: Yup.string().required(),
-    })
-  ),
+  phoneNumbers: Yup.array()
+    .of(
+      Yup.object().shape({
+        type: Yup.string().required('You must give a label'),
+        number: Yup.number()
+          .typeError('Phone numbers can only contain digits')
+          .required('You must give a number'),
+      })
+    )
+    .max(
+      4,
+      "You can't add any more phone numbers. Consider adding a relationship or case note instead."
+    ),
   emailAddress: Yup.string().email('You must give a valid email'),
   /** metadata */
   createdBy: Yup.string().email(),

--- a/pages/people/[id]/index.tsx
+++ b/pages/people/[id]/index.tsx
@@ -5,6 +5,7 @@ import { Resident } from 'types';
 import { canManageCases } from 'lib/permissions';
 import { isAuthorised } from 'utils/auth';
 import PersonHistory from 'components/NewPersonView/PersonHistory';
+import PreviewBanner from 'components/NewPersonView/PreviewBanner';
 
 interface Props {
   person: Resident;
@@ -13,7 +14,10 @@ interface Props {
 const PersonPage = ({ person }: Props): React.ReactElement => {
   return (
     <Layout person={person}>
-      <PersonHistory personId={person.id} />
+      <>
+        <PreviewBanner socialCareId={person.id} />
+        <PersonHistory personId={person.id} />
+      </>
     </Layout>
   );
 };

--- a/pages/residents/[id]/index.tsx
+++ b/pages/residents/[id]/index.tsx
@@ -69,9 +69,10 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
           {
             label: 'First name',
             name: 'firstName',
-            required: true,
+
+            markAsRequired: true,
           },
-          { label: 'Last name', name: 'lastName', required: true },
+          { label: 'Last name', name: 'lastName', markAsRequired: true },
           {
             label: 'Other names',
             name: 'otherNames',
@@ -82,7 +83,8 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
           {
             label: 'Date of birth',
             name: 'dateOfBirth',
-            required: true,
+            markAsRequired: true,
+
             beforeDisplay: (val) => formatDate(val as string) || '',
             beforeEdit: (val) => (val as string)?.split('T')[0],
             type: 'date',
@@ -92,6 +94,7 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
             name: 'dateOfDeath',
             beforeDisplay: (val) => formatDate(val as string) || '',
             beforeEdit: (val) => (val as string)?.split('T')[0],
+            beforeSave: (val) => val || null,
             type: 'date',
           },
           {
@@ -163,7 +166,6 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
             label: 'Email address',
             name: 'emailAddress',
             showInSummary: true,
-            type: 'email',
             beforeDisplay: (val) => (
               <a
                 className="lbh-link lbh-link--no-visited-state"
@@ -314,7 +316,7 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
           //   beforeDisplay: (val) => JSON.stringify(val),
           // },
         ]}
-        aside={<Mapping resident={resident} />}
+        aside={<Mapping socialCareId={resident.id} />}
       />
     </Layout>
   );

--- a/stylesheets/all.scss
+++ b/stylesheets/all.scss
@@ -229,3 +229,8 @@ input[type='time'] {
 .govuk-template {
   overflow-y: initial;
 }
+
+// fix tab spacing{
+.js-enabled .govuk-tabs__list-item--selected {
+  padding-bottom: 11px;
+}

--- a/stylesheets/all.scss
+++ b/stylesheets/all.scss
@@ -234,3 +234,25 @@ input[type='time'] {
 .js-enabled .govuk-tabs__list-item--selected {
   padding-bottom: 11px;
 }
+
+.lbh-page-announcement--orange {
+  border-color: lbh-colour('lbh-f04');
+  background: transparentize(lbh-colour('lbh-f04'), 0.9);
+
+  a {
+    font-weight: 600;
+
+    &:visited {
+      color: lbh-colour('lbh-link');
+    }
+
+    &:hover {
+      color: lbh-colour('lbh-link-hover');
+    }
+
+    &:active,
+    &:focus {
+      color: lbh-colour('lbh-text');
+    }
+  }
+}

--- a/types.ts
+++ b/types.ts
@@ -5,7 +5,7 @@ export type ErrorAPI = AxiosError;
 export interface Address {
   address: string;
   postcode: string;
-  uprn?: number | string;
+  uprn?: string;
 }
 
 export interface AddressWrapper {


### PR DESCRIPTION
improves the way we validate data for a resident by:

- storing it in one place: a central yup schema in `lib/validators.ts`
- refactoring `<InlineEditor/>` to use formik rather than react-hook-form, so we can make easy use of yup validation
- improving the custom address and phone number editors to display yup error messages too

this should make it much easier to maintain our validation conditions and error messages

<img width="527" alt="Screenshot 2022-02-10 at 16 30 39" src="https://user-images.githubusercontent.com/14189497/153452808-1fa3ae9e-fc51-4ace-be56-d8903d37e363.png">
<img width="531" alt="Screenshot 2022-02-10 at 16 30 29" src="https://user-images.githubusercontent.com/14189497/153452813-090f094f-4fc3-4c95-9dd2-6991537a9917.png">
o