### PR TITLE
chore: only proper people can change restrictions

### DIFF
--- a/pages/residents/[id]/index.tsx
+++ b/pages/residents/[id]/index.tsx
@@ -268,6 +268,7 @@ const ResidentPage = ({ resident }: Props): React.ReactElement => {
             label: 'Restricted?',
             showInSummary: true,
             beforeDisplay: (val) => (val === 'Y' ? 'Yes' : 'No'),
+            readOnly: canManage,
             name: 'restricted',
             options: [
               {

--- a/pagesTest/residents/[id]/index.spec.tsx
+++ b/pagesTest/residents/[id]/index.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, queryByRole } from '@testing-library/react';
 import { mockedResident } from 'factories/residents';
 import ResidentPage from 'pages/residents/[id]';
 import { useCases } from 'utils/api/cases';
@@ -65,5 +65,20 @@ describe('ResidentPage', () => {
     );
 
     expect(screen.getByText('This resident has no case notes yet.'));
+  });
+
+  it("doesn't let normal users change restricted status", () => {
+    render(
+      <AppConfigProvider appConfig={{}}>
+        <ResidentPage resident={{ ...mockedResident, restricted: 'Y' }} />
+      </AppConfigProvider>
+    );
+
+    expect(
+      queryByRole(
+        screen.getByText('Restricted?')?.parentElement as HTMLElement,
+        'button'
+      )
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
prevents a simple privilege escalation attack where a non-admin user could change a restricted resident to unrestricted.

now, the restricted control is read-only unless the user is sufficiently powerful