### PR TITLE
fix: Add worker name for worker only allocations

### DIFF
--- a/pages/residents/[id]/allocations.tsx
+++ b/pages/residents/[id]/allocations.tsx
@@ -103,7 +103,7 @@ const AllocationsPage = ({ resident }: Props): React.ReactElement => {
                   title={
                     a.allocatedWorkerTeam
                       ? `Team allocation: ${a.allocatedWorkerTeam}`
-                      : 'Worker Allocation'
+                      : `Worker Allocation: ${a.allocatedWorker}`
                   }
                   link={
                     <Link

--- a/pages/residents/[id]/allocations.tsx
+++ b/pages/residents/[id]/allocations.tsx
@@ -73,7 +73,7 @@ const AllocationsPage = ({ resident }: Props): React.ReactElement => {
                     </Link>
                   )}
 
-                  {a.allocatedWorker ? (
+                  {a.allocatedWorker && a.allocatedWorkerTeam ? (
                     <span style={{ float: 'right', marginRight: '-18px' }}>
                       <Link
                         href={`/residents/${resident.id}/allocations/${


### PR DESCRIPTION
**What**  
Makes it more clear which worker is allocated to the resident for worker only allocations.

**Why**  
Because team allocations show the team, worker only allocations should show the worker.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
