### PR TITLE
feat: RagRating for legacy allocations

### DIFF
--- a/components/PriorityRating/PriorityRating.spec.tsx
+++ b/components/PriorityRating/PriorityRating.spec.tsx
@@ -3,7 +3,10 @@ import PriorityRating, {
   getRatingString,
   getRatingColour,
 } from './PriorityRating';
-import { mockedAllocation } from 'factories/allocatedWorkers';
+import {
+  mockedAllocation,
+  allocationFactory,
+} from 'factories/allocatedWorkers';
 import { mockedResident } from 'factories/residents';
 
 describe('PriorityRating', () => {
@@ -13,8 +16,8 @@ describe('PriorityRating', () => {
     );
 
     expect(screen.getByTestId('colourdot')).not.toBeNull();
-    expect(screen.getByText('Medium'));
-    expect(screen.getByText('Edit'));
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+    expect(screen.getByText('Edit')).toBeInTheDocument();
   });
 
   it('properly convert ragRatings to CSS colours', () => {
@@ -31,5 +34,16 @@ describe('PriorityRating', () => {
     expect(getRatingString('medium')).toBe('Medium');
     expect(getRatingString('low')).toBe('Low');
     expect(getRatingString('none')).toBe('No priority');
+  });
+
+  it('shows "no priority" and edit link in case a ragRating is not specified (legacy allocation)', () => {
+    render(
+      <PriorityRating
+        allocation={allocationFactory.build({ ragRating: undefined })}
+        resident={mockedResident}
+      />
+    );
+    expect(screen.getByText('No priority')).toBeInTheDocument();
+    expect(screen.getByText('Edit')).toBeInTheDocument();
   });
 });

--- a/components/PriorityRating/PriorityRating.spec.tsx
+++ b/components/PriorityRating/PriorityRating.spec.tsx
@@ -36,7 +36,7 @@ describe('PriorityRating', () => {
     expect(getRatingString('none')).toBe('No priority');
   });
 
-  it('shows "no priority" and edit link in case a ragRating is not specified (legacy allocation)', () => {
+  it('shows "no priority", grey dot and edit link in case a ragRating is not specified (legacy allocation)', () => {
     render(
       <PriorityRating
         allocation={allocationFactory.build({ ragRating: undefined })}
@@ -44,6 +44,7 @@ describe('PriorityRating', () => {
       />
     );
     expect(screen.getByText('No priority')).toBeInTheDocument();
+    expect(screen.getByTestId('colourdot')).not.toBeNull();
     expect(screen.getByText('Edit')).toBeInTheDocument();
   });
 });

--- a/components/PriorityRating/PriorityRating.tsx
+++ b/components/PriorityRating/PriorityRating.tsx
@@ -41,16 +41,25 @@ const PriorityRating = ({
     borderRadius: '50%',
   };
 
-  style.backgroundColor = getRatingColour(
-    allocation.ragRating.toLowerCase() as keyof typeof colorMapping
-  );
+  if (allocation.ragRating) {
+    style.backgroundColor = getRatingColour(
+      allocation.ragRating.toLowerCase() as keyof typeof colorMapping
+    );
+  }
 
   return (
     <>
-      {`${getRatingString(
-        allocation.ragRating.toLowerCase() as keyof typeof ratingMapping
-      )} `}
-      <span data-testid="colourdot" style={style}></span>
+      {allocation.ragRating ? (
+        <>
+          {`${getRatingString(
+            allocation.ragRating.toLowerCase() as keyof typeof ratingMapping
+          )} `}
+          <span data-testid="colourdot" style={style}></span>
+        </>
+      ) : (
+        <>No priority</>
+      )}
+
       <span style={{ float: 'right', margin: '0 -18px 0 0' }}>
         <Link
           href={`/residents/${resident.id}/allocations/${allocation.id}/editpriority`}

--- a/components/PriorityRating/PriorityRating.tsx
+++ b/components/PriorityRating/PriorityRating.tsx
@@ -41,24 +41,20 @@ const PriorityRating = ({
     borderRadius: '50%',
   };
 
-  if (allocation.ragRating) {
-    style.backgroundColor = getRatingColour(
-      allocation.ragRating.toLowerCase() as keyof typeof colorMapping
-    );
+  if (!allocation.ragRating) {
+    allocation.ragRating = 'none';
   }
+
+  style.backgroundColor = getRatingColour(
+    allocation.ragRating.toLowerCase() as keyof typeof colorMapping
+  );
 
   return (
     <>
-      {allocation.ragRating ? (
-        <>
-          {`${getRatingString(
-            allocation.ragRating.toLowerCase() as keyof typeof ratingMapping
-          )} `}
-          <span data-testid="colourdot" style={style}></span>
-        </>
-      ) : (
-        <>No priority</>
-      )}
+      {`${getRatingString(
+        allocation.ragRating.toLowerCase() as keyof typeof ratingMapping
+      )} `}
+      <span data-testid="colourdot" style={style}></span>
 
       <span style={{ float: 'right', margin: '0 -18px 0 0' }}>
         <Link

--- a/pages/residents/[id]/allocations.tsx
+++ b/pages/residents/[id]/allocations.tsx
@@ -46,16 +46,6 @@ const AllocationsPage = ({ resident }: Props): React.ReactElement => {
         ) : allocationsToShow ? (
           <>
             {data.allocations?.map((a: Allocation) => {
-              const priorityLevel = (
-                <>
-                  {a.ragRating ? (
-                    <PriorityRating resident={resident} allocation={a} />
-                  ) : (
-                    'No priority '
-                  )}
-                </>
-              );
-
               const workerAllocation = (
                 <>
                   {a.allocatedWorker ? (
@@ -115,7 +105,9 @@ const AllocationsPage = ({ resident }: Props): React.ReactElement => {
                 >
                   <SummaryList
                     rows={{
-                      'Priority  Level': priorityLevel,
+                      'Priority  Level': (
+                        <PriorityRating resident={resident} allocation={a} />
+                      ),
                       'Date allocated to team': `${formatDate(
                         a.allocationStartDate
                       )} — ${


### PR DESCRIPTION
**What**  
This PR lets us add a priority level for legacy allocations (created without ragRating in the previous versions)

<img width="873" alt="Screenshot 2022-03-28 at 16 25 17" src="https://user-images.githubusercontent.com/13645306/160432348-8d94e1bb-e1bd-4bec-9f63-1d296b50ff84.png">

**Why**  
Before this there was no way on editing a ragRating for legacy applications

