### PR TITLE
fix: disable Case Status via feature flag

### DIFF
--- a/cypress/integration/case_status_CIN.ts
+++ b/cypress/integration/case_status_CIN.ts
@@ -60,7 +60,20 @@ const newResident = {
   createdBy: 'e2e.tests.adult@hackney.gov.uk',
 };
 
-describe('Using CIN case status', () => {
+describe.only('Check Case Status Feature is disabled', () => {
+  it('should not be possible to add a Case Status on a child', () => {
+    cy.visitAs(`/people/${residentId}`, AuthRoles.ChildrensGroup);
+    cy.get('Add a case status').should('not.exist');
+  });
+
+  it('should not be possible to view a Case Status on a child', () => {
+    cy.visitAs(`/people/${residentId}/details`, AuthRoles.ChildrensGroup);
+    cy.url().should('include', '/details');
+    cy.contains('Child in need').should('not.exist');
+  });
+});
+
+xdescribe('Using CIN case status', () => {
   beforeEach(() => {
     // This is required as the email address stored in the cookie is not an
     // existing worker.

--- a/cypress/integration/case_status_CP.ts
+++ b/cypress/integration/case_status_CP.ts
@@ -59,6 +59,14 @@ const newResident = {
   createdBy: 'e2e.tests.adult@hackney.gov.uk',
 };
 
+describe.only('Check Case Status Feature is disabled', () => {
+  it('should not be possible to view a Case Status on a child', () => {
+    cy.visitAs(`/people/${residentId}/details`, AuthRoles.ChildrensGroup);
+    cy.url().should('include', '/details');
+    cy.contains('Child protection').should('not.exist');
+  });
+});
+
 xdescribe('Using CP case status', () => {
   beforeEach(() => {
     // This is required as the email address stored in the cookie is not an

--- a/cypress/integration/case_status_LAC.ts
+++ b/cypress/integration/case_status_LAC.ts
@@ -62,7 +62,15 @@ const newResident = {
   createdBy: 'e2e.tests.adult@hackney.gov.uk',
 };
 
-describe('Using LAC case status', () => {
+describe.only('Check Case Status Feature is disabled', () => {
+  it('should not be possible to view a Case Status on a child', () => {
+    cy.visitAs(`/people/${residentId}/details`, AuthRoles.ChildrensGroup);
+    cy.url().should('include', '/details');
+    cy.contains('Looked after child').should('not.exist');
+  });
+});
+
+xdescribe('Using LAC case status', () => {
   beforeEach(() => {
     // This is required as the email address stored in the cookie is not an
     // existing worker.

--- a/features.ts
+++ b/features.ts
@@ -30,10 +30,9 @@ export const getFeatureFlags = ({
       isActive:
         environmentName === 'development' || user?.hasDevPermissions || false,
     },
-    // FEATURE-FLAG-EXPIRES [2022-06-31]: case-status
+    // FEATURE-FLAG-EXPIRES [2031-06-31]: case-status
     'case-status': {
-      isActive:
-        environmentName === 'development' || user?.hasAdminPermissions || false,
+      isActive: false,
     },
     // FEATURE-FLAG-EXPIRES [2022-06-31]: preview-new-resident-view
     'preview-new-resident-view': {


### PR DESCRIPTION
**What**  
As we are not currently using the Case Status functionality, we have removed the functionality by setting the relevant feature flag to 'false'.

We also X'd out the cypress tests for the case statuses for CIN, CP & LAC.
We added new cypress tests here to test for the absence of the case status link

**Why**  
The E2E tests for the case statuses take some time to run so disabling will speed up the build pipeline.
