### PR TITLE
fix: Fixes for allocations

### DIFF
--- a/components/Allocations/AddAllocation/AddAllocation.tsx
+++ b/components/Allocations/AddAllocation/AddAllocation.tsx
@@ -59,7 +59,7 @@ const AddAllocation = ({ personId, ageContext }: Props): React.ReactElement => {
         allocationStartDate: format(allocationDate, 'yyyy-MM-dd'),
       });
 
-      push(`/people/${personId}`);
+      push(`/residents/${personId}/allocations`);
     } catch (e) {
       setPostError(true);
     }

--- a/components/Allocations/AddWorkerAllocation/AddWorkerAllocation.tsx
+++ b/components/Allocations/AddWorkerAllocation/AddWorkerAllocation.tsx
@@ -60,7 +60,7 @@ const AddWorkerAllocation = ({
         allocationStartDate: format(allocationDate, 'yyyy-MM-dd'),
         allocatedTeamId: Number(teamId),
       });
-      push(`/people/${personId}`);
+      push(`/residents/${personId}/allocations`);
     } catch (e) {
       setPostError(true);
     }

--- a/components/Allocations/DeallocateTeamWorker/DeallocateTeamWorker.tsx
+++ b/components/Allocations/DeallocateTeamWorker/DeallocateTeamWorker.tsx
@@ -61,7 +61,7 @@ const DeallocateTeamWorker = ({
         deallocationDate: format(deallocationDate, 'yyyy-MM-dd'),
       });
 
-      push(`/people/${resident.id}`);
+      push(`/residents/${resident.id}/allocations`);
     } catch (e) {
       setPostError(true);
     }

--- a/components/Allocations/EditAllocationPriority/EditAllocationPriority.tsx
+++ b/components/Allocations/EditAllocationPriority/EditAllocationPriority.tsx
@@ -35,7 +35,7 @@ const EditAllocationPriority = ({
         ragRating: priorityRating,
       });
 
-      push(`/people/${resident.id}`);
+      push(`/residents/${resident.id}/allocations`);
     } catch (e) {
       setPostError(true);
     }

--- a/components/PriorityRating/PriorityRating.tsx
+++ b/components/PriorityRating/PriorityRating.tsx
@@ -51,7 +51,7 @@ const PriorityRating = ({
         allocation.ragRating.toLowerCase() as keyof typeof ratingMapping
       )} `}
       <span data-testid="colourdot" style={style}></span>
-      <span style={{ float: 'right', margin: '0' }}>
+      <span style={{ float: 'right', margin: '0 -18px 0 0' }}>
         <Link
           href={`/residents/${resident.id}/allocations/${allocation.id}/editpriority`}
         >

--- a/pages/residents/[id]/allocations.tsx
+++ b/pages/residents/[id]/allocations.tsx
@@ -62,7 +62,7 @@ const AllocationsPage = ({ resident }: Props): React.ReactElement => {
                     a.allocatedWorker
                   ) : (
                     <Link
-                      href={`/residents/${resident.id}/allocations/${a.id}/allocateworker`}
+                      href={`/residents/${resident.id}/allocations/${a.id}/allocateworker?teamAllocationStartDate=${a.allocationStartDate}&teamId=${a.teamId}`}
                     >
                       <a className="lbh-link lbh-link--muted">
                         + Add worker for {a.allocatedWorkerTeam}

--- a/pages/residents/[id]/allocations.tsx
+++ b/pages/residents/[id]/allocations.tsx
@@ -64,7 +64,7 @@ const AllocationsPage = ({ resident }: Props): React.ReactElement => {
                     <Link
                       href={`/residents/${resident.id}/allocations/${a.id}/allocateworker?teamAllocationStartDate=${a.allocationStartDate}&teamId=${a.teamId}`}
                     >
-                      <a className="lbh-link lbh-link--muted">
+                      <a className="lbh-link lbh-link--no-visited-state">
                         + Add worker for {a.allocatedWorkerTeam}
                       </a>
                     </Link>

--- a/pages/residents/[id]/allocations.tsx
+++ b/pages/residents/[id]/allocations.tsx
@@ -71,7 +71,7 @@ const AllocationsPage = ({ resident }: Props): React.ReactElement => {
                   )}
 
                   {a.allocatedWorker ? (
-                    <span style={{ float: 'right' }}>
+                    <span style={{ float: 'right', marginRight: '-18px' }}>
                       <Link
                         href={`/residents/${resident.id}/allocations/${
                           a.id

--- a/pages/residents/[id]/allocations.tsx
+++ b/pages/residents/[id]/allocations.tsx
@@ -65,7 +65,10 @@ const AllocationsPage = ({ resident }: Props): React.ReactElement => {
                       href={`/residents/${resident.id}/allocations/${a.id}/allocateworker?teamAllocationStartDate=${a.allocationStartDate}&teamId=${a.teamId}`}
                     >
                       <a className="lbh-link lbh-link--no-visited-state">
-                        + Add worker for {a.allocatedWorkerTeam}
+                        + Add worker
+                        {a.allocatedWorkerTeam
+                          ? ` for ${a.allocatedWorkerTeam}`
+                          : ''}
                       </a>
                     </Link>
                   )}

--- a/pages/residents/[id]/allocations/[allocationId]/allocateworker.tsx
+++ b/pages/residents/[id]/allocations/[allocationId]/allocateworker.tsx
@@ -15,6 +15,10 @@ const AddWorkerAllocationPage = (): React.ReactElement => {
   const { query, replace } = useRouter();
   const personId = Number(query.id as string);
   const allocationId = Number(query.allocationId as string);
+
+  const teamAllocationStartDate = String(query.teamAllocationStartDate);
+  const teamId = Number(query.teamId);
+
   const { user } = useAuth() as { user: User };
   const { data: resident, error } = useResident(personId);
 
@@ -32,9 +36,6 @@ const AddWorkerAllocationPage = (): React.ReactElement => {
     });
     return <></>;
   }
-
-  const teamAllocationStartDate = String(query.teamAllocationStartDate);
-  const teamId = Number(query.teamId);
 
   return (
     <>

--- a/types.ts
+++ b/types.ts
@@ -17,6 +17,7 @@ export type AgeContext = 'A' | 'B' | 'C' | undefined;
 
 export interface Allocation {
   id: number;
+  teamId?: number;
   caseStatus: 'Closed' | 'Open';
   allocatedWorkerTeam: string;
   allocatedWorker: string;


### PR DESCRIPTION
**What**  

- Fix redirect to people view on deallocation
- Fix redirect to old person view when editing rag rating.
- Fix setting teamID and allocation date in the url when allocating a worker to an existing team allocation
- If worker not set for allocation do not make get request to get worker details (the request is for the Workers in the team)
- Links in blue 
- Alignment of “deallocate worker“

**Why**  
To complete the Worker Allocation flow
