### PR TITLE
fix: Preview banner

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -58,9 +58,6 @@ REDIRECT_URL=
 # The ID for Google Analytics data to be reported to
 NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=
 
-# The Google Form URL that powers the feedback link
-NEXT_PUBLIC_FEEDBACK_LINK=
-
 # Workflows pilot
 NEXT_PUBLIC_CORE_PATHWAY_APP_URL=
 

--- a/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/components/ErrorBoundary/ErrorBoundary.tsx
@@ -45,8 +45,14 @@ class ErrorBoundaryComponent extends Component<
           <div className="govuk-error-summary__body">
             <p>
               Try your request again. If the error persists, contact us via the{' '}
-              <a href={process.env.NEXT_PUBLIC_FEEDBACK_LINK}>feedback form</a>.
-              Please include the information below in your feedback so we can
+              <a
+                href={
+                  'https://docs.google.com/forms/d/e/1FAIpQLScILbPD1ioKHzp1D3HN4_DKaxV2tpWLMu8upSSqNgSPCo85cg/viewform'
+                }
+              >
+                feedback form
+              </a>
+              . Please include the information below in your feedback so we can
               fully understand how to resolve the problem.
             </p>
             <ul className="govuk-list govuk-error-summary__list">

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -23,7 +23,8 @@ const Layout = ({
 
   if (noLayout) return <>{children}</>;
 
-  const feedbackLink = process.env.NEXT_PUBLIC_FEEDBACK_LINK || '';
+  const feedbackLink =
+    'https://docs.google.com/forms/d/e/1FAIpQLScILbPD1ioKHzp1D3HN4_DKaxV2tpWLMu8upSSqNgSPCo85cg/viewform';
 
   return (
     <>

--- a/components/NewPersonView/PreviewBanner.tsx
+++ b/components/NewPersonView/PreviewBanner.tsx
@@ -29,7 +29,11 @@ const PreviewBanner = ({
           </p>
           <p className="lbh-body-s govuk-!-margin-top-2">
             <Link href={`/residents/${resident.id}`}>Try it now</Link>
-            <Link href={process.env.NEXT_PUBLIC_FEEDBACK_LINK as string}>
+            <Link
+              href={
+                'https://docs.google.com/forms/d/e/1FAIpQLScILbPD1ioKHzp1D3HN4_DKaxV2tpWLMu8upSSqNgSPCo85cg/viewform'
+              }
+            >
               <a className="govuk-!-margin-left-3">Give feedback</a>
             </Link>
           </p>

--- a/components/NewPersonView/PreviewBanner.tsx
+++ b/components/NewPersonView/PreviewBanner.tsx
@@ -28,14 +28,16 @@ const PreviewBanner = ({
             chronology of their workflows and browse case notes faster.
           </p>
           <p className="lbh-body-s govuk-!-margin-top-2">
-            <Link href={`/residents/${resident.id}`}>Try it now</Link>
-            <Link
+            <Link href={`/residents/${resident.id}`}>Try it now</Link>{' '}
+            <a
               href={
                 'https://docs.google.com/forms/d/e/1FAIpQLScILbPD1ioKHzp1D3HN4_DKaxV2tpWLMu8upSSqNgSPCo85cg/viewform'
               }
+              target={'_blank'}
+              rel="noreferrer"
             >
-              <a className="govuk-!-margin-left-3">Give feedback</a>
-            </Link>
+              Give feedback
+            </a>
           </p>
         </div>
       </section>

--- a/features.ts
+++ b/features.ts
@@ -36,7 +36,7 @@ export const getFeatureFlags = ({
     },
     // FEATURE-FLAG-EXPIRES [2022-06-31]: preview-new-resident-view
     'preview-new-resident-view': {
-      isActive: environmentName === 'production',
+      isActive: environmentName !== 'production',
     },
     /*
       The feature-flags-implementation-proof has been setup to have an expiry date in the far future.

--- a/pages/people/[id]/index.tsx
+++ b/pages/people/[id]/index.tsx
@@ -5,6 +5,7 @@ import { Resident } from 'types';
 import { canManageCases } from 'lib/permissions';
 import { isAuthorised } from 'utils/auth';
 import PersonHistory from 'components/NewPersonView/PersonHistory';
+import PreviewBanner from 'components/NewPersonView/PreviewBanner';
 
 interface Props {
   person: Resident;
@@ -14,6 +15,7 @@ const PersonPage = ({ person }: Props): React.ReactElement => {
   return (
     <Layout person={person}>
       <>
+        <PreviewBanner resident={person} />
         <PersonHistory personId={person.id} />
       </>
     </Layout>

--- a/serverless.yml
+++ b/serverless.yml
@@ -55,7 +55,6 @@ functions:
       AUTHORISED_AUDITABLE_GROUP: ${ssm:/lbh-social-care/${self:provider.stage}/authorised-auditable-group}
       POSTCODE_LOOKUP_URL: ${ssm:/lbh-social-care/${self:provider.stage}/postcode-lookup-url}
       POSTCODE_LOOKUP_APIKEY: ${ssm:/lbh-social-care/${self:provider.stage}/postcode-lookup-apikey}
-      NEXT_PUBLIC_FEEDBACK_LINK: ${ssm:/lbh-social-care/${self:provider.stage}/next-public-feedback-link}
       REDIRECT_URL: ${ssm:/lbh-social-care/${self:provider.stage}/redirect_url}
       NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: ${ssm:/lbh-social-care/${self:provider.stage}/next_public_google_analytics_id}
       NEXT_PUBLIC_SENTRY_DSN: ${ssm:/lbh-social-care/${self:provider.stage}/next-public-sentry-dsn}


### PR DESCRIPTION
**What**  

- This PR re-enables the Preview banner for adults
- <Link> component has been changed to a <a>  component
- Feedback form link is now hardcoded
- The Feature flag has been changed so it's enabled everywhere but production environment.
- Removed `NEXT_PUBLIC_FEEDBACK_LINK` env variable

**Why**  
This PR re-enables the Preview banner for adults after the incident