### PR TITLE
fix(SCT-1737): Change from using mosaic_id to person_id in the front end search

### DIFF
--- a/components/Search/forms/SearchResidentsForm.spec.tsx
+++ b/components/Search/forms/SearchResidentsForm.spec.tsx
@@ -27,7 +27,7 @@ describe(`SearchResidentsForm`, () => {
     });
     expect(props.onFormSubmit).toHaveBeenCalledWith({
       name: 'foo',
-      mosaic_id: '',
+      person_id: '',
       postcode: '',
       date_of_birth: null,
     });
@@ -42,7 +42,7 @@ describe(`SearchResidentsForm`, () => {
     });
     expect(props.onFormSubmit).toHaveBeenCalledWith({
       name: 'bar',
-      mosaic_id: '',
+      person_id: '',
       postcode: '',
       date_of_birth: null,
     });

--- a/components/Search/forms/SearchResidentsForm.tsx
+++ b/components/Search/forms/SearchResidentsForm.tsx
@@ -10,7 +10,7 @@ interface FormValues {
   name?: string;
   date_of_birth?: string | null;
   postcode?: string;
-  mosaic_id?: string;
+  person_id?: string;
 }
 
 interface Props {
@@ -89,11 +89,11 @@ const SearchResidentsForm = ({
           <TextInput
             label="Social care ID"
             labelSize="s"
-            name="mosaic_id"
+            name="person_id"
             hint="e.g. 1234567890"
             inputClassName="govuk-input--width-10"
             inputMode="numeric"
-            error={errors.mosaic_id}
+            error={errors.person_id}
             register={register}
           />
         </div>

--- a/components/Tabs/Tabs.spec.tsx
+++ b/components/Tabs/Tabs.spec.tsx
@@ -41,4 +41,39 @@ describe(`Tabs`, () => {
       expect(updatedQuery.mosaic_id).toBe(undefined);
     }
   });
+  it('should remove name if a name is present and the url is /cases', () => {
+    const query = { person_id: 123, name: 'tom' } as unknown as ParsedUrlQuery;
+    const updatedQuery = updateQuery(query, '/cases');
+    if (updatedQuery) {
+      expect(updatedQuery.mosaic_id).toBe(123);
+      expect(updatedQuery.name).toBe(undefined);
+    }
+  });
+  it('should remove name, date of birth and postcode if they are present and the url is /cases', () => {
+    const query = {
+      person_id: 123,
+      name: 'tom',
+      date_of_birth: '22-01-2022',
+      postcode: 'N1 1QA',
+    } as unknown as ParsedUrlQuery;
+    const updatedQuery = updateQuery(query, '/cases');
+    if (updatedQuery) {
+      expect(updatedQuery.mosaic_id).toBe(123);
+      expect(updatedQuery.name).toBe(undefined);
+    }
+  });
+  it('should not remove name, date of birth and postcode if they are present and the url is /search', () => {
+    const query = {
+      person_id: 123,
+      name: 'tom',
+      date_of_birth: '22-01-2022',
+      postcode: 'N1 1QA',
+    } as unknown as ParsedUrlQuery;
+    const updatedQuery = updateQuery(query, '/search');
+    if (updatedQuery) {
+      expect(updatedQuery.name).toBe('tom');
+      expect(updatedQuery.date_of_birth).toBe('22-01-2022');
+      expect(updatedQuery.postcode).toBe('N1 1QA');
+    }
+  });
 });

--- a/components/Tabs/Tabs.spec.tsx
+++ b/components/Tabs/Tabs.spec.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
-
+import { ParsedUrlQuery } from 'querystring';
 import Tabs from './Tabs';
+import { updateQuery } from './Tabs';
 
 const mockedUseRouter = { pathname: '/foo' };
 
