### PR TITLE
fix: Change allocatedWorkerTeamId parameter name

### DIFF
--- a/pages/residents/[id]/allocations.tsx
+++ b/pages/residents/[id]/allocations.tsx
@@ -62,7 +62,7 @@ const AllocationsPage = ({ resident }: Props): React.ReactElement => {
                     a.allocatedWorker
                   ) : (
                     <Link
-                      href={`/residents/${resident.id}/allocations/${a.id}/allocateworker?teamAllocationStartDate=${a.allocationStartDate}&teamId=${a.teamId}`}
+                      href={`/residents/${resident.id}/allocations/${a.id}/allocateworker?teamAllocationStartDate=${a.allocationStartDate}&teamId=${a.allocatedWorkerTeamId}`}
                     >
                       <a className="lbh-link lbh-link--no-visited-state">
                         + Add worker

--- a/types.ts
+++ b/types.ts
@@ -17,8 +17,8 @@ export type AgeContext = 'A' | 'B' | 'C' | undefined;
 
 export interface Allocation {
   id: number;
-  teamId?: number;
   caseStatus: 'Closed' | 'Open';
+  allocatedWorkerTeamId?: number;
   allocatedWorkerTeam: string;
   allocatedWorker: string;
   allocationStartDate: string;


### PR DESCRIPTION
**What**  
Expected parameter for Allocations has been changed from `teamId` to `allocatedWorkerTeamId `

**Why**  
This is needed to align the FE with the BE
