### PR TITLE
feat(SCT-1737, SCT-1738): Refactor frontend to use new search endpoint 

### DIFF
--- a/components/Search/Search.spec.tsx
+++ b/components/Search/Search.spec.tsx
@@ -58,15 +58,15 @@ describe(`Search`, () => {
         <Search {...props} type="people" />
       </UserContext.Provider>
     );
-    const fullNameInput = getByLabelText('Name');
-    fireEvent.change(fullNameInput, { target: { value: 'foo' } });
+    const nameInput = getByLabelText('Name');
+    fireEvent.change(nameInput, { target: { value: 'foo' } });
     await act(async () => {
       fireEvent.submit(getByRole('form'));
     });
     expect(mockedUseRouter.replace).toHaveBeenCalled();
     expect(mockedUseRouter.replace).toHaveBeenCalledWith(
-      'foopath?foo=bar&full_name=foo',
-      'foopath?foo=bar&full_name=foo',
+      'foopath?foo=bar&name=foo',
+      'foopath?foo=bar&name=foo',
       { shallow: true, scroll: false }
     );
     const searchResult = await findByText('PEOPLE SEARCH RESULT');
@@ -99,15 +99,15 @@ describe(`Search`, () => {
         <Search {...props} type="people" />
       </UserContext.Provider>
     );
-    const fullNameInput = getByLabelText('Name');
-    fireEvent.change(fullNameInput, { target: { value: 'foo' } });
+    const nameInput = getByLabelText('Name');
+    fireEvent.change(nameInput, { target: { value: 'foo' } });
     await act(async () => {
       fireEvent.submit(getByRole('form'));
     });
     expect(mockedUseRouter.replace).toHaveBeenCalled();
     expect(mockedUseRouter.replace).toHaveBeenCalledWith(
-      'foopath?foo=bar&full_name=foo',
-      'foopath?foo=bar&full_name=foo',
+      'foopath?foo=bar&name=foo',
+      'foopath?foo=bar&name=foo',
       { shallow: true, scroll: false }
     );
     const searchResult = await findByText('PEOPLE SEARCH RESULT');

--- a/components/Search/Search.spec.tsx
+++ b/components/Search/Search.spec.tsx
@@ -58,15 +58,15 @@ describe(`Search`, () => {
         <Search {...props} type="people" />
       </UserContext.Provider>
     );
-    const firstNameInput = getByLabelText('First name');
-    fireEvent.change(firstNameInput, { target: { value: 'foo' } });
+    const fullNameInput = getByLabelText('Name');
+    fireEvent.change(fullNameInput, { target: { value: 'foo' } });
     await act(async () => {
       fireEvent.submit(getByRole('form'));
     });
     expect(mockedUseRouter.replace).toHaveBeenCalled();
     expect(mockedUseRouter.replace).toHaveBeenCalledWith(
-      'foopath?foo=bar&first_name=foo',
-      'foopath?foo=bar&first_name=foo',
+      'foopath?foo=bar&full_name=foo',
+      'foopath?foo=bar&full_name=foo',
       { shallow: true, scroll: false }
     );
     const searchResult = await findByText('PEOPLE SEARCH RESULT');
@@ -99,15 +99,15 @@ describe(`Search`, () => {
         <Search {...props} type="people" />
       </UserContext.Provider>
     );
-    const firstNameInput = getByLabelText('First name');
-    fireEvent.change(firstNameInput, { target: { value: 'foo' } });
+    const fullNameInput = getByLabelText('Name');
+    fireEvent.change(fullNameInput, { target: { value: 'foo' } });
     await act(async () => {
       fireEvent.submit(getByRole('form'));
     });
     expect(mockedUseRouter.replace).toHaveBeenCalled();
     expect(mockedUseRouter.replace).toHaveBeenCalledWith(
-      'foopath?foo=bar&first_name=foo',
-      'foopath?foo=bar&first_name=foo',
+      'foopath?foo=bar&full_name=foo',
+      'foopath?foo=bar&full_name=foo',
       { shallow: true, scroll: false }
     );
     const searchResult = await findByText('PEOPLE SEARCH RESULT');

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -17,7 +17,8 @@ import Spinner from 'components/Spinner/Spinner';
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import { useAuth } from 'components/UserContext/UserContext';
 
-import { useResidents } from 'utils/api/residents';
+// import { useResidents } from 'utils/api/residents'
+import { SearchPerson } from 'utils/api/search';
 import { useCases } from 'utils/api/cases';
 import { getQueryString } from 'utils/urls';
 
@@ -81,13 +82,13 @@ const Search = ({
         return {
           SearchForm: SearchResidentsForm,
           SearchResults: ResidentsTable,
-          useSearch: useResidents,
+          useSearch: SearchPerson,
         };
       case 'relationship':
         return {
           SearchForm: SearchResidentsForm,
           SearchResults: RelationshipTable,
-          useSearch: useResidents,
+          useSearch: SearchPerson,
         };
     }
   }, [type, showOnlyMyResults, user?.email]);

--- a/components/Search/forms/SearchResidentsForm.spec.tsx
+++ b/components/Search/forms/SearchResidentsForm.spec.tsx
@@ -26,7 +26,7 @@ describe(`SearchResidentsForm`, () => {
       fireEvent.submit(getByRole('form'));
     });
     expect(props.onFormSubmit).toHaveBeenCalledWith({
-      full_name: 'foo',
+      name: 'foo',
       mosaic_id: '',
       postcode: '',
       date_of_birth: null,
@@ -35,13 +35,13 @@ describe(`SearchResidentsForm`, () => {
 
   it('should initialise the form with the passed defaultValues', async () => {
     const { getByRole } = render(
-      <SearchResidentsForm {...props} defaultValues={{ full_name: 'bar' }} />
+      <SearchResidentsForm {...props} defaultValues={{ name: 'bar' }} />
     );
     await act(async () => {
       fireEvent.submit(getByRole('form'));
     });
     expect(props.onFormSubmit).toHaveBeenCalledWith({
-      full_name: 'bar',
+      name: 'bar',
       mosaic_id: '',
       postcode: '',
       date_of_birth: null,

--- a/components/Search/forms/SearchResidentsForm.spec.tsx
+++ b/components/Search/forms/SearchResidentsForm.spec.tsx
@@ -19,15 +19,14 @@ describe(`SearchResidentsForm`, () => {
       <SearchResidentsForm {...props} />
     );
 
-    const firstNameInput = getByLabelText('First name');
-    fireEvent.change(firstNameInput, { target: { value: 'foo' } });
+    const fullNameInput = getByLabelText('Name');
+    fireEvent.change(fullNameInput, { target: { value: 'foo' } });
 
     await act(async () => {
       fireEvent.submit(getByRole('form'));
     });
     expect(props.onFormSubmit).toHaveBeenCalledWith({
-      first_name: 'foo',
-      last_name: '',
+      full_name: 'foo',
       mosaic_id: '',
       postcode: '',
       date_of_birth: null,
@@ -36,14 +35,13 @@ describe(`SearchResidentsForm`, () => {
 
   it('should initialise the form with the passed defaultValues', async () => {
     const { getByRole } = render(
-      <SearchResidentsForm {...props} defaultValues={{ first_name: 'bar' }} />
+      <SearchResidentsForm {...props} defaultValues={{ full_name: 'bar' }} />
     );
     await act(async () => {
       fireEvent.submit(getByRole('form'));
     });
     expect(props.onFormSubmit).toHaveBeenCalledWith({
-      first_name: 'bar',
-      last_name: '',
+      full_name: 'bar',
       mosaic_id: '',
       postcode: '',
       date_of_birth: null,

--- a/components/Search/forms/SearchResidentsForm.tsx
+++ b/components/Search/forms/SearchResidentsForm.tsx
@@ -7,9 +7,7 @@ import { TextInput, DateInput } from 'components/Form';
 import Button from 'components/Button/Button';
 
 interface FormValues {
-  first_name?: string;
-  last_name?: string;
-  full_name?: string;
+  name?: string;
   date_of_birth?: string | null;
   postcode?: string;
   mosaic_id?: string;
@@ -44,9 +42,9 @@ const SearchResidentsForm = ({
           <TextInput
             label="Name"
             labelSize="s"
-            name="full_name"
+            name="name"
             hint="This can be either a first or last name or both"
-            error={errors.full_name}
+            error={errors.name}
             register={register}
           />
         </div>

--- a/components/Search/forms/SearchResidentsForm.tsx
+++ b/components/Search/forms/SearchResidentsForm.tsx
@@ -18,7 +18,6 @@ interface Props {
   defaultValues: FormValues;
   ctaText?: string;
 }
-console.log('resident search form');
 
 const SearchResidentsForm = ({
   onFormSubmit,

--- a/components/Search/forms/SearchResidentsForm.tsx
+++ b/components/Search/forms/SearchResidentsForm.tsx
@@ -9,6 +9,7 @@ import Button from 'components/Button/Button';
 interface FormValues {
   first_name?: string;
   last_name?: string;
+  full_name?: string;
   date_of_birth?: string | null;
   postcode?: string;
   mosaic_id?: string;
@@ -19,6 +20,7 @@ interface Props {
   defaultValues: FormValues;
   ctaText?: string;
 }
+console.log('resident search form');
 
 const SearchResidentsForm = ({
   onFormSubmit,
@@ -38,21 +40,13 @@ const SearchResidentsForm = ({
   return (
     <form role="form" onSubmit={handleSubmit((data) => onFormSubmit(data))}>
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-one-half">
+        <div className="govuk-grid-column-three-quarters">
           <TextInput
-            label="First name"
+            label="Name"
             labelSize="s"
-            name="first_name"
-            error={errors.first_name}
-            register={register}
-          />
-        </div>
-        <div className="govuk-grid-column-one-half">
-          <TextInput
-            label="Last name"
-            labelSize="s"
-            name="last_name"
-            error={errors.last_name}
+            name="full_name"
+            hint="This can be either a first or last name or both"
+            error={errors.full_name}
             register={register}
           />
         </div>

--- a/cypress/integration/add_view_and_remove_relationship.ts
+++ b/cypress/integration/add_view_and_remove_relationship.ts
@@ -18,9 +18,7 @@ describe('Adding, viewing and remove a relationship', () => {
     cy.contains('Add a new relationship').click();
 
     // Search for related person
-    cy.get('input[name=first_name]').type(
-      Cypress.env('CHILDREN_RECORD_FIRST_NAME')
-    );
+    cy.get('input[name=name]').type(Cypress.env('CHILDREN_RECORD_FIRST_NAME'));
 
     cy.contains('button', 'Search').click();
 

--- a/cypress/integration/search_for_person.ts
+++ b/cypress/integration/search_for_person.ts
@@ -4,9 +4,7 @@ describe('Search for a person', () => {
   describe('As a user in the Childrens group', () => {
     it('should show a list that contains children records when a search is completed', () => {
       cy.visitAs('/search', AuthRoles.ChildrensGroup);
-
-      cy.contains('First name').type(Cypress.env('CHILDREN_RECORD_FIRST_NAME'));
-      cy.contains('Last name').type(Cypress.env('CHILDREN_RECORD_LAST_NAME'));
+      cy.contains('Name').type(Cypress.env('CHILDREN_RECORD_FULL_NAME'));
       cy.get('[type="submit"]').click();
 
       cy.get('[data-testid="residents-table"]').contains(
@@ -16,13 +14,13 @@ describe('Search for a person', () => {
       cy.get('[data-testid="residents-table"]').contains(
         Cypress.env('CHILDREN_RECORD_FULL_NAME')
       );
+
+      cy.contains('Load more').should('not.exist');
     });
 
     it('should show a list that contains adult records when a search is completed', () => {
       cy.visitAs('/search', AuthRoles.ChildrensGroup);
-
-      cy.contains('First name').type(Cypress.env('ADULT_RECORD_FIRST_NAME'));
-      cy.contains('Last name').type(Cypress.env('ADULT_RECORD_LAST_NAME'));
+      cy.contains('Name').type(Cypress.env('ADULT_RECORD_FULL_NAME'));
       cy.get('[type="submit"]').click();
 
       cy.get('[data-testid="residents-table"]').contains(
@@ -32,13 +30,14 @@ describe('Search for a person', () => {
       cy.get('[data-testid="residents-table"]').contains(
         Cypress.env('ADULT_RECORD_FULL_NAME')
       );
+
+      cy.contains('Load more').should('not.exist');
     });
 
     it('should not redirect to login page after clicking "clear search" twice', () => {
       cy.visitAs('/search', AuthRoles.ChildrensGroup);
 
-      cy.contains('First name').type(Cypress.env('ADULT_RECORD_FIRST_NAME'));
-      cy.contains('Last name').type(Cypress.env('ADULT_RECORD_LAST_NAME'));
+      cy.contains('Name').type(Cypress.env('ADULT_RECORD_FULL_NAME'));
 
       cy.get('#clear-link').click();
       cy.get('#clear-link').click();
@@ -51,8 +50,7 @@ describe('Search for a person', () => {
     it('should show a list that contains children records when a search is completed', () => {
       cy.visitAs('/search', AuthRoles.AdultsGroup);
 
-      cy.contains('First name').type(Cypress.env('CHILDREN_RECORD_FIRST_NAME'));
-      cy.contains('Last name').type(Cypress.env('CHILDREN_RECORD_LAST_NAME'));
+      cy.contains('Name').type(Cypress.env('CHILDREN_RECORD_FULL_NAME'));
       cy.get('[type="submit"]').click();
 
       cy.get('[data-testid="residents-table"]').contains(
@@ -62,13 +60,13 @@ describe('Search for a person', () => {
       cy.get('[data-testid="residents-table"]').contains(
         Cypress.env('CHILDREN_RECORD_FULL_NAME')
       );
+      cy.contains('Load more').should('not.exist');
     });
 
     it('should show a list that contains adult records when a search is completed', () => {
       cy.visitAs('/search', AuthRoles.AdultsGroup);
 
-      cy.contains('First name').type(Cypress.env('ADULT_RECORD_FIRST_NAME'));
-      cy.contains('Last name').type(Cypress.env('ADULT_RECORD_LAST_NAME'));
+      cy.contains('Name').type(Cypress.env('ADULT_RECORD_FULL_NAME'));
       cy.get('[type="submit"]').click();
 
       cy.get('[data-testid="residents-table"]').contains(
@@ -78,6 +76,7 @@ describe('Search for a person', () => {
       cy.get('[data-testid="residents-table"]').contains(
         Cypress.env('ADULT_RECORD_FULL_NAME')
       );
+      cy.contains('Load more').should('not.exist');
     });
   });
 
@@ -89,28 +88,30 @@ describe('Search for a person', () => {
       cy.get('[type="submit"]').click();
       cy.get('td a').click();
       cy.contains(Cypress.env('NAME_FOR_MOSAIC_ID_TEST')).should('be.visible');
+      cy.contains('Load more').should('not.exist');
     });
 
     it('should show a list that contains adult records when a search is completed', () => {
       cy.visitAs('/search', AuthRoles.AdminDevGroup);
 
-      cy.contains('First name').type(Cypress.env('ADULT_RECORD_FIRST_NAME'));
-      cy.contains('Last name').type(Cypress.env('ADULT_RECORD_LAST_NAME'));
+      cy.contains('Name').type(Cypress.env('ADULT_RECORD_FULL_NAME'));
       cy.get('form').submit();
       cy.contains(Cypress.env('ADULT_RECORD_FULL_NAME')).should('be.visible');
+      cy.contains('Load more').should('not.exist');
     });
 
-    it('should show a list that contains children records when a search is completed', () => {
+    it.only('should show a list that contains children records when a search is completed', () => {
       cy.visitAs('/search', AuthRoles.AdminDevGroup);
 
-      cy.contains('First name').type(Cypress.env('CHILDREN_RECORD_FIRST_NAME'));
-      cy.contains('Last name').type(Cypress.env('CHILDREN_RECORD_LAST_NAME'));
+      cy.contains('Name').type(Cypress.env('CHILDREN_RECORD_FULL_NAME'));
       cy.get('[type="submit"]').click();
       cy.contains(
         `${Cypress.env('CHILDREN_RECORD_FIRST_NAME')} ${Cypress.env(
           'CHILDREN_RECORD_LAST_NAME'
         )}`
-      ).click();
+      );
+      cy.contains('Load more').should('not.exist');
+      cy.contains(Cypress.env('CHILDREN_RECORD_FULL_NAME')).click();
       cy.contains(Cypress.env('CHILDREN_RECORD_FULL_NAME')).should(
         'be.visible'
       );

--- a/cypress/integration/search_for_person.ts
+++ b/cypress/integration/search_for_person.ts
@@ -100,7 +100,7 @@ describe('Search for a person', () => {
       cy.contains('Load more').should('not.exist');
     });
 
-    it.only('should show a list that contains children records when a search is completed', () => {
+    it('should show a list that contains children records when a search is completed', () => {
       cy.visitAs('/search', AuthRoles.AdminDevGroup);
 
       cy.contains('Name').type(Cypress.env('CHILDREN_RECORD_FULL_NAME'));
@@ -115,6 +115,59 @@ describe('Search for a person', () => {
       cy.contains(Cypress.env('CHILDREN_RECORD_FULL_NAME')).should(
         'be.visible'
       );
+    });
+
+    describe('test fuzzy name search', () => {
+      it('should return correct person when one letter wrong in first name', () => {
+        cy.visitAs('/search', AuthRoles.AdminDevGroup);
+
+        cy.contains('Name').type('Cristoball');
+        cy.get('[type="submit"]').click();
+
+        cy.get('[data-testid="residents-table"]').contains(
+          Cypress.env('CHILDREN_RECORD_PERSON_ID')
+        );
+
+        cy.get('[data-testid="residents-table"]').contains(
+          Cypress.env('CHILDREN_RECORD_FULL_NAME')
+        );
+
+        cy.contains('Load more').should('not.exist');
+      });
+
+      it('should return correct person when one letter incorrect in first name & one letter incorrect in last name', () => {
+        cy.visitAs('/search', AuthRoles.AdminDevGroup);
+
+        cy.contains('Name').type('Cristubal CawFell');
+        cy.get('[type="submit"]').click();
+
+        cy.get('[data-testid="residents-table"]').contains(
+          Cypress.env('CHILDREN_RECORD_PERSON_ID')
+        );
+
+        cy.get('[data-testid="residents-table"]').contains(
+          Cypress.env('CHILDREN_RECORD_FULL_NAME')
+        );
+
+        cy.contains('Load more').should('not.exist');
+      });
+
+      it.only('should return correct person when we have 2 persons with same name but different date of birth', () => {
+        cy.visitAs('/search', AuthRoles.AdminDevGroup);
+
+        cy.contains('Name').type('Qumendus');
+        cy.get('input[name=date_of_birth-day]').type('01');
+        cy.get('input[name=date_of_birth-month]').type('06');
+        cy.get('input[name=date_of_birth-year]').type('2000');
+        cy.get('[type="submit"]').click();
+
+        cy.get('[data-testid="residents-table"]').contains('Qumendus Quality');
+
+        cy.get('[data-testid="residents-table"]').contains('50000362');
+        cy.get('[data-testid="residents-table"]')
+          .contains('Qumendus Quality')
+          .should('have.length', 1);
+      });
     });
   });
 });

--- a/factories/search.ts
+++ b/factories/search.ts
@@ -1,0 +1,22 @@
+import { Factory } from 'fishery';
+import { ResidentsAPI, LegacyResident } from 'types';
+
+export const legacyResidentFactory = Factory.define<LegacyResident>(
+  ({ sequence }) => ({
+    mosaicId: String(sequence),
+    dateOfBirth: '2020-11-13',
+    firstName: 'Foo',
+    lastName: 'Bar',
+    nhsNumber: '12345',
+    ageContext: 'A',
+    gender: 'F',
+  })
+);
+
+export const mockResidentAPIFactory = Factory.define<ResidentsAPI>(() => ({
+  residents: [legacyResidentFactory.build()],
+  nextCursor: '20',
+  totalCount: '300',
+}));
+
+export const mockResponseApi = mockResidentAPIFactory.build();

--- a/lib/search.spec.ts
+++ b/lib/search.spec.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import * as searchAPI from './search';
+import { mockedLegacyResident } from 'factories/residents';
+
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock('axios');
+
+describe('search APIs', () => {
+  describe('searchPerson', () => {
+    it("calls the service API's search person endpoint", async () => {
+      mockedAxios.get.mockResolvedValue({
+        data: [mockedLegacyResident],
+      });
+
+      const data = await searchAPI.searchPerson(
+        {
+          foo: 'bar',
+        },
+        'A'
+      );
+
+      expect(mockedAxios.get).toHaveBeenCalled();
+      expect(mockedAxios.get.mock.calls[0][0]).toEqual(
+        `${ENDPOINT_API}/search/person`
+      );
+      expect(mockedAxios.get.mock.calls[0][1]?.headers).toEqual({
+        'x-api-key': AWS_KEY,
+      });
+      expect(data).toEqual([mockedLegacyResident]);
+    });
+  });
+});

--- a/lib/search.spec.ts
+++ b/lib/search.spec.ts
@@ -21,7 +21,7 @@ describe('search APIs', () => {
 
       expect(mockedAxios.get).toHaveBeenCalled();
       expect(mockedAxios.get.mock.calls[0][0]).toEqual(
-        `${ENDPOINT_API}/search?foo=bar`
+        `${ENDPOINT_API}/search/person?foo=bar`
       );
       expect(mockedAxios.get.mock.calls[0][1]?.headers).toEqual({
         'x-api-key': AWS_KEY,

--- a/lib/search.spec.ts
+++ b/lib/search.spec.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import * as searchAPI from './search';
-import { mockedLegacyResident } from 'factories/residents';
+import { mockResponseApi } from 'factories/search';
 
 const ENDPOINT_API = process.env.ENDPOINT_API;
 const AWS_KEY = process.env.AWS_KEY;
@@ -12,24 +12,21 @@ describe('search APIs', () => {
   describe('searchPerson', () => {
     it("calls the service API's search person endpoint", async () => {
       mockedAxios.get.mockResolvedValue({
-        data: [mockedLegacyResident],
+        data: mockResponseApi,
       });
 
-      const data = await searchAPI.searchPerson(
-        {
-          foo: 'bar',
-        },
-        'A'
-      );
+      const data = await searchAPI.searchPerson({
+        foo: 'bar',
+      });
 
       expect(mockedAxios.get).toHaveBeenCalled();
       expect(mockedAxios.get.mock.calls[0][0]).toEqual(
-        `${ENDPOINT_API}/search/person`
+        `${ENDPOINT_API}/search?foo=bar`
       );
       expect(mockedAxios.get.mock.calls[0][1]?.headers).toEqual({
         'x-api-key': AWS_KEY,
       });
-      expect(data).toEqual([mockedLegacyResident]);
+      expect(data).toEqual(mockResponseApi);
     });
   });
 });

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -29,13 +29,74 @@ const sanitiseResidentData = (residents: ResidentBE[]): LegacyResident[] =>
     };
   });
 
+const searchUrlParameters = (
+  name?: string,
+  dateOfBirth?: string,
+  postcode?: string,
+  personId?: string,
+  cursor?: string
+) => {
+  let queryString = '';
+
+  name
+    ? (queryString = queryString.concat(
+        queryString ? '&' : '?',
+        `name=${name}`
+      ))
+    : '';
+  dateOfBirth
+    ? (queryString = queryString.concat(
+        queryString ? '&' : '?',
+        `date_of_birth=${dateOfBirth}`
+      ))
+    : '';
+  postcode
+    ? (queryString = queryString.concat(
+        queryString ? '&' : '?',
+        `postcode=${postcode}`
+      ))
+    : '';
+  personId
+    ? (queryString = queryString.concat(
+        queryString ? '&' : '?',
+        `person_id=${personId}`
+      ))
+    : '';
+  cursor
+    ? (queryString = queryString.concat(
+        queryString ? '&' : '?',
+        `cursor=${cursor}`
+      ))
+    : (queryString = queryString.concat(queryString ? '&' : '?', `cursor=0`));
+
+  console.log('URL Parameters', queryString);
+
+  return queryString;
+};
+
 export const searchPerson = async (
-  params: Record<string, unknown>,
-  contextFlag?: string
+  name?: string,
+  dateOfBirth?: string,
+  postcode?: string,
+  personId?: string,
+  cursor?: string
 ): Promise<ResidentsAPI> => {
-  const { data } = await axios.get(`${ENDPOINT_API}/search/person`, {
-    headers,
-    params: { ...params, contextFlag },
-  });
+  const urlParms = searchUrlParameters(
+    name,
+    dateOfBirth,
+    postcode,
+    personId,
+    cursor
+  );
+  console.log(
+    `https://virtserver.swaggerhub.com/Hackney/social-care-case-viewer-api/1.0.0/search${urlParms}`
+  );
+  const { data } = await axios.get(
+    `
+    https://virtserver.swaggerhub.com/Hackney/social-care-case-viewer-api/1.0.0/search${urlParms}`,
+    {
+      headers,
+    }
+  );
   return { ...data, residents: sanitiseResidentData(data.residents) };
 };

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import type { ResidentsAPI, LegacyResident } from 'types';
+import { getQueryString } from 'utils/urls';
 
 const ENDPOINT_API = process.env.ENDPOINT_API;
 const AWS_KEY = process.env.AWS_KEY;
@@ -29,71 +30,11 @@ const sanitiseResidentData = (residents: ResidentBE[]): LegacyResident[] =>
     };
   });
 
-const searchUrlParameters = (
-  name?: string,
-  dateOfBirth?: string,
-  postcode?: string,
-  personId?: string,
-  cursor?: string
-) => {
-  let queryString = '';
-
-  name
-    ? (queryString = queryString.concat(
-        queryString ? '&' : '?',
-        `name=${name}`
-      ))
-    : '';
-  dateOfBirth
-    ? (queryString = queryString.concat(
-        queryString ? '&' : '?',
-        `date_of_birth=${dateOfBirth}`
-      ))
-    : '';
-  postcode
-    ? (queryString = queryString.concat(
-        queryString ? '&' : '?',
-        `postcode=${postcode}`
-      ))
-    : '';
-  personId
-    ? (queryString = queryString.concat(
-        queryString ? '&' : '?',
-        `person_id=${personId}`
-      ))
-    : '';
-  cursor
-    ? (queryString = queryString.concat(
-        queryString ? '&' : '?',
-        `cursor=${cursor}`
-      ))
-    : (queryString = queryString.concat(queryString ? '&' : '?', `cursor=0`));
-
-  console.log('URL Parameters', queryString);
-
-  return queryString;
-};
-
 export const searchPerson = async (
-  name?: string,
-  dateOfBirth?: string,
-  postcode?: string,
-  personId?: string,
-  cursor?: string
+  parameters: Record<string, unknown>
 ): Promise<ResidentsAPI> => {
-  const urlParms = searchUrlParameters(
-    name,
-    dateOfBirth,
-    postcode,
-    personId,
-    cursor
-  );
-  console.log(
-    `https://virtserver.swaggerhub.com/Hackney/social-care-case-viewer-api/1.0.0/search${urlParms}`
-  );
   const { data } = await axios.get(
-    `
-    https://virtserver.swaggerhub.com/Hackney/social-care-case-viewer-api/1.0.0/search${urlParms}`,
+    `${ENDPOINT_API}/search?${getQueryString(parameters)}`,
     {
       headers,
     }

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,20 @@
+import axios from 'axios';
+import type { SearchData } from 'types';
+
+const ENDPOINT_API = process.env.ENDPOINT_API;
+const AWS_KEY = process.env.AWS_KEY;
+const headers = { 'x-api-key': AWS_KEY };
+
+export const searchPerson = async (
+  params: Record<string, unknown>,
+  contextFlag?: string
+): Promise<SearchData | []> => {
+  const { data }: { data: SearchData } = await axios.get(
+    `${ENDPOINT_API}/search/person`,
+    {
+      headers,
+      params: { ...params, contextFlag },
+    }
+  );
+  return data;
+};

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -34,7 +34,7 @@ export const searchPerson = async (
   parameters: Record<string, unknown>
 ): Promise<ResidentsAPI> => {
   const { data } = await axios.get(
-    `${ENDPOINT_API}/search?${getQueryString(parameters)}`,
+    `${ENDPOINT_API}/search/person?${getQueryString(parameters)}`,
     {
       headers,
     }

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { SearchData } from 'types';
+import type { ResidentsAPI } from 'types';
 
 const ENDPOINT_API = process.env.ENDPOINT_API;
 const AWS_KEY = process.env.AWS_KEY;
@@ -8,8 +8,8 @@ const headers = { 'x-api-key': AWS_KEY };
 export const searchPerson = async (
   params: Record<string, unknown>,
   contextFlag?: string
-): Promise<SearchData | []> => {
-  const { data }: { data: SearchData } = await axios.get(
+): Promise<ResidentsAPI | []> => {
+  const { data }: { data: ResidentsAPI } = await axios.get(
     `${ENDPOINT_API}/search/person`,
     {
       headers,

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,20 +1,41 @@
 import axios from 'axios';
-import type { ResidentsAPI } from 'types';
+import type { ResidentsAPI, LegacyResident } from 'types';
 
 const ENDPOINT_API = process.env.ENDPOINT_API;
 const AWS_KEY = process.env.AWS_KEY;
 const headers = { 'x-api-key': AWS_KEY };
 
+interface ResidentBE extends LegacyResident {
+  addressList: Array<{
+    displayAddressFlag: 'Y' | 'N';
+    addressLine1: string;
+    postCode: string;
+    uprn: string;
+  }>;
+}
+
+const sanitiseResidentData = (residents: ResidentBE[]): LegacyResident[] =>
+  residents?.map(({ addressList, ...resident }: ResidentBE): LegacyResident => {
+    const address = addressList?.find(
+      ({ displayAddressFlag }) => displayAddressFlag === 'Y'
+    );
+    return {
+      ...resident,
+      address: address && {
+        address: address.addressLine1,
+        postcode: address.postCode,
+        uprn: address.uprn,
+      },
+    };
+  });
+
 export const searchPerson = async (
   params: Record<string, unknown>,
   contextFlag?: string
-): Promise<ResidentsAPI | []> => {
-  const { data }: { data: ResidentsAPI } = await axios.get(
-    `${ENDPOINT_API}/search/person`,
-    {
-      headers,
-      params: { ...params, contextFlag },
-    }
-  );
-  return data;
+): Promise<ResidentsAPI> => {
+  const { data } = await axios.get(`${ENDPOINT_API}/search/person`, {
+    headers,
+    params: { ...params, contextFlag },
+  });
+  return { ...data, residents: sanitiseResidentData(data.residents) };
 };

--- a/pages/api/search/person/index.ts
+++ b/pages/api/search/person/index.ts
@@ -1,0 +1,48 @@
+import { StatusCodes } from 'http-status-codes';
+
+import { searchPerson } from 'lib/search';
+import { isAuthorised } from 'utils/auth';
+
+import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
+import { AxiosError } from 'axios';
+import { apiHandler } from 'lib/apiHandler';
+
+const endpoint: NextApiHandler = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
+  const user = isAuthorised(req);
+  if (!user) {
+    return res.status(StatusCodes.UNAUTHORIZED).end();
+  }
+  if (!user.isAuthorised) {
+    return res.status(StatusCodes.FORBIDDEN).end();
+  }
+
+  switch (req.method) {
+    case 'GET':
+      try {
+        const data = await searchPerson(req.query);
+        res.status(StatusCodes.OK).json(data);
+      } catch (error) {
+        console.error(
+          'Search get error:',
+          (error as AxiosError)?.response?.data
+        );
+        (error as AxiosError)?.response?.status === StatusCodes.NOT_FOUND
+          ? res
+              .status(StatusCodes.NOT_FOUND)
+              .json({ message: 'Residents Not Found' })
+          : res
+              .status(StatusCodes.INTERNAL_SERVER_ERROR)
+              .json({ message: 'Unable to get the Residents' });
+      }
+      break;
+    default:
+      res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: 'Invalid request method' });
+  }
+};
+
+export default apiHandler(endpoint);

--- a/pages/api/search/person/index.ts
+++ b/pages/api/search/person/index.ts
@@ -21,16 +21,8 @@ const endpoint: NextApiHandler = async (
 
   switch (req.method) {
     case 'GET':
-      console.log('request in api/search/person ', req.query);
-
       try {
-        const data = await searchPerson(
-          req.query.name as string,
-          req.query.date_of_birth as string,
-          req.query.postcode as string,
-          req.query.mosaic_id as string,
-          req.query.cursor as string
-        );
+        const data = await searchPerson(req.query);
         res.status(StatusCodes.OK).json(data);
       } catch (error) {
         console.error(

--- a/pages/api/search/person/index.ts
+++ b/pages/api/search/person/index.ts
@@ -21,8 +21,16 @@ const endpoint: NextApiHandler = async (
 
   switch (req.method) {
     case 'GET':
+      console.log('request in api/search/person ', req.query);
+
       try {
-        const data = await searchPerson(req.query);
+        const data = await searchPerson(
+          req.query.name as string,
+          req.query.date_of_birth as string,
+          req.query.postcode as string,
+          req.query.mosaic_id as string,
+          req.query.cursor as string
+        );
         res.status(StatusCodes.OK).json(data);
       } catch (error) {
         console.error(

--- a/types.ts
+++ b/types.ts
@@ -156,6 +156,7 @@ export interface LegacyResident {
 export interface ResidentsAPI {
   residents: LegacyResident[] | [];
   nextCursor?: string;
+  totalCount?: string;
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -610,7 +610,3 @@ export interface Resident {
   ageContext?: AgeContext;
   addresses?: LegacyAddress[];
 }
-
-export interface SearchData {
-  records: LegacyResident[];
-}

--- a/types.ts
+++ b/types.ts
@@ -610,3 +610,7 @@ export interface Resident {
   ageContext?: AgeContext;
   addresses?: LegacyAddress[];
 }
+
+export interface SearchData {
+  records: LegacyResident[];
+}

--- a/utils/api/search.spec.ts
+++ b/utils/api/search.spec.ts
@@ -12,7 +12,7 @@ describe('searchAPI', () => {
       .spyOn(SWR, 'useSWRInfinite')
       .mockImplementation(
         (getKey: (page: number, data: Record<string, unknown>) => string) =>
-          mockSWRInfinite(getKey(0, { person: [] }))
+          mockSWRInfinite(getKey(0, { residents: [] }))
       );
     searchAPI.SearchPerson({
       foo: 'bar',

--- a/utils/api/search.spec.ts
+++ b/utils/api/search.spec.ts
@@ -1,0 +1,22 @@
+import * as searchAPI from './search';
+import * as SWR from 'swr';
+
+jest.mock('axios');
+jest.mock('swr');
+
+const mockSWRInfinite = jest.fn();
+
+describe('searchAPI', () => {
+  it('should work properly', async () => {
+    jest
+      .spyOn(SWR, 'useSWRInfinite')
+      .mockImplementation(
+        (getKey: (page: number, data: Record<string, unknown>) => string) =>
+          mockSWRInfinite(getKey(0, { person: [] }))
+      );
+    searchAPI.SearchPerson({
+      foo: 'bar',
+    });
+    expect(mockSWRInfinite).toHaveBeenCalledWith('/api/search/person?foo=bar');
+  });
+});

--- a/utils/api/search.ts
+++ b/utils/api/search.ts
@@ -6,7 +6,6 @@ export const SearchPerson = (
   params: Record<string, unknown>,
   invoke = true
 ): SWRInfiniteResponse<Record<string, unknown>, Error> => {
-  console.log('searchPerson utils/api ', params);
   return useSWRInfinite(
     // @ts-ignore
     invoke ? getInfiniteKey('/api/search/person', 'person', params) : null

--- a/utils/api/search.ts
+++ b/utils/api/search.ts
@@ -8,6 +8,6 @@ export const SearchPerson = (
 ): SWRInfiniteResponse<Record<string, unknown>, Error> => {
   return useSWRInfinite(
     // @ts-ignore
-    invoke ? getInfiniteKey('/api/search/person', 'person', params) : null
+    invoke ? getInfiniteKey('/api/search/person', 'residents', params) : null
   );
 };

--- a/utils/api/search.ts
+++ b/utils/api/search.ts
@@ -5,8 +5,10 @@ import { getInfiniteKey } from 'utils/api';
 export const SearchPerson = (
   params: Record<string, unknown>,
   invoke = true
-): SWRInfiniteResponse<Record<string, unknown>, Error> =>
-  useSWRInfinite(
+): SWRInfiniteResponse<Record<string, unknown>, Error> => {
+  console.log('searchPerson utils/api ', params);
+  return useSWRInfinite(
     // @ts-ignore
     invoke ? getInfiniteKey('/api/search/person', 'person', params) : null
   );
+};

--- a/utils/api/search.ts
+++ b/utils/api/search.ts
@@ -1,0 +1,12 @@
+import { useSWRInfinite, SWRInfiniteResponse } from 'swr';
+
+import { getInfiniteKey } from 'utils/api';
+
+export const SearchPerson = (
+  params: Record<string, unknown>,
+  invoke = true
+): SWRInfiniteResponse<Record<string, unknown>, Error> =>
+  useSWRInfinite(
+    // @ts-ignore
+    invoke ? getInfiniteKey('/api/search/person', 'person', params) : null
+  );


### PR DESCRIPTION
**What**  
* Combined the first name and last name search boxes, so there is now just one person name search box when looking for a person or adding a relationship
* Updated tests to input information into this new search box
* Added new search endpoint that will be used when searching for a person or adding a relationship

![image](https://user-images.githubusercontent.com/32848419/157489131-77e14042-9c36-4bb2-a47d-350dd9bd89d3.png)


**Why**  
This change was made to allow for fuzzy searching on a persons name. This means that users could misspell a person's name and still be able to find the person they are looking for.

**Anything else?**
This depends on [this PR](https://github.com/LBHackney-IT/social-care-case-viewer-api/pull/595) which adds the new endpoint in the backend
