### PR TITLE
chore: bring back resident view v3 preview banner

### DIFF
--- a/features.ts
+++ b/features.ts
@@ -36,7 +36,7 @@ export const getFeatureFlags = ({
     },
     // FEATURE-FLAG-EXPIRES [2022-06-31]: preview-new-resident-view
     'preview-new-resident-view': {
-      isActive: environmentName !== 'production',
+      isActive: true,
     },
     /*
       The feature-flags-implementation-proof has been setup to have an expiry date in the far future.


### PR DESCRIPTION
bring back preview banner linking to the new resident view 