### PR TITLE
fix: Disable flaky e2e tests

### DIFF
--- a/cypress/integration/view_warning_note_details.ts
+++ b/cypress/integration/view_warning_note_details.ts
@@ -2,7 +2,7 @@ import { AuthRoles } from '../support/commands';
 
 describe('Viewing a created warning note', () => {
   describe('As a user in the Adults group and records are not restricted', () => {
-    it('should show only the initial details of a warning note when created', () => {
+    xit('should show only the initial details of a warning note when created', () => {
       cy.visitAs(
         `/people/${Cypress.env('ADULT_RECORD_PERSON_ID')}`,
         AuthRoles.AdultsGroup
@@ -20,7 +20,7 @@ describe('Viewing a created warning note', () => {
       cy.contains('WARNING DETAILS').should('not.exist');
     });
 
-    it('should show the details of all submitted reviews and the initial note when a warning note has been reviewed', () => {
+    xit('should show the details of all submitted reviews and the initial note when a warning note has been reviewed', () => {
       cy.visitAs(
         `/people/${Cypress.env('ADULT_RECORD_PERSON_ID')}`,
         AuthRoles.AdultsGroup
@@ -54,7 +54,7 @@ describe('Viewing a created warning note', () => {
   });
 
   describe('As a user in the Children group and records are not restricted', () => {
-    it('should show only the initial details of a warning note when created', () => {
+    xit('should show only the initial details of a warning note when created', () => {
       cy.visitAs(
         `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}`,
         AuthRoles.ChildrensGroup
@@ -71,7 +71,7 @@ describe('Viewing a created warning note', () => {
       cy.contains('WARNING DETAILS').should('not.exist');
     });
 
-    it('should show the details of all submitted reviews and the initial note when a warning note has been reviewed', () => {
+    xit('should show the details of all submitted reviews and the initial note when a warning note has been reviewed', () => {
       cy.visitAs(
         `/people/${Cypress.env('CHILDREN_RECORD_PERSON_ID')}`,
         AuthRoles.ChildrensGroup


### PR DESCRIPTION
**What**  
E2E tests for Warning Notes are flaky and prone to error.
In particular those tests are looking for warning note creation/update/end strings in the timeline, but as time passes, those strings are buried in the timeline and the tests fails.

Tests has been disabled.


**Why**  
This is because they test only for the presence of the Warning Note strings.
E2E tests should test the whole flow, not only the presence of a string.
