### PR TITLE
feat: turn on new resident view

### DIFF
--- a/components/AllocatedCases/AllocatedCasesTable.tsx
+++ b/components/AllocatedCases/AllocatedCasesTable.tsx
@@ -31,7 +31,7 @@ const AllocatedCasesTable = ({
           <td className="govuk-table__cell">{cell.personId} </td>
           <td className="govuk-table__cell">
             {
-              <Link href={`/people/${cell.personId}`}>
+              <Link href={`/residents/${cell.personId}`}>
                 <a className="govuk-link">{cell.personName}</a>
               </Link>
             }

--- a/components/AllocatedCases/__snapshots__/AllocatedCasesTable.spec.tsx.snap
+++ b/components/AllocatedCases/__snapshots__/AllocatedCasesTable.spec.tsx.snap
@@ -54,7 +54,7 @@ exports[`AllocatedCasesTable component should render records properly 1`] = `
         >
           <a
             class="govuk-link"
-            href="/people/1234"
+            href="/residents/1234"
           >
             foo
           </a>

--- a/components/AllocatedWorkers/AllocationRecap/AllocationRecap.tsx
+++ b/components/AllocatedWorkers/AllocationRecap/AllocationRecap.tsx
@@ -58,7 +58,7 @@ const AllocationRecap = ({
       </h1>
       <p className="govuk-body govuk-!-margin-top-6">
         <b>Person</b>:{' '}
-        <Link href={`/people/${allocation.personId}`}>
+        <Link href={`/residents/${allocation.personId}`}>
           {allocation.personName}
         </Link>
       </p>

--- a/components/AllocatedWorkers/AllocationRecap/__snapshots__/AllocationRecap.spec.tsx.snap
+++ b/components/AllocatedWorkers/AllocationRecap/__snapshots__/AllocationRecap.spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`AllocationRecap should render properly on allocation 1`] = `
     </b>
     : 
     <a
-      href="/people/1234"
+      href="/residents/1234"
     >
       foo
     </a>
@@ -117,7 +117,7 @@ exports[`AllocationRecap should render properly on deallocation 1`] = `
     </b>
     : 
     <a
-      href="/people/1234"
+      href="/residents/1234"
     >
       foo
     </a>

--- a/components/NewPersonView/PreviewBanner.tsx
+++ b/components/NewPersonView/PreviewBanner.tsx
@@ -20,24 +20,16 @@ const PreviewBanner = ({
         className="lbh-page-announcement lbh-page-announcement--orange"
       >
         <h4 className="lbh-page-announcement__title">
-          Try the faster, brand new resident view
+          This view will soon be retired
         </h4>
         <div className="lbh-page-announcement__content">
           <p className="lbh-body-s">
             You can record much more information about a resident, see a
-            chronology of their workflows and browse case notes faster.
+            chronology of their workflows and browse case notes faster using the
+            new resident view.
           </p>
           <p className="lbh-body-s govuk-!-margin-top-2">
             <Link href={`/residents/${resident.id}`}>Try it now</Link>{' '}
-            <a
-              href={
-                'https://docs.google.com/forms/d/e/1FAIpQLScILbPD1ioKHzp1D3HN4_DKaxV2tpWLMu8upSSqNgSPCo85cg/viewform'
-              }
-              target={'_blank'}
-              rel="noreferrer"
-            >
-              Give feedback
-            </a>
           </p>
         </div>
       </section>

--- a/components/Search/results/ResidentsTable.tsx
+++ b/components/Search/results/ResidentsTable.tsx
@@ -32,7 +32,7 @@ const ResultEntry = ({
       <td className="govuk-table__cell">
         {newTab ? (
           <a
-            href={`/people/${mosaicId}`}
+            href={`/residents/${mosaicId}`}
             target="_blank"
             rel="noreferrer"
             className="govuk-link govuk-custom-text-color"
@@ -40,7 +40,7 @@ const ResultEntry = ({
             {firstName} {lastName}
           </a>
         ) : (
-          <Link href={`/people/${mosaicId}`}>
+          <Link href={`/residents/${mosaicId}`}>
             <a className="govuk-link govuk-custom-text-color">
               {firstName} {lastName}
             </a>

--- a/components/Search/results/__snapshots__/ResidentsTable.spec.tsx.snap
+++ b/components/Search/results/__snapshots__/ResidentsTable.spec.tsx.snap
@@ -58,7 +58,7 @@ exports[`ResidentsTable component should render a list of residents 1`] = `
         >
           <a
             class="govuk-link govuk-custom-text-color"
-            href="/people/1"
+            href="/residents/1"
           >
             Foo Bar
           </a>
@@ -147,7 +147,7 @@ exports[`ResidentsTable component should render a resident without an address 1`
         >
           <a
             class="govuk-link govuk-custom-text-color"
-            href="/people/3"
+            href="/residents/3"
           >
             Foo Bar
           </a>
@@ -233,7 +233,7 @@ exports[`ResidentsTable component when the address is less than 20 characters sh
         >
           <a
             class="govuk-link govuk-custom-text-color"
-            href="/people/4"
+            href="/residents/4"
           >
             Foo Bar
           </a>
@@ -328,7 +328,7 @@ exports[`ResidentsTable component when the address is more than 20 characters sh
         >
           <a
             class="govuk-link govuk-custom-text-color"
-            href="/people/5"
+            href="/residents/5"
           >
             Foo Bar
           </a>


### PR DESCRIPTION
updates paths in important places from `/people/:id` to `/residents/:id`

any missed instances can be caught in follow-up prs.

also changes the preview banner wording to reflect that the classic person view is no longer the default.