### PR TITLE
feat(SCT-1761): show new resident link earlier

### DIFF
--- a/components/Search/Search.spec.tsx
+++ b/components/Search/Search.spec.tsx
@@ -178,6 +178,57 @@ describe(`Search`, () => {
     expect(getByText('add a new person')).toBeInTheDocument();
   });
 });
+it('when there are more than 20 but less than 40 results shows add a user after one load more clicks', async () => {
+  (SearchPerson as jest.Mock).mockImplementation(
+    makeSearchResultsImplementation(2)
+  );
+
+  const { getByText, getByLabelText, getByRole } = render(
+    <UserContext.Provider
+      value={{
+        user: { name: 'foo' } as unknown as User,
+      }}
+    >
+      <Search {...props} type="people" />
+    </UserContext.Provider>
+  );
+
+  const nameInput = getByLabelText('First name');
+  fireEvent.change(nameInput, { target: { value: 'foo' } });
+  await act(async () => {
+    fireEvent.submit(getByRole('form'));
+  });
+
+  await waitFor(() =>
+    expect(getByText('add a new person')).toBeInTheDocument()
+  );
+});
+
+it('when there are more than 60 results shows add a user after two load more clicks', async () => {
+  (SearchPerson as jest.Mock).mockImplementation(
+    makeSearchResultsImplementation(3)
+  );
+
+  const { getByText, getByLabelText, getByRole } = render(
+    <UserContext.Provider
+      value={{
+        user: { name: 'foo' } as unknown as User,
+      }}
+    >
+      <Search {...props} type="people" />
+    </UserContext.Provider>
+  );
+
+  const nameInput = getByLabelText('First name');
+  fireEvent.change(nameInput, { target: { value: 'foo' } });
+  await act(async () => {
+    fireEvent.submit(getByRole('form'));
+  });
+
+  await waitFor(() =>
+    expect(getByText('add a new person')).toBeInTheDocument()
+  );
+});
 
 const makeSearchResultsImplementation = (count: number) => () => {
   const response: { size: number; data: Array<unknown> } = {

--- a/components/Search/Search.spec.tsx
+++ b/components/Search/Search.spec.tsx
@@ -177,57 +177,58 @@ describe(`Search`, () => {
 
     expect(getByText('add a new person')).toBeInTheDocument();
   });
-});
-it('when there are more than 20 but less than 40 results shows add a user after one load more clicks', async () => {
-  (SearchPerson as jest.Mock).mockImplementation(
-    makeSearchResultsImplementation(2)
-  );
 
-  const { getByText, getByLabelText, getByRole } = render(
-    <UserContext.Provider
-      value={{
-        user: { name: 'foo' } as unknown as User,
-      }}
-    >
-      <Search {...props} type="people" />
-    </UserContext.Provider>
-  );
+  it('when there are more than 20 but less than 40 results shows add a user after one load more clicks', async () => {
+    (SearchPerson as jest.Mock).mockImplementation(
+      makeSearchResultsImplementation(2)
+    );
 
-  const nameInput = getByLabelText('First name');
-  fireEvent.change(nameInput, { target: { value: 'foo' } });
-  await act(async () => {
-    fireEvent.submit(getByRole('form'));
+    const { getByText, getByLabelText, getByRole } = render(
+      <UserContext.Provider
+        value={{
+          user: { name: 'foo' } as unknown as User,
+        }}
+      >
+        <Search {...props} type="people" />
+      </UserContext.Provider>
+    );
+
+    const nameInput = getByLabelText('First name');
+    fireEvent.change(nameInput, { target: { value: 'foo' } });
+    await act(async () => {
+      fireEvent.submit(getByRole('form'));
+    });
+
+    await waitFor(() =>
+      expect(getByText('add a new person')).toBeInTheDocument()
+    );
   });
 
-  await waitFor(() =>
-    expect(getByText('add a new person')).toBeInTheDocument()
-  );
-});
+  it('when there are more than 60 results shows add a user after two load more clicks', async () => {
+    (SearchPerson as jest.Mock).mockImplementation(
+      makeSearchResultsImplementation(3)
+    );
 
-it('when there are more than 60 results shows add a user after two load more clicks', async () => {
-  (SearchPerson as jest.Mock).mockImplementation(
-    makeSearchResultsImplementation(3)
-  );
+    const { getByText, getByLabelText, getByRole } = render(
+      <UserContext.Provider
+        value={{
+          user: { name: 'foo' } as unknown as User,
+        }}
+      >
+        <Search {...props} type="people" />
+      </UserContext.Provider>
+    );
 
-  const { getByText, getByLabelText, getByRole } = render(
-    <UserContext.Provider
-      value={{
-        user: { name: 'foo' } as unknown as User,
-      }}
-    >
-      <Search {...props} type="people" />
-    </UserContext.Provider>
-  );
+    const nameInput = getByLabelText('First name');
+    fireEvent.change(nameInput, { target: { value: 'foo' } });
+    await act(async () => {
+      fireEvent.submit(getByRole('form'));
+    });
 
-  const nameInput = getByLabelText('First name');
-  fireEvent.change(nameInput, { target: { value: 'foo' } });
-  await act(async () => {
-    fireEvent.submit(getByRole('form'));
+    await waitFor(() =>
+      expect(getByText('add a new person')).toBeInTheDocument()
+    );
   });
-
-  await waitFor(() =>
-    expect(getByText('add a new person')).toBeInTheDocument()
-  );
 });
 
 const makeSearchResultsImplementation = (count: number) => () => {

--- a/components/Search/Search.spec.tsx
+++ b/components/Search/Search.spec.tsx
@@ -153,4 +153,60 @@ describe(`Search`, () => {
       true
     );
   });
+
+  it('when there are less than 20 results shows add a user', async () => {
+    (SearchPerson as jest.Mock).mockImplementation(
+      makeSearchResultsImplementation(1)
+    );
+
+    const { getByText, getByLabelText, getByRole } = render(
+      <UserContext.Provider
+        value={{
+          user: { name: 'foo' } as unknown as User,
+        }}
+      >
+        <Search {...props} type="people" />
+      </UserContext.Provider>
+    );
+
+    const nameInput = getByLabelText('First name');
+    fireEvent.change(nameInput, { target: { value: 'foo' } });
+    act(() => {
+      fireEvent.submit(getByRole('form'));
+    });
+
+    expect(getByText('add a new person')).toBeInTheDocument();
+  });
 });
+
+const makeSearchResultsImplementation = (count: number) => () => {
+  const response: { size: number; data: Array<unknown> } = {
+    size: 1,
+    data: [],
+  };
+
+  for (let i = 0; i < count; i++) {
+    response.data.push({
+      nextCursor: '',
+      totalCount: count * 20 - 1,
+      residents: new Array(count * 20 - 1)
+        .fill({
+          firstName: 'Ross',
+          lastName: 'Geller',
+          uprn: '10002263753',
+          dateOfBirth: '2006-02-03T00:00:00.0000000',
+          ageContext: 'A',
+          gender: 'M',
+          nhsNumber: '9707109432',
+          restricted: 'N',
+          address: { address: '4A, LONDON ROAD', postcode: 'TW1 3RR' },
+        })
+        .map((val, index) => ({
+          ...val,
+          mosaicId: index + i * 100,
+        })),
+    });
+  }
+
+  return response;
+};

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -5,19 +5,15 @@ import { useRouter } from 'next/router';
 import s from './Search.module.scss';
 import ss from 'stylesheets/Section.module.scss';
 import cx from 'classnames';
-
 import SearchResidentsForm from './forms/SearchResidentsForm';
 import SearchCasesForm from './forms/SearchCasesForm';
 import ResidentsTable from './results/ResidentsTable';
 import RelationshipTable from './results//RelationshipTable';
 import CasesTable, { CaseTableColumns } from 'components/Cases/CasesTable';
-
 import Button from 'components/Button/Button';
 import Spinner from 'components/Spinner/Spinner';
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import { useAuth } from 'components/UserContext/UserContext';
-
-// import { useResidents } from 'utils/api/residents'
 import { SearchPerson } from 'utils/api/search';
 import { useCases } from 'utils/api/cases';
 import { getQueryString } from 'utils/urls';
@@ -158,7 +154,6 @@ const Search = ({
               callback={callback}
               columns={columns}
               user={user}
-              // onSort={onSort} // commented out as the feature is not ready in the BE
             />
           ) : (
             <>
@@ -180,13 +175,26 @@ const Search = ({
       </div>
       {error && data !== 1 && <ErrorMessage />}
 
-      {type === 'people' && results && !results?.nextCursor && (
-        <>
-          {results?.records?.length > 0 ? (
-            <>
-              <p>Can&apos;t find a match?</p>
+      {type === 'people' &&
+        results &&
+        (!results?.nextCursor || parseInt(results?.nextCursor) > 39) && (
+          <>
+            {results?.records?.length > 0 ? (
+              <>
+                <p>Can&apos;t find a match?</p>
+                <p>
+                  Try narrowing your search, or{' '}
+                  <Link href={`/people/add?${getQueryString(query)}`}>
+                    <a className="lbh-link lbh-link--no-visited-state">
+                      add a new person
+                    </a>
+                  </Link>
+                  .
+                </p>
+              </>
+            ) : (
               <p>
-                Try narrowing your search, or{' '}
+                Try widening your search, or{' '}
                 <Link href={`/people/add?${getQueryString(query)}`}>
                   <a className="lbh-link lbh-link--no-visited-state">
                     add a new person
@@ -194,47 +202,36 @@ const Search = ({
                 </Link>
                 .
               </p>
-            </>
-          ) : (
-            <p>
-              Try widening your search, or{' '}
-              <Link href={`/people/add?${getQueryString(query)}`}>
-                <a className="lbh-link lbh-link--no-visited-state">
-                  add a new person
-                </a>
-              </Link>
-              .
-            </p>
-          )}
+            )}
 
-          <div className={s.mutedPanel}>
-            <div
-              className={cx(
-                'govuk-warning-text lbh-warning-text',
-                s.warningText
-              )}
-            >
-              <span
-                className={cx('govuk-warning-text__icon', s.icon)}
-                aria-hidden="true"
+            <div className={s.mutedPanel}>
+              <div
+                className={cx(
+                  'govuk-warning-text lbh-warning-text',
+                  s.warningText
+                )}
               >
-                !
-              </span>
-              <strong className={cx('govuk-warning-text__text', s.text)}>
-                <h2>Prevent duplicate people</h2>
-                <p>Before adding a new person, try:</p>
-                <ul className="lbh-list lbh-list--bullet">
-                  <li>alternate spellings or variations of the same name</li>
-                  <li>
-                    different combinations of names, date of birth or postcode
-                  </li>
-                  <li>using just the first part of the postcode</li>
-                </ul>
-              </strong>
+                <span
+                  className={cx('govuk-warning-text__icon', s.icon)}
+                  aria-hidden="true"
+                >
+                  !
+                </span>
+                <strong className={cx('govuk-warning-text__text', s.text)}>
+                  <h2>Prevent duplicate people</h2>
+                  <p>Before adding a new person, try:</p>
+                  <ul className="lbh-list lbh-list--bullet">
+                    <li>alternate spellings or variations of the same name</li>
+                    <li>
+                      different combinations of names, date of birth or postcode
+                    </li>
+                    <li>using just the first part of the postcode</li>
+                  </ul>
+                </strong>
+              </div>
             </div>
-          </div>
-        </>
-      )}
+          </>
+        )}
     </>
   );
 };


### PR DESCRIPTION
**What**  
Show the "add new person" link after at most two clicks of load more.

**Why**  
There is potential for hundreds of results to come back and clicking load more many times just to get to add a new person is no longer suitable.

**Anything else?**

- Have you added any new third-party libraries? ❌
- Are any new environment variables or configuration values needed? ❌
- Anything else in this PR that isn't covered by the what/why? ❌
