### PR TITLE
chore(SCT-1666): upgrade Nextjs to 12.1.0, remove target parameter

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,6 @@ const { withSentryConfig } = require('@sentry/nextjs');
 module.exports = withSentryConfig(
   {
     distDir: 'build/_next',
-    target: 'server',
     poweredByHeader: false,
 
     async redirects() {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@reach/dialog": "^0.16.2",
-    "@sentry/nextjs": "^6.16.0",
+    "@sentry/nextjs": "^6.17.9",
     "axios": "^0.21.2",
     "body-parser": "^1.19.0",
     "classnames": "^2.3.1",
@@ -36,7 +36,7 @@
     "lbh-frontend": "^3.5.3",
     "lodash.debounce": "^4.0.8",
     "lodash.get": "^4.4.2",
-    "next": "^11.1.3",
+    "next": "^12.1.0",
     "notifications-node-client": "^5.1.0",
     "react": "17.0.2",
     "react-beforeunload": "^2.5.1",


### PR DESCRIPTION
**What**  
Upgrade with Nextjs security patch

Remove 'target' parameter from next.config.js
