### PR TITLE
fix: Fix parameter names allocations

### DIFF
--- a/components/Allocations/AddAllocation/AddAllocation.spec.tsx
+++ b/components/Allocations/AddAllocation/AddAllocation.spec.tsx
@@ -160,7 +160,7 @@ describe(`AddAllocation`, () => {
     expect(allocatedWorkerAPI.addAllocatedWorker).toHaveBeenCalledWith(123, {
       allocatedTeamId: 3,
       allocationStartDate: format(new Date(), 'yyyy-MM-dd'),
-      ragRating: 'amber',
+      ragRating: 'medium',
     });
   });
 });

--- a/components/Allocations/AddAllocation/AddAllocation.tsx
+++ b/components/Allocations/AddAllocation/AddAllocation.tsx
@@ -108,11 +108,11 @@ const AddAllocation = ({ personId, ageContext }: Props): React.ReactElement => {
         name="priority"
         label="Choose a priority rating"
         options={[
-          { value: 'purple', text: 'Urgent priority' },
-          { value: 'red', text: 'High priority' },
-          { value: 'amber', text: 'Medium priority' },
-          { value: 'green', text: 'Low priority' },
-          { value: 'white', text: 'No priority' },
+          { value: 'urgent', text: 'Urgent priority' },
+          { value: 'high', text: 'High priority' },
+          { value: 'medium', text: 'Medium priority' },
+          { value: 'low', text: 'Low priority' },
+          { value: 'none', text: 'No priority' },
         ]}
         onChange={(elm) => {
           setPriority(elm.target.value);

--- a/components/Allocations/EditAllocationPriority/EditAllocationPriority.spec.tsx
+++ b/components/Allocations/EditAllocationPriority/EditAllocationPriority.spec.tsx
@@ -64,7 +64,7 @@ describe(`DeallocateTeamWorker`, () => {
     expect(allocatedWorkerAPI.patchAllocation).toHaveBeenCalled();
     expect(allocatedWorkerAPI.patchAllocation).toHaveBeenCalledWith(1, {
       id: 12,
-      ragRating: 'red',
+      ragRating: 'high',
     });
   });
 });

--- a/components/Allocations/EditAllocationPriority/EditAllocationPriority.tsx
+++ b/components/Allocations/EditAllocationPriority/EditAllocationPriority.tsx
@@ -53,11 +53,11 @@ const EditAllocationPriority = ({
           name="priority"
           label="Choose a priority rating"
           options={[
-            { value: 'purple', text: 'Urgent priority' },
-            { value: 'red', text: 'High priority' },
-            { value: 'amber', text: 'Medium priority' },
-            { value: 'green', text: 'Low priority' },
-            { value: 'white', text: 'No priority' },
+            { value: 'urgent', text: 'Urgent priority' },
+            { value: 'high', text: 'High priority' },
+            { value: 'medium', text: 'Medium priority' },
+            { value: 'low', text: 'Low priority' },
+            { value: 'none', text: 'No priority' },
           ]}
           onChange={(elm) => {
             setPriority(elm.target.value);

--- a/components/PriorityRating/PriorityRating.spec.tsx
+++ b/components/PriorityRating/PriorityRating.spec.tsx
@@ -13,7 +13,6 @@ describe('PriorityRating', () => {
     );
 
     expect(screen.getByTestId('colourdot')).not.toBeNull();
-
     expect(screen.getByText('Medium'));
     expect(screen.getByText('Edit'));
   });

--- a/components/PriorityRating/PriorityRating.spec.tsx
+++ b/components/PriorityRating/PriorityRating.spec.tsx
@@ -19,18 +19,18 @@ describe('PriorityRating', () => {
   });
 
   it('properly convert ragRatings to CSS colours', () => {
-    expect(getRatingColour('purple')).toBe('purple');
-    expect(getRatingColour('red')).toBe('red');
-    expect(getRatingColour('amber')).toBe('orange');
-    expect(getRatingColour('green')).toBe('green');
-    expect(getRatingColour('white')).toBe('grey');
+    expect(getRatingColour('urgent')).toBe('purple');
+    expect(getRatingColour('high')).toBe('red');
+    expect(getRatingColour('medium')).toBe('orange');
+    expect(getRatingColour('low')).toBe('green');
+    expect(getRatingColour('none')).toBe('grey');
   });
 
   it('properly convert ragRatings to string', () => {
-    expect(getRatingString('purple')).toBe('Urgent');
-    expect(getRatingString('red')).toBe('High');
-    expect(getRatingString('amber')).toBe('Medium');
-    expect(getRatingString('green')).toBe('Low');
-    expect(getRatingString('white')).toBe('No priority');
+    expect(getRatingString('urgent')).toBe('Urgent');
+    expect(getRatingString('high')).toBe('High');
+    expect(getRatingString('medium')).toBe('Medium');
+    expect(getRatingString('low')).toBe('Low');
+    expect(getRatingString('none')).toBe('No priority');
   });
 });

--- a/components/PriorityRating/PriorityRating.tsx
+++ b/components/PriorityRating/PriorityRating.tsx
@@ -14,19 +14,19 @@ export const getRatingColour = (rating: keyof typeof colorMapping): string => {
 };
 
 const ratingMapping = {
-  purple: 'Urgent',
-  red: 'High',
-  amber: 'Medium',
-  green: 'Low',
-  white: 'No priority',
+  urgent: 'Urgent',
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+  none: 'No priority',
 };
 
 const colorMapping = {
-  purple: 'purple',
-  red: 'red',
-  amber: 'orange',
-  green: 'green',
-  white: 'grey',
+  urgent: 'purple',
+  high: 'red',
+  medium: 'orange',
+  low: 'green',
+  none: 'grey',
 };
 
 const PriorityRating = ({

--- a/factories/allocatedWorkers.ts
+++ b/factories/allocatedWorkers.ts
@@ -14,7 +14,7 @@ export const allocationFactory = Factory.define<Allocation>(({ sequence }) => ({
   personName: 'foo',
   personAddress: 'the address',
   personDateOfBirth: '2020-03-20',
-  ragRating: 'amber',
+  ragRating: 'medium',
 }));
 
 export const mockedAllocation = allocationFactory.build();


### PR DESCRIPTION
**What**  
This PR fixes the values sent by the frontend for the `ragRating` parameter

**Why**  
I'm sending colours, BE is expecting keywords

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
