### PR TITLE
fix: remove script to copy node modules as part of lambda layer setup

### DIFF
--- a/scripts/prepareNodeModules.sh
+++ b/scripts/prepareNodeModules.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Create layer directory for node modules"
-mkdir -p layer/nodejs/node_modules
-
-echo "Install production dependencies in layer directory"
-yarn install --production --modules-folder ./layer/nodejs/node_modules
-
-echo "Done creating nodejs/node_modules layer"


### PR DESCRIPTION
**What**  
This script was still hanging around - no longer required as we arent using a lambda layer


