### PR TITLE
feat(SCT-1766): Allow searching on postcode fragments

### DIFF
--- a/components/Search/forms/SearchResidentsForm.spec.tsx
+++ b/components/Search/forms/SearchResidentsForm.spec.tsx
@@ -34,6 +34,65 @@ describe(`SearchResidentsForm`, () => {
     });
   });
 
+  it('should not submit with a postcode fragment less than two characters', async () => {
+    const { getByRole, getByLabelText, getByText } = render(
+      <SearchResidentsForm {...props} />
+    );
+
+    const firstNameInput = getByLabelText('Postcode');
+    fireEvent.change(firstNameInput, { target: { value: 'E' } });
+
+    props.onFormSubmit.mockClear();
+
+    await act(async () => {
+      fireEvent.submit(getByRole('form'));
+    });
+    expect(props.onFormSubmit).not.toHaveBeenCalledWith();
+    expect(
+      getByText('You must enter at least the first two letters of the postcode')
+    ).toBeVisible();
+  });
+
+  it('should submit with a postcode fragment', async () => {
+    const { getByRole, getByLabelText } = render(
+      <SearchResidentsForm {...props} />
+    );
+
+    const firstNameInput = getByLabelText('Postcode');
+    fireEvent.change(firstNameInput, { target: { value: 'E8' } });
+
+    await act(async () => {
+      fireEvent.submit(getByRole('form'));
+    });
+    expect(props.onFormSubmit).toHaveBeenCalledWith({
+      first_name: '',
+      last_name: '',
+      person_id: '',
+      postcode: 'E8',
+      date_of_birth: null,
+    });
+  });
+
+  it('should submit with a full postcode', async () => {
+    const { getByRole, getByLabelText } = render(
+      <SearchResidentsForm {...props} />
+    );
+
+    const firstNameInput = getByLabelText('Postcode');
+    fireEvent.change(firstNameInput, { target: { value: 'E8 1AA' } });
+
+    await act(async () => {
+      fireEvent.submit(getByRole('form'));
+    });
+    expect(props.onFormSubmit).toHaveBeenCalledWith({
+      first_name: '',
+      last_name: '',
+      person_id: '',
+      postcode: 'E8 1AA',
+      date_of_birth: null,
+    });
+  });
+
   it('should initialise the form with the passed defaultValues', async () => {
     const { getByRole } = render(
       <SearchResidentsForm {...props} defaultValues={{ first_name: 'bar' }} />

--- a/components/Search/forms/SearchResidentsForm.tsx
+++ b/components/Search/forms/SearchResidentsForm.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import isPast from 'date-fns/isPast';
-import isPostcodeValid from 'uk-postcode-validator';
-
 import { TextInput, DateInput } from 'components/Form';
 import Button from 'components/Button/Button';
 
@@ -86,8 +84,8 @@ const SearchResidentsForm = ({
               validate: {
                 valid: (value) =>
                   value === '' ||
-                  (value && isPostcodeValid(value)) ||
-                  'You entered an invalid postcode',
+                  (value && value.trim().length > 1) ||
+                  'You must enter at least the first two letters of the postcode',
               },
             }}
           />


### PR DESCRIPTION
**What**  
https://hackney.atlassian.net/browse/SCT-1766

Allows users to enter a fragment of a postcode, a minimum of two characters is expected.

**Why**  

Now we are bringing back lots of results, users need to be able to filter them on the postcode.

**Anything else?**

- Have you added any new third-party libraries? ❌
- Are any new environment variables or configuration values needed? ❌
- Anything else in this PR that isn't covered by the what/why? ❌
