### PR TITLE
chore: better empty and initial states for case notes, workflows and maps

### DIFF
--- a/components/ResidentPage/Mapping.spec.tsx
+++ b/components/ResidentPage/Mapping.spec.tsx
@@ -36,4 +36,19 @@ describe('Mapping', () => {
       'https://maps.googleapis.com/maps/api/streetview?size=360x360&return_error_code=true&location=sjakdjlk,%20hdsadjk'
     );
   });
+
+  it('handles a resident with no address', () => {
+    (useResident as jest.Mock).mockReturnValue({
+      data: {
+        ...mockedResident,
+        address: {
+          address: '',
+          postcode: '',
+        },
+      },
+    });
+
+    render(<Mapping socialCareId={1} />);
+    expect(screen.queryByRole('img')).toBeNull();
+  });
 });

--- a/components/ResidentPage/Mapping.tsx
+++ b/components/ResidentPage/Mapping.tsx
@@ -51,6 +51,8 @@ const Mapping = ({ socialCareId }: Props): React.ReactElement | null => {
 
   if (!data) return null;
 
+  if (!data.address?.postcode && !data.address?.address) return null; // handle resident with no address set
+
   const mapUrl = `https://maps.googleapis.com/maps/api/staticmap?size=360x360&return_error_code=true&markers=${prettyAddress(
     data
   )}&zoom=15&key=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_KEY}`;

--- a/components/ResidentPage/StatusTags.module.scss
+++ b/components/ResidentPage/StatusTags.module.scss
@@ -8,10 +8,11 @@
     font-size: 0.9rem;
     font-weight: 600;
     padding: 0px 5px;
-  }
-
-  li + li {
     margin-top: 0;
-    margin-left: 7px;
+    margin-right: 7px;
+
+    &:last-child {
+      margin-right: 0;
+    }
   }
 }

--- a/components/ResidentPage/WorkflowChunk.module.scss
+++ b/components/ResidentPage/WorkflowChunk.module.scss
@@ -12,6 +12,7 @@
     margin-top: 0;
     margin-bottom: 0.25rem;
     position: relative;
+    margin-right: 10px;
   }
 
   // tag
@@ -20,7 +21,11 @@
     font-size: 0.9rem;
     font-weight: 600;
     padding: 0px 5px;
-    margin-left: 10px;
+    margin-right: 10px;
+
+    &:last-child {
+      margin-right: 0;
+    }
   }
 
   p {

--- a/components/ResidentPage/WorkflowChunk.tsx
+++ b/components/ResidentPage/WorkflowChunk.tsx
@@ -24,7 +24,7 @@ export const WorkflowChunk = ({ workflow }: Props): React.ReactElement => (
       <span className="govuk-tag lbh-tag lbh-tag--yellow">In progress</span>
     )}
 
-    <p className="lbh-body-xs">
+    <p className="lbh-body-xs govuk-!-margin-top-1">
       Started {formatDate(workflow.createdAt.toString())} ·{' '}
       {prettyStatus(workflow)}
     </p>

--- a/components/ResidentPage/WorkflowOverview.spec.tsx
+++ b/components/ResidentPage/WorkflowOverview.spec.tsx
@@ -69,4 +69,9 @@ describe('WorkflowOverview', () => {
     expect(screen.getAllByText('In progress').length).toBe(3);
     expect(screen.getAllByRole('link').length).toBe(4);
   });
+
+  it('handles when there are no workflows to show', () => {
+    render(<WorkflowOverview socialCareId={1} workflows={[]} />);
+    expect(screen.getByText('This resident has no workflows yet.'));
+  });
 });

--- a/components/ResidentPage/WorkflowOverview.spec.tsx
+++ b/components/ResidentPage/WorkflowOverview.spec.tsx
@@ -74,4 +74,19 @@ describe('WorkflowOverview', () => {
     render(<WorkflowOverview socialCareId={1} workflows={[]} />);
     expect(screen.getByText('This resident has no workflows yet.'));
   });
