### PR TITLE
fix: Removed FE filter for closed allocations

### DIFF
--- a/lib/allocatedWorkers.spec.ts
+++ b/lib/allocatedWorkers.spec.ts
@@ -18,7 +18,7 @@ describe('allocatedWorkersAPI', () => {
       const data = await allocatedWorkersAPI.getResidentAllocatedWorkers(123);
       expect(mockedAxios.get).toHaveBeenCalled();
       expect(mockedAxios.get.mock.calls[0][0]).toEqual(
-        `${ENDPOINT_API}/allocations`
+        `${ENDPOINT_API}/allocations?status=open`
       );
       expect(mockedAxios.get.mock.calls[0][1]?.headers).toEqual({
         'x-api-key': AWS_KEY,
@@ -64,7 +64,7 @@ describe('allocatedWorkersAPI', () => {
       const data = await allocatedWorkersAPI.getResidentAllocatedWorkers(123);
       expect(mockedAxios.get).toHaveBeenCalled();
       expect(mockedAxios.get.mock.calls[0][0]).toEqual(
-        `${ENDPOINT_API}/allocations`
+        `${ENDPOINT_API}/allocations?status=open`
       );
       expect(mockedAxios.get.mock.calls[0][1]?.headers).toEqual({
         'x-api-key': AWS_KEY,
@@ -208,7 +208,7 @@ describe('allocatedWorkersAPI', () => {
       const data = await allocatedWorkersAPI.getAllocationsByWorker(123);
       expect(mockedAxios.get).toHaveBeenCalled();
       expect(mockedAxios.get.mock.calls[0][0]).toEqual(
-        `${ENDPOINT_API}/allocations`
+        `${ENDPOINT_API}/allocations?status=open`
       );
       expect(mockedAxios.get.mock.calls[0][1]?.headers).toEqual({
         'x-api-key': AWS_KEY,

--- a/lib/allocatedWorkers.spec.ts
+++ b/lib/allocatedWorkers.spec.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosError } from 'axios';
-import endOfTomorrow from 'date-fns/endOfTomorrow';
 
 import * as allocatedWorkersAPI from './allocatedWorkers';
 
@@ -27,65 +26,6 @@ describe('allocatedWorkersAPI', () => {
         mosaic_id: 123,
       });
       expect(data).toEqual({ allocations: ['hello'] });
-    });
-
-    it('should filter out closed or expired allocations', async () => {
-      mockedAxios.get.mockResolvedValue({
-        data: {
-          allocations: [
-            {
-              id: 1,
-              allocationEndDate: null,
-              caseStatus: 'Closed',
-            },
-            {
-              id: 2,
-              allocationEndDate: null,
-              caseStatus: 'closed',
-            },
-            {
-              id: 3,
-              allocationEndDate: null,
-              caseStatus: 'Open',
-            },
-            {
-              id: 4,
-              allocationEndDate: '2020-01-31 00:00:00',
-              caseStatus: 'Open',
-            },
-            {
-              id: 5,
-              allocationEndDate: endOfTomorrow(),
-              caseStatus: 'Open',
-            },
-          ],
-        },
-      });
-      const data = await allocatedWorkersAPI.getResidentAllocatedWorkers(123);
-      expect(mockedAxios.get).toHaveBeenCalled();
-      expect(mockedAxios.get.mock.calls[0][0]).toEqual(
-        `${ENDPOINT_API}/allocations?status=open`
-      );
-      expect(mockedAxios.get.mock.calls[0][1]?.headers).toEqual({
-        'x-api-key': AWS_KEY,
-      });
-      expect(mockedAxios.get.mock.calls[0][1]?.params).toEqual({
-        mosaic_id: 123,
-      });
-      expect(data).toEqual({
-        allocations: [
-          {
-            id: 3,
-            allocationEndDate: null,
-            caseStatus: 'Open',
-          },
-          {
-            id: 5,
-            allocationEndDate: endOfTomorrow(),
-            caseStatus: 'Open',
-          },
-        ],
-      });
     });
   });
 

--- a/lib/allocatedWorkers.ts
+++ b/lib/allocatedWorkers.ts
@@ -1,7 +1,5 @@
 import axios from 'axios';
 import * as yup from 'yup';
-import isPast from 'date-fns/isPast';
-import parseISO from 'date-fns/parseISO';
 
 import type { Allocation, AllocationData } from 'types';
 
@@ -14,13 +12,6 @@ interface AllocationsParams {
   [key: string]: unknown;
 }
 
-const filterClosedAllocations = (allocations: Allocation[]) =>
-  allocations?.filter(
-    ({ caseStatus, allocationEndDate }) =>
-      caseStatus?.toLowerCase() !== 'closed' &&
-      (!allocationEndDate || !isPast(parseISO(allocationEndDate)))
-  );
-
 export const getAllocations = async (
   params: AllocationsParams,
   showOnlyOpen = true
@@ -32,7 +23,7 @@ export const getAllocations = async (
   return showOnlyOpen
     ? {
         ...data,
-        allocations: filterClosedAllocations(data.allocations),
+        allocations: data.allocations,
       }
     : data;
 };

--- a/lib/allocatedWorkers.ts
+++ b/lib/allocatedWorkers.ts
@@ -16,16 +16,14 @@ export const getAllocations = async (
   params: AllocationsParams,
   showOnlyOpen = true
 ): Promise<AllocationData> => {
-  const { data } = await axios.get(`${ENDPOINT_API}/allocations`, {
-    headers: { 'x-api-key': AWS_KEY },
-    params,
-  });
-  return showOnlyOpen
-    ? {
-        ...data,
-        allocations: data.allocations,
-      }
-    : data;
+  const { data } = await axios.get(
+    `${ENDPOINT_API}/allocations${showOnlyOpen && '?status=open'}`,
+    {
+      headers: { 'x-api-key': AWS_KEY },
+      params,
+    }
+  );
+  return data;
 };
 
 export const getResidentAllocatedWorkers = (


### PR DESCRIPTION
**What**  
This PR removes an unnecessary Allocations at FE API level.
The correct URL parameter is now sent as an URL parameter in the request

**Why**  
The Allocations loaded in the FE are filtered by "closed" status and "allocationEndDate".
This is an issue because the BE is sending only 20 rows (not all) and the FE is doing the filtering, so it's not entirely clear what's going on "under the hood"

**Anything else?**
This filter should be in the BE, and the 20 rows limit removed.
This PR should be merged after that happens.