@@ -24,5 +25,13 @@ describe(`Tabs`, () => {
   it('should render properly', () => {
     const { asFragment } = render(<Tabs {...props} />);
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should add mosaic_id if a person_id is present and the url is /cases', () => {
+    const query = { person_id: 123 } as unknown as ParsedUrlQuery;
+    const updatedQuery = updateQuery(query, '/cases');
+    if (updatedQuery) {
+      expect(updatedQuery.mosaic_id).toBe(123);
+    }
   });
 });

--- a/components/Tabs/Tabs.spec.tsx
+++ b/components/Tabs/Tabs.spec.tsx
@@ -34,4 +34,11 @@ describe(`Tabs`, () => {
       expect(updatedQuery.mosaic_id).toBe(123);
     }
   });
+  it('should not add mosaic_id if a person_id is present and the url is /search', () => {
+    const query = { person_id: 123 } as unknown as ParsedUrlQuery;
+    const updatedQuery = updateQuery(query, '/search');
+    if (updatedQuery) {
+      expect(updatedQuery.mosaic_id).toBe(undefined);
+    }
+  });
 });

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -16,18 +16,23 @@ export interface Props {
 }
 
 const updateQuery = (query: ParsedUrlQuery, url: string) => {
-  console.log('url & query', url, query);
   if (query) {
-    const updatedQuery = query;
+    const updatedQuery: ParsedUrlQuery = { ...query };
     if (url == '/cases') {
       if (query.person_id && !query.mosaic_id) {
-        console.log('ding');
         updatedQuery.mosaic_id = query.person_id;
-        console.log('updated query', updatedQuery);
       }
       if (!query.person_id && query.mosaic_id) {
-        console.log('dong');
         delete updatedQuery.mosaic_id;
+      }
+      if (updatedQuery.name) {
+        delete updatedQuery.name;
+      }
+      if (updatedQuery.date_of_birth) {
+        delete updatedQuery.date_of_birth;
+      }
+      if (updatedQuery.postcode) {
+        delete updatedQuery.postcode;
       }
     }
     return updatedQuery;

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -27,7 +27,7 @@ const Tabs = ({ title, tabs, children }: Props): React.ReactElement => {
               [s.active]: pathname === url,
             })}
           >
-            <Link href={{ pathname: url, query: query }} scroll={false}>
+            <Link href={{ pathname: url }} scroll={false}>
               <a className={`lbh-link lbh-link--no-visited-state ${s.link}`}>
                 {text}
               </a>

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -46,8 +46,6 @@ export const updateQuery = (
 
 const Tabs = ({ title, tabs, children }: Props): React.ReactElement => {
   const { pathname, query } = useRouter();
-  console.log(pathname);
-  console.log(query);
   return (
     <div className="govuk-tabs lbh-tabs">
       <h2 className="govuk-tabs__title">{title}</h2>

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -2,6 +2,7 @@ import cx from 'classnames';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import s from './Tabs.module.scss';
+import { ParsedUrlQuery } from 'querystring';
 
 interface Tab {
   url: string;
@@ -14,8 +15,21 @@ export interface Props {
   children: React.ReactChild;
 }
 
+const updateQuery = (query: ParsedUrlQuery) => {
+  if (query && url == '/search') {
+    return query.replace('moasic_id', 'person_id');
+  }
+  if (query && url == '/cases') {
+    return query.replace('person_id', 'moasic_id');
+  } else {
+    return undefined;
+  }
+};
+
 const Tabs = ({ title, tabs, children }: Props): React.ReactElement => {
   const { pathname, query } = useRouter();
+  console.log(pathname);
+  console.log(query);
   return (
     <div className="govuk-tabs lbh-tabs">
       <h2 className="govuk-tabs__title">{title}</h2>
@@ -27,7 +41,10 @@ const Tabs = ({ title, tabs, children }: Props): React.ReactElement => {
               [s.active]: pathname === url,
             })}
           >
-            <Link href={{ pathname: url }} scroll={false}>
+            <Link
+              href={{ pathname: url, query: updateQuery(query) }}
+              scroll={false}
+            >
               <a className={`lbh-link lbh-link--no-visited-state ${s.link}`}>
                 {text}
               </a>

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -15,12 +15,22 @@ export interface Props {
   children: React.ReactChild;
 }
 
-const updateQuery = (query: ParsedUrlQuery) => {
-  if (query && url == '/search') {
-    return query.replace('moasic_id', 'person_id');
-  }
-  if (query && url == '/cases') {
-    return query.replace('person_id', 'moasic_id');
+const updateQuery = (query: ParsedUrlQuery, url: string) => {
+  console.log('url & query', url, query);
+  if (query) {
+    const updatedQuery = query;
+    if (url == '/cases') {
+      if (query.person_id && !query.mosaic_id) {
+        console.log('ding');
+        updatedQuery.mosaic_id = query.person_id;
+        console.log('updated query', updatedQuery);
+      }
+      if (!query.person_id && query.mosaic_id) {
+        console.log('dong');
+        delete updatedQuery.mosaic_id;
+      }
+    }
+    return updatedQuery;
   } else {
     return undefined;
   }
@@ -42,7 +52,7 @@ const Tabs = ({ title, tabs, children }: Props): React.ReactElement => {
             })}
           >
             <Link
-              href={{ pathname: url, query: updateQuery(query) }}
+              href={{ pathname: url, query: updateQuery(query, url) }}
               scroll={false}
             >
               <a className={`lbh-link lbh-link--no-visited-state ${s.link}`}>

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -15,7 +15,10 @@ export interface Props {
   children: React.ReactChild;
 }
 
-const updateQuery = (query: ParsedUrlQuery, url: string) => {
+export const updateQuery = (
+  query: ParsedUrlQuery,
+  url: string
+): ParsedUrlQuery | undefined => {
   if (query) {
     const updatedQuery: ParsedUrlQuery = { ...query };
     if (url == '/cases') {

--- a/cypress/integration/search_for_person.ts
+++ b/cypress/integration/search_for_person.ts
@@ -84,7 +84,7 @@ describe('Search for a person', () => {
     it('show a list of records that match the Mosaic ID when a search is completed', () => {
       cy.visitAs('/search', AuthRoles.AdminDevGroup);
 
-      cy.get('[data-testid="mosaic_id"]').type(Cypress.env('MOSAIC_ID_TEST'));
+      cy.get('[data-testid="person_id"]').type(Cypress.env('MOSAIC_ID_TEST'));
       cy.get('[type="submit"]').click();
       cy.get('td a').click();
       cy.contains(Cypress.env('NAME_FOR_MOSAIC_ID_TEST')).should('be.visible');
@@ -138,7 +138,7 @@ describe('Search for a person', () => {
       it('should return correct person when one letter incorrect in first name & one letter incorrect in last name', () => {
         cy.visitAs('/search', AuthRoles.AdminDevGroup);
 
-        cy.contains('Name').type('Cristubal CawFell');
+        cy.contains('Name').type('Cristbal Cawdel');
         cy.get('[type="submit"]').click();
 
         cy.get('[data-testid="residents-table"]').contains(
@@ -152,7 +152,7 @@ describe('Search for a person', () => {
         cy.contains('Load more').should('not.exist');
       });
 
-      it.only('should return correct person when we have 2 persons with same name but different date of birth', () => {
+      it('should return correct person when we have 2 persons with same name but different date of birth', () => {
         cy.visitAs('/search', AuthRoles.AdminDevGroup);
 
         cy.contains('Name').type('Qumendus');


### PR DESCRIPTION
**What**  
Update the frontend to have the name person_id for the field used to search for a specific id

**Why**  
The frontend was passing mosaic_id to the new search endpoint, however the end point was expecting person_id

**Anything else?**
Altered the query that is passed when switching from person search to record search. Now only the person_id will be passed between the two searches
