### PR TITLE
fix: Update the pipeline to build before deploying.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,9 @@ jobs:
     steps:
       - *attach_workspace
       - run:
+          name: build
+          command: NEXT_PUBLIC_CORE_PATHWAY_APP_URL=$STAGING_CORE_PATHWAY_APP_URL yarn build
+      - run:
           name: deploy
           command: SENTRY_RELEASE=$CIRCLE_SHA1 yarn --frozen-lockfile --production=true && sudo npm i -g serverless && sls deploy --stage staging
 
@@ -132,6 +135,9 @@ jobs:
     executor: aws-cli/default
     steps:
       - *attach_workspace
+      - run:
+          name: build
+          command: NEXT_PUBLIC_CORE_PATHWAY_APP_URL=$PRODUCTION_CORE_PATHWAY_APP_URL yarn build
       - run:
           name: deploy
           command: SENTRY_RELEASE=$CIRCLE_SHA1 yarn --frozen-lockfile --production=true && sudo npm i -g serverless && sls deploy -s mosaic-prod


### PR DESCRIPTION
**What**  
Updates the `build-deploy-staging` and `build-deploy-mosaic-production` jobs to have a build step that sets the value of `NEXT_PUBLIC_CORE_PATHWAY_APP_URL` to be the URL for the deployment environment.

**Why**  
This fixes a bug that involved Staging using a production URL when starting/adding a new workflow.

**Anything else?**
- This change also involves adding new environment variables: `STAGING_CORE_PATHWAY_APP_URL` and `PRODUCTION_CORE_PATHWAY_APP_URL` to CircleCI