+
+  it('handles when there are workflows but nothing in progress', () => {
+    render(
+      <WorkflowOverview
+        socialCareId={1}
+        workflows={[
+          {
+            ...mockWorkflow,
+            submittedAt: new Date(),
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText('Nothing is in progress right now.'));
+  });
 });

--- a/components/ResidentPage/WorkflowOverview.tsx
+++ b/components/ResidentPage/WorkflowOverview.tsx
@@ -20,19 +20,29 @@ const WorkflowOverview = ({
     ?.filter((w) => !w.submittedAt)
     .filter((w) => w.id !== mostRecent?.id); // exclude most recent workflow
 
+  if (workflows?.length === 0)
+    return <p className="lbh-body-s">This resident has no workflows yet.</p>;
+
   return (
     <>
       <div className="govuk-grid-row">
         {inProgress && (
           <div className="govuk-grid-column-one-half">
             <h3 className="lbh-heading-h5">In progress</h3>
-            {inProgress.slice(0, 3)?.map((w) => (
-              <WorkflowChunk workflow={w} key={w.id} />
-            ))}
-            {inProgress.length > 3 && (
-              <p className="lbh-body-xs govuk-!-margin-top-2">
-                and {inProgress.length - 3} more
-              </p>
+
+            {inProgress.length > 0 ? (
+              <>
+                {inProgress.slice(0, 3)?.map((w) => (
+                  <WorkflowChunk workflow={w} key={w.id} />
+                ))}
+                {inProgress.length > 3 && (
+                  <p className="lbh-body-xs govuk-!-margin-top-2">
+                    and {inProgress.length - 3} more
+                  </p>
+                )}
+              </>
+            ) : (
+              <p className="lbh-body-s">Nothing is in progress right now.</p>
             )}
           </div>
         )}

--- a/pages/residents/[id]/index.tsx
+++ b/pages/residents/[id]/index.tsx
@@ -486,22 +486,25 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
         }
       >
         <>
-          {cases && (
-            <>
-              <CaseNoteGrid
-                cases={cases}
-                resident={resident}
-                totalCount={totalCount}
-              />
-              {canManage && (
-                <Link href={`/residents/${resident.id}/case-notes`}>
-                  <a className="lbh-link lbh-link--muted lbh-body-xs govuk-!-margin-top-2">
-                    See all {totalCount} case notes & records
-                  </a>
-                </Link>
-              )}
-            </>
-          )}
+          {cases &&
+            (cases.length > 0 ? (
+              <>
+                <CaseNoteGrid
+                  cases={cases}
+                  resident={resident}
+                  totalCount={totalCount}
+                />
+                {canManage && (
+                  <Link href={`/residents/${resident.id}/case-notes`}>
+                    <a className="lbh-link lbh-link--muted lbh-body-xs govuk-!-margin-top-2">
+                      See all {totalCount} case notes & records
+                    </a>
+                  </Link>
+                )}
+              </>
+            ) : (
+              <p className="lbh-body-s">This resident has no case notes yet.</p>
+            ))}
         </>
       </Collapsible>
 

--- a/pages/residents/[id]/index.tsx
+++ b/pages/residents/[id]/index.tsx
@@ -326,6 +326,10 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
             options: Object.entries(primarySupportReasons).map(
               ([short, long]) => ({ label: long, value: short })
             ),
+            beforeDisplay: (value) =>
+              Object.entries(primarySupportReasons).find(
+                ([short]) => value === short
+              )?.[1] || (value as string),
           },
           // {
           //   name: 'openCase',

--- a/pagesTest/residents/[id]/index.spec.tsx
+++ b/pagesTest/residents/[id]/index.spec.tsx
@@ -13,11 +13,13 @@ jest.mock('next/router');
 (useRouter as jest.Mock).mockReturnValue({ asPath: '' });
 
 jest.mock('utils/api/cases');
-(useCases as jest.Mock).mockReturnValue([
-  {
-    cases: [],
-  },
-]);
+(useCases as jest.Mock).mockReturnValue({
+  data: [
+    {
+      cases: [],
+    },
+  ],
+});
 
 jest.mock('components/UserContext/UserContext');
 (useAuth as jest.Mock).mockReturnValue({ user: mockedUser });
@@ -53,5 +55,15 @@ describe('ResidentPage', () => {
     );
     expect(screen.getByText('Adult social care'));
     expect(screen.getByText('Closed case'));
+  });
+
+  it('correctly handles when there are no case notes', () => {
+    render(
+      <AppConfigProvider appConfig={{}}>
+        <ResidentPage resident={mockedResident} />
+      </AppConfigProvider>
+    );
+
+    expect(screen.getByText('This resident has no case notes yet.'));
   });
 });


### PR DESCRIPTION
- [x] better null states for case notes/records and workflows
- [x] better null state for map+street view module
- [x] improve the spacing between status tags when they wrap onto a new line
- [x] show full, rather than abbreviated, primary support reason in the read-only (rather than edit) state of the personal details dialog

<img width="862" alt="Screenshot 2022-03-04 at 14 36 00" src="https://user-images.githubusercontent.com/14189497/156782605-4a703a35-29a3-48c8-a90d-eb6f738dfb6a.png">

<img width="347" alt="Screenshot 2022-03-04 at 14 44 10" src="https://user-images.githubusercontent.com/14189497/156783938-bc603883-188d-4085-a0b4-d5db4add48be.png">

<img width="598" alt="Screenshot 2022-03-04 at 15 03 04" src="https://user-images.githubusercontent.com/14189497/156787280-7f00a005-4096-44a0-9be1-6c1edbfb4dc2.png">