### PR TITLE
chore: strip html tags from historic notes

### DIFF
--- a/components/ResidentPage/CaseNoteDialog.spec.tsx
+++ b/components/ResidentPage/CaseNoteDialog.spec.tsx
@@ -21,7 +21,10 @@ jest.mock('utils/api/submissions');
   data: mockedCaseNote,
 });
 (useHistoricCaseNote as jest.Mock).mockReturnValue({
-  data: mockedHistoricCaseNote,
+  data: {
+    ...mockedHistoricCaseNote,
+    content: '<h1>foo historic</h1>',
+  },
 });
 (useSubmission as jest.Mock).mockReturnValue({
   data: {
@@ -136,6 +139,33 @@ describe('CaseNoteDialog', () => {
 
     expect(screen.getAllByRole('term').length).toBe(6);
     expect(screen.getAllByRole('definition').length).toBe(6);
+  });
+
+  it('strips html tags from historic case notes', () => {
+    (useRouter as jest.Mock).mockReturnValueOnce({
+      query: {
+        case_note: mockedCaseNote.recordId,
+      },
+    });
+
+    render(
+      <CaseNoteDialog
+        totalCount={1}
+        socialCareId={123}
+        caseNotes={[
+          {
+            ...mockedCaseNote,
+            caseFormData: {
+              ...mockedCaseNote.caseFormData,
+              is_historical: true,
+            },
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('foo historic'));
+    expect(screen.queryByText('<h1>foo historic</h1>')).toBeNull;
   });
 
   it('can be navigate to an older note by keyboard', () => {

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -65,7 +65,9 @@ const HistoricCaseContent = ({ recordId }: HistoricContentProps) => {
         rows={Object.fromEntries(
           Object.entries(data).map(([key, value]) => [
             prettyKey(key),
-            JSON.stringify(value).replace(/"/g, ''),
+            JSON.stringify(value)
+              .replace(/"/g, '')
+              .replace(/(<([^>]+)>)/gi, ''),
           ])
         )}
       />


### PR DESCRIPTION
historic case notes have some html tags in their content.

they're no longer needed, so we strip them out here.