### PR TITLE
feat(SCT-1756): stop combining first and last name on search

### DIFF
--- a/utils/api/search.ts
+++ b/utils/api/search.ts
@@ -6,22 +6,8 @@ export const SearchPerson = (
   params: Record<string, unknown>,
   invoke = true
 ): SWRInfiniteResponse<Record<string, unknown>, Error> => {
-  const internal_params = Object.assign({}, params);
-
-  if (internal_params.first_name || internal_params.last_name) {
-    const first_name = internal_params.first_name;
-    const last_name = internal_params.last_name;
-
-    delete internal_params.first_name;
-    delete internal_params.last_name;
-
-    internal_params.name = `${first_name ?? ''} ${last_name ?? ''}`;
-  }
-
   return useSWRInfinite(
     // @ts-ignore
-    invoke
-      ? getInfiniteKey('/api/search/person', 'residents', internal_params)
-      : null
+    invoke ? getInfiniteKey('/api/search/person', 'residents', params) : null
   );
 };


### PR DESCRIPTION
**What**  
Send first and last name separately to search endpoint, API updated under https://github.com/LBHackney-IT/social-care-case-viewer-api/pull/601

**Why**  
Details discussed on ticket, but primarily to allow for more accurate results when giving first and last names.

**Anything else?**

- Have you added any new third-party libraries? ❌
- Are any new environment variables or configuration values needed? ❌
- Anything else in this PR that isn't covered by the what/why? ❌
