### PR TITLE
chore: new resident view tweaks

### DIFF
--- a/components/Dialog/Dialog.tsx
+++ b/components/Dialog/Dialog.tsx
@@ -1,5 +1,6 @@
 import React, { KeyboardEventHandler } from 'react';
 import { Dialog as ReachDialog } from '@reach/dialog';
+import classNames from 'classnames';
 
 interface Props {
   isOpen: boolean;
@@ -8,6 +9,7 @@ interface Props {
   title: string;
   showCloseButton?: boolean;
   onKeyUp?: KeyboardEventHandler<HTMLDivElement>;
+  className?: string;
 }
 
 const Dialog = ({
@@ -17,13 +19,14 @@ const Dialog = ({
   title,
   showCloseButton = true,
   onKeyUp,
+  className,
   ...props
 }: Props): React.ReactElement => (
   <ReachDialog
     isOpen={isOpen}
     onDismiss={onDismiss}
     aria-label={title}
-    className="lbh-dialog lbh-dialog--light"
+    className={classNames('lbh-dialog lbh-dialog--light', className)}
     onKeyUp={onKeyUp}
     {...props}
   >

--- a/components/ResidentPage/CaseNoteDialog.module.scss
+++ b/components/ResidentPage/CaseNoteDialog.module.scss
@@ -1,5 +1,9 @@
 @import 'lbh-frontend/lbh/base';
 
+.dialog {
+  max-width: 600px;
+}
+
 .actions {
   margin-top: 0.5rem;
   margin-bottom: 1.5rem;

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -157,6 +157,7 @@ const CaseNoteDialog = ({
         isOpen={!!query['case_note']}
         onDismiss={handleClose}
         onKeyUp={handleKeyboardNav}
+        className={s.dialog}
       >
         <p className="lbh-body-s">
           {note.pinnedAt && `Pinned · `}

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -150,6 +150,7 @@ const CaseNoteDialog = ({
 
   if (note) {
     const link = generateCaseLink(note);
+    const isWorkflow = note?.caseFormData?.workflowId;
 
     return (
       <Dialog
@@ -166,12 +167,20 @@ const CaseNoteDialog = ({
         </p>
 
         <p className={`lbh-body-xs ${s.actions}`}>
-          {link && (
-            <>
-              <Link href={link}>
-                <a className="lbh-link">Printable version</a>
-              </Link>
-            </>
+          {isWorkflow ? (
+            <Link
+              href={`${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}/workflows/${note.caseFormData.workflowId}`}
+            >
+              Go to workflow
+            </Link>
+          ) : (
+            link && (
+              <>
+                <Link href={link}>
+                  <a className="lbh-link">Printable version</a>
+                </Link>
+              </>
+            )
           )}
 
           {note.formType === 'flexible-form' && (
@@ -199,6 +208,8 @@ const CaseNoteDialog = ({
             submissionId={note.recordId}
             socialCareId={socialCareId}
           />
+        ) : isWorkflow ? (
+          <></>
         ) : (
           <CaseContent recordId={note.recordId} socialCareId={socialCareId} />
         )}

--- a/components/ResidentPage/CaseNoteGrid.module.scss
+++ b/components/ResidentPage/CaseNoteGrid.module.scss
@@ -4,6 +4,7 @@
   display: grid;
   gap: 0.75rem;
   list-style: none;
+  margin-bottom: 0.75rem;
 
   @include govuk-media-query($from: tablet) {
     grid-template-columns: 1fr 1fr;

--- a/components/ResidentPage/CaseNoteGrid.module.scss
+++ b/components/ResidentPage/CaseNoteGrid.module.scss
@@ -41,7 +41,7 @@
 
   @include govuk-media-query($from: tablet) {
     padding: 0.75rem;
-    min-height: 150px;
+    min-height: 200px;
   }
 
   &:focus-within {
@@ -50,7 +50,11 @@
     box-shadow: 0px 4px 0px lbh-colour('lbh-text');
 
     div {
-      visibility: hidden;
+      color: lbh-colour('lbh-text');
+
+      &:after {
+        visibility: hidden;
+      }
     }
 
     p {
@@ -81,19 +85,24 @@
 
   h2 {
     margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  p:last-child {
+    margin-top: auto;
   }
 }
 
 .preview {
   position: relative;
-  margin-top: 0.5rem;
   max-height: 70px;
   overflow: hidden;
   @include lbh-body-xs;
-  //   flex: 1;
+  flex: 1;
   word-wrap: anywhere;
   color: lbh-colour('lbh-grey-1');
-  margin-bottom: auto;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
   pointer-events: none; // can be clicked through
 
   &:after {
@@ -104,7 +113,7 @@
     height: 50%;
     display: block;
     content: '';
-    background-image: linear-gradient(
+    background: linear-gradient(
       transparentize(lbh-colour('lbh-grey-4'), 1),
       lbh-colour('lbh-grey-4')
     );
@@ -112,13 +121,13 @@
 }
 
 .pinned {
-  background: transparentize(lbh-colour('lbh-primary-focus'), 0.9);
+  background: lighten(lbh-colour('lbh-primary-focus'), 30);
   border-color: lbh-colour('lbh-primary-focus');
 
-  div {
-    background-image: linear-gradient(
-      transparentize(lbh-colour('lbh-primary-focus'), 1),
-      transparentize(lbh-colour('lbh-primary-focus'), 0.9)
+  div:after {
+    background: linear-gradient(
+      transparentize(lighten(lbh-colour('lbh-primary-focus'), 30), 1),
+      lighten(lbh-colour('lbh-primary-focus'), 30)
     );
   }
 }

--- a/components/ResidentPage/CaseNoteGrid.module.scss
+++ b/components/ResidentPage/CaseNoteGrid.module.scss
@@ -122,6 +122,10 @@
   }
 }
 
+.workflow {
+  background: lbh-colour('lbh-panel');
+}
+
 .tileSkeleton {
   position: relative;
   box-sizing: border-box;

--- a/components/ResidentPage/CaseNoteGrid.tsx
+++ b/components/ResidentPage/CaseNoteGrid.tsx
@@ -24,7 +24,7 @@ const CaseNoteGrid = ({
 
   if (user && !canManageCases(user, resident))
     return (
-      <p>
+      <p className="lbh-body-s">
         You don&apos;t have permission to see this resident&apos;s case notes
         and records.
       </p>

--- a/components/ResidentPage/CaseNoteTile.tsx
+++ b/components/ResidentPage/CaseNoteTile.tsx
@@ -10,6 +10,7 @@ import { truncate } from 'lib/utils';
 import React from 'react';
 import { useWorker } from 'utils/api/workers';
 import cx from 'classnames';
+import { useSubmission } from 'utils/api/submissions';
 
 const prettyLink = (c: Case): string => {
   if (c?.caseFormData?.workflowId)
@@ -20,6 +21,25 @@ const prettyLink = (c: Case): string => {
 interface TileProps {
   c: Case;
 }
+
+interface SubmissionPreviewProps {
+  submissionId: string;
+}
+
+const SubmissionPreview = ({ submissionId }: SubmissionPreviewProps) => {
+  const { data } = useSubmission(submissionId);
+
+  const text = data?.formAnswers?.['singleStep']?.['Body'];
+
+  if (text)
+    return (
+      <div aria-hidden="true" className={s.preview}>
+        {truncate(text as string, 20)}
+      </div>
+    );
+
+  return null;
+};
 
 const CaseNoteTile = ({ c }: TileProps): React.ReactElement => {
   const isWorkflow = c?.caseFormData?.workflowId;
@@ -48,10 +68,9 @@ const CaseNoteTile = ({ c }: TileProps): React.ReactElement => {
         </Link>
       </h2>
 
-      <div aria-hidden="true" className={s.preview}>
-        {c?.caseFormData?.case_note_description &&
-          truncate(c?.caseFormData?.case_note_description || '', 20)}
-      </div>
+      {c.formType === 'flexible-form' && (
+        <SubmissionPreview submissionId={c.recordId} />
+      )}
 
       {c.officerEmail && (
         <p className="lbh-body-xs">

--- a/components/ResidentPage/CaseNoteTile.tsx
+++ b/components/ResidentPage/CaseNoteTile.tsx
@@ -22,6 +22,8 @@ interface TileProps {
 }
 
 const CaseNoteTile = ({ c }: TileProps): React.ReactElement => {
+  const isWorkflow = c?.caseFormData?.workflowId;
+
   const { data } = useWorker({
     email: c.officerEmail || '',
   });
@@ -29,9 +31,13 @@ const CaseNoteTile = ({ c }: TileProps): React.ReactElement => {
   const worker = data?.[0];
 
   return (
-    <li key={c.recordId} className={cx(s.tile, c.pinnedAt && s.pinned)}>
+    <li
+      key={c.recordId}
+      className={cx(s.tile, c.pinnedAt && s.pinned, isWorkflow && s.workflow)}
+    >
       <p className="lbh-body-xs">
         {prettyCaseDate(c)}
+        {isWorkflow && ` · Workflow`}
         {c.pinnedAt && ` · Pinned`}
       </p>
       <h2 className="lbh-heading-h4">

--- a/components/ResidentPage/CaseOpenness.spec.tsx
+++ b/components/ResidentPage/CaseOpenness.spec.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { mockedAllocations } from 'factories/allocatedWorkers';
+import { mockedResident } from 'factories/residents';
+import CaseOpennessTag from './CaseOpenness';
+
+describe('CaseOpennessTag', () => {
+  it('shows an open, active case', () => {
+    render(
+      <CaseOpennessTag
+        resident={mockedResident}
+        allocations={{
+          allocations: mockedAllocations,
+        }}
+      />
+    );
+    expect(screen.getByText('Open active case'));
+  });
+
+  it('shows an open case', () => {
+    render(
+      <CaseOpennessTag
+        resident={{
+          ...mockedResident,
+          allocatedTeam: 'foo',
+        }}
+        allocations={{
+          allocations: [],
+        }}
+      />
+    );
+    expect(screen.getByText('Open case'));
+  });
+
+  it('shows a closed case', () => {
+    render(
+      <CaseOpennessTag
+        resident={mockedResident}
+        allocations={{
+          allocations: [],
+        }}
+      />
+    );
+    expect(screen.getByText('Closed case'));
+  });
+});

--- a/components/ResidentPage/CaseOpenness.tsx
+++ b/components/ResidentPage/CaseOpenness.tsx
@@ -9,7 +9,7 @@ const CaseOpennessTag = ({
   resident,
   allocations,
 }: Props): React.ReactElement => {
-  if (allocations?.allocations?.length > 0)
+  if (allocations?.allocations && allocations?.allocations?.length > 0)
     return (
       <li className="govuk-tag lbh-tag lbh-tag--blue">Open active case</li>
     );

--- a/components/ResidentPage/CaseOpenness.tsx
+++ b/components/ResidentPage/CaseOpenness.tsx
@@ -2,7 +2,7 @@ import { AllocationData, Resident } from 'types';
 
 interface Props {
   resident: Resident;
-  allocations: AllocationData;
+  allocations?: AllocationData;
 }
 
 const CaseOpennessTag = ({

--- a/components/ResidentPage/CaseOpenness.tsx
+++ b/components/ResidentPage/CaseOpenness.tsx
@@ -1,0 +1,23 @@
+import { AllocationData, Resident } from 'types';
+
+interface Props {
+  resident: Resident;
+  allocations: AllocationData;
+}
+
+const CaseOpennessTag = ({
+  resident,
+  allocations,
+}: Props): React.ReactElement => {
+  if (allocations?.allocations?.length > 0)
+    return (
+      <li className="govuk-tag lbh-tag lbh-tag--blue">Open active case</li>
+    );
+
+  if (resident.allocatedTeam)
+    return <li className="govuk-tag lbh-tag lbh-tag--blue">Open case</li>;
+
+  return <li className="govuk-tag lbh-tag lbh-tag--grey">Closed case</li>;
+};
+
+export default CaseOpennessTag;

--- a/components/ResidentPage/Layout.spec.tsx
+++ b/components/ResidentPage/Layout.spec.tsx
@@ -57,7 +57,7 @@ describe('Layout', () => {
       </AppConfigProvider>
     );
     expect(screen.getAllByRole('list').length).toBe(3);
-    expect(screen.getAllByRole('listitem').length).toBe(9);
+    expect(screen.getAllByRole('listitem').length).toBe(8);
     expect(screen.getByText('Adult social care'));
   });
 });

--- a/components/ResidentPage/Layout.tsx
+++ b/components/ResidentPage/Layout.tsx
@@ -55,10 +55,6 @@ const Layout = ({ title, resident, children }: Props): React.ReactElement => {
       text: 'Add case note',
       href: `/people/${resident.id}/case-note`,
     },
-    {
-      text: 'Add a case status',
-      href: `/people/${resident.id}/case-status/add`,
-    },
   ];
 
   return (

--- a/components/ResidentPage/Layout.tsx
+++ b/components/ResidentPage/Layout.tsx
@@ -54,6 +54,7 @@ const Layout = ({ title, resident, children }: Props): React.ReactElement => {
     {
       text: 'Add case note',
       href: `/people/${resident.id}/case-note`,
+      tip: "It's now faster to find and move through case notes",
     },
   ];
 
@@ -129,7 +130,7 @@ const Layout = ({ title, resident, children }: Props): React.ReactElement => {
                 <NavLink
                   href={link.href}
                   key={link.href}
-                  tip={link.tip}
+                  tip={link?.tip}
                   secondary
                 >
                   {link.text}

--- a/components/ResidentPage/Layout.tsx
+++ b/components/ResidentPage/Layout.tsx
@@ -92,7 +92,7 @@ const Layout = ({ title, resident, children }: Props): React.ReactElement => {
             </p>
           )}
 
-          <StatusTags resident={resident} />
+          <StatusTags resident={resident} allocations={allocations} />
 
           {/* <CaseStatusFlag person={resident} /> */}
         </div>

--- a/components/ResidentPage/Layout.tsx
+++ b/components/ResidentPage/Layout.tsx
@@ -46,11 +46,11 @@ const Layout = ({ title, resident, children }: Props): React.ReactElement => {
   ];
 
   const secondaryNavigation = [
-    {
-      text: 'Shareable version',
-      href: `/people/${resident.id}/warning-notes/add?id=${resident.id}`,
-      tip: "A handy printer-friendly view of this resident's info",
-    },
+    // {
+    //   text: 'Shareable version',
+    //   href: `/people/${resident.id}/warning-notes/add?id=${resident.id}`,
+    //   tip: "A handy printer-friendly view of this resident's info",
+    // },
     {
       text: 'Add case note',
       href: `/people/${resident.id}/case-note`,

--- a/components/ResidentPage/StatusTags.tsx
+++ b/components/ResidentPage/StatusTags.tsx
@@ -25,14 +25,14 @@ const StatusTags = ({ resident, allocations }: Props): React.ReactElement => {
 
       <CaseOpennessTag resident={resident} allocations={allocations} />
 
+      {resident?.dateOfDeath && (
+        <li className="govuk-tag lbh-tag lbh-tag--grey">Deceased</li>
+      )}
+
       {resident.primarySupportReason && (
         <li className="govuk-tag lbh-tag lbh-tag--green">
           {resident.primarySupportReason}
         </li>
-      )}
-
-      {resident?.dateOfDeath && (
-        <li className="govuk-tag lbh-tag lbh-tag--grey">Deceased</li>
       )}
 
       {resident?.restricted === 'Y' && (

--- a/components/ResidentPage/StatusTags.tsx
+++ b/components/ResidentPage/StatusTags.tsx
@@ -1,12 +1,14 @@
-import { Resident } from 'types';
+import { AllocationData, Resident } from 'types';
 import { useCaseStatuses } from 'utils/api/caseStatus';
+import CaseOpennessTag from './CaseOpenness';
 import s from './StatusTags.module.scss';
 
 interface Props {
   resident: Resident;
+  allocations?: AllocationData;
 }
 
-const StatusTags = ({ resident }: Props): React.ReactElement => {
+const StatusTags = ({ resident, allocations }: Props): React.ReactElement => {
   const { data: statuses } = useCaseStatuses(resident.id);
 
   return (
@@ -21,9 +23,7 @@ const StatusTags = ({ resident }: Props): React.ReactElement => {
         </li>
       )}
 
-      {/* {resident.openCase && (
-        <li className="govuk-tag lbh-tag lbh-tag--blue">Open case</li>
-      )} */}
+      <CaseOpennessTag resident={resident} allocations={allocations} />
 
       {resident.primarySupportReason && (
         <li className="govuk-tag lbh-tag lbh-tag--green">

--- a/components/ResidentPage/WorkflowOverview.tsx
+++ b/components/ResidentPage/WorkflowOverview.tsx
@@ -47,7 +47,7 @@ const WorkflowOverview = ({
 
       <footer className={`lbh-body-s ${s.footer}`}>
         <Link href={`/residents/${socialCareId}/workflows`}>
-          <a>See all{workflows && ` ${workflows.length} workflows`}</a>
+          <a>See chain of all{workflows && ` ${workflows.length} workflows`}</a>
         </Link>
         <a
           href={`${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}?quick_filter=all&social_care_id=${socialCareId}`}

--- a/components/ResidentPage/WorkflowOverview.tsx
+++ b/components/ResidentPage/WorkflowOverview.tsx
@@ -45,8 +45,6 @@ const WorkflowOverview = ({
         )}
       </div>
 
-      {/* <h3 className="lbh-heading-h5">Review soon</h3> */}
-
       <footer className={`lbh-body-s ${s.footer}`}>
         <Link href={`/residents/${socialCareId}/workflows`}>
           <a>See all{workflows && ` ${workflows.length} workflows`}</a>

--- a/data/primarySupportReasons.ts
+++ b/data/primarySupportReasons.ts
@@ -1,0 +1,16 @@
+export default {
+  'Access and mobility only': 'Physical support - access and mobility only',
+  'Personal care': 'Physical Support - Personal care support',
+  'Visual impairment': 'Sensory Support - Support for visual impairment',
+  'Hearing impairment': 'Sensory Support - Support for hearing impairment',
+  'Dual impairment': 'Sensory Support - Support for dual impairment',
+  'Memory & Cognition': 'Support with Memory & Cognition',
+  'Learning Disability': 'Learning Disability Support',
+  'Mental Health (ASC)': 'Mental Health Support (ASC)',
+  'Mental Health (ELFT)': 'Mental Health Support (ELFT)',
+  'Substance misuse': 'Social Support: Substance misuse support',
+  'Asylum seeker': 'Social Support: Asylum seeker support',
+  'Social Isolation / Other':
+    'Social Support: Support for Social Isolation/Other',
+  'Support to Carer': 'Social Support: Support to Carer',
+};

--- a/pages/residents/[id]/allocations.tsx
+++ b/pages/residents/[id]/allocations.tsx
@@ -26,7 +26,7 @@ const AllocationsPage = ({ resident }: Props): React.ReactElement => {
   return (
     <Layout resident={resident} title="Allocations">
       <>
-        <p className="lbh-body-s">
+        <p className="lbh-body-s govuk-!-margin-bottom-6">
           {resident.allocatedTeam
             ? `Allocated to ${resident.allocatedTeam}`
             : `This resident is not allocated to a team.`}

--- a/pages/residents/[id]/index.tsx
+++ b/pages/residents/[id]/index.tsx
@@ -476,11 +476,18 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
       >
         <>
           {cases && (
-            <CaseNoteGrid
-              cases={cases}
-              resident={resident}
-              totalCount={totalCount}
-            />
+            <>
+              <CaseNoteGrid
+                cases={cases}
+                resident={resident}
+                totalCount={totalCount}
+              />
+              <Link href="/">
+                <a className="lbh-link lbh-link--muted lbh-body-xs govuk-!-margin-top-2">
+                  See all {totalCount} case notes
+                </a>
+              </Link>
+            </>
           )}
         </>
       </Collapsible>

--- a/pages/residents/[id]/index.tsx
+++ b/pages/residents/[id]/index.tsx
@@ -482,7 +482,7 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
                 resident={resident}
                 totalCount={totalCount}
               />
-              <Link href="/">
+              <Link href={`/residents/${resident.id}/case-notes`}>
                 <a className="lbh-link lbh-link--muted lbh-body-xs govuk-!-margin-top-2">
                   See all {totalCount} case notes
                 </a>

--- a/pages/residents/[id]/index.tsx
+++ b/pages/residents/[id]/index.tsx
@@ -28,6 +28,7 @@ import CustomKeyContactsEditor from 'components/ResidentPage/CustomKeyContactsEd
 import CustomGPDetailsEditor from 'components/ResidentPage/CustomGPDetailsEditor';
 import { useTeams } from 'utils/api/allocatedWorkers';
 import { differenceInYears } from 'date-fns';
+import primarySupportReasons from 'data/primarySupportReasons';
 
 interface Props {
   resident: Resident;
@@ -317,6 +318,9 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
           {
             name: 'primarySupportReason',
             label: 'Primary support reason',
+            options: Object.entries(primarySupportReasons).map(
+              ([short, long]) => ({ label: long, value: short })
+            ),
           },
           // {
           //   name: 'openCase',

--- a/pages/residents/[id]/index.tsx
+++ b/pages/residents/[id]/index.tsx
@@ -488,7 +488,7 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
               />
               <Link href={`/residents/${resident.id}/case-notes`}>
                 <a className="lbh-link lbh-link--muted lbh-body-xs govuk-!-margin-top-2">
-                  See all {totalCount} case notes
+                  See all {totalCount} case notes & records
                 </a>
               </Link>
             </>

--- a/utils/contentSecurity.spec.ts
+++ b/utils/contentSecurity.spec.ts
@@ -22,7 +22,7 @@ describe('generating the desired CSP from a nonce', () => {
         "script-src-elem 'self' 'nonce-4fzzzxjylrx4fzzzxjylrx4fzzzxjylrx4fzzzxjylrx4fzzzxjylrx' www.googletagmanager.com script.hotjar.com static.hotjar.com; " +
         "font-src 'self' fonts.gstatic.com; " +
         'frame-src vars.hotjar.com; ' +
-        "img-src 'self' script.hotjar.com www.googletagmanager.com; " +
+        "img-src 'self' script.hotjar.com www.googletagmanager.com maps.googleapis.com; " +
         "frame-ancestors 'self'; " +
         "form-action 'self';"
     );

--- a/utils/contentSecurity.ts
+++ b/utils/contentSecurity.ts
@@ -32,7 +32,12 @@ const policy: CSPPolicy = {
   ],
   'font-src': ["'self'", 'fonts.gstatic.com'],
   'frame-src': ['vars.hotjar.com'],
-  'img-src': ["'self'", 'script.hotjar.com', 'www.googletagmanager.com'],
+  'img-src': [
+    "'self'",
+    'script.hotjar.com',
+    'www.googletagmanager.com',
+    'maps.googleapis.com',
+  ],
   'frame-ancestors': ["'self'"],
   'form-action': ["'self'"],
 };


### PR DESCRIPTION
assorted small tweaks to get resident view shipshape

checked by elsa already

- [x] consistent styling of the "you don't have permission to see x" messages
- [x] update csp to permit google map and street view imagery
- [x] add see all x case notes to overview page collapsible
- [x] improve visual design of workflows in the case notes grid
- [x] case note dialogs slightly wider to accomodate long body text
- [x] remove currently non-functional "add a case status" link temporarily
- [x] update wording of "see all x workflows" to "see chain of x workflows"
- [x] fix cors error on workflows
- [x] add automated open case logic based on allocations
- [x] update primary support reason options
- [x] add case note preview to case note tiles in all cases by using the submissions api
- [ ] flip feature flag to true and update e2e tests