### PR TITLE
fix: Added nonce to stylesheet link

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -74,6 +74,7 @@ export default class AppDocument extends Document<{ nonce?: string }> {
           ) : null}
           <link
             rel="stylesheet"
+            nonce={this.props.nonce}
             href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap"
           />
         </Head>


### PR DESCRIPTION
**What**  
The login page is not loading the Google CDN for the font stylesheet.
This is because there's a CSP preventing the script for loading.
This PR adds the nonce to the script so it can be executed correctly.

**Why**  
The login page is not loading the Google CDN for the font stylesheet.