### PR TITLE
fix: fix font in new NextJS version

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -72,6 +72,10 @@ export default class AppDocument extends Document<{ nonce?: string }> {
               }}
             />
           ) : null}
+          <link
+            rel="stylesheet"
+            href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap"
+          />
         </Head>
         <body className="govuk-template__body lbh-template__body js-enabled">
           <noscript


### PR DESCRIPTION
**What**  
The new NextJS version breaks the font import.
We added them back manually
