### PR TITLE
fix: fix arrow nav

### DIFF
--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -13,7 +13,7 @@ import { useCase, useCases, useHistoricCaseNote } from 'utils/api/cases';
 import { useSubmission } from 'utils/api/submissions';
 import FlexibleAnswers from 'components/FlexibleAnswers/FlexibleAnswers';
 import Link from 'next/link';
-import { KeyboardEventHandler, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import RemoveCaseNoteDialog from './RemoveCaseNoteDialog';
 import { generateInternalLink } from 'utils/urls';
 
@@ -136,21 +136,31 @@ const CaseNoteDialog = ({
   });
   const worker = workerData?.[0];
 
-  const handleKeyboardNav: KeyboardEventHandler<HTMLDivElement> = (e) => {
-    let newId;
-    if (e.key === 'ArrowLeft') {
-      newId = caseNotes?.[i - 1]?.recordId; // previous/newer note
-    }
-    if (e.key === 'ArrowRight') {
-      if (caseNotes.length > i) {
-        newId = caseNotes?.[i + 1]?.recordId; // next/older note
+  const handleKeyboardNav = useCallback(
+    (e) => {
+      let newId;
+      if (e.key === 'ArrowLeft') {
+        console.log('<-');
+        newId = caseNotes?.[i - 1]?.recordId; // previous/newer note
       }
-    }
-    if (newId)
-      replace(`${window.location.pathname}?case_note=${newId}`, undefined, {
-        scroll: false,
-      });
-  };
+      if (e.key === 'ArrowRight') {
+        console.log('->');
+        if (caseNotes.length > i) {
+          newId = caseNotes?.[i + 1]?.recordId; // next/older note
+        }
+      }
+      if (newId)
+        replace(`${window.location.pathname}?case_note=${newId}`, undefined, {
+          scroll: false,
+        });
+    },
+    [caseNotes, i, replace]
+  );
+
+  useEffect(() => {
+    document.addEventListener('keyup', handleKeyboardNav);
+    return () => document.removeEventListener('keyup', handleKeyboardNav);
+  }, [handleKeyboardNav]);
 
   const handleClose = () =>
     replace(window.location.pathname, undefined, {
@@ -179,7 +189,6 @@ const CaseNoteDialog = ({
         title={prettyCaseTitle(note)}
         isOpen={!!query['case_note']}
         onDismiss={handleClose}
-        onKeyUp={handleKeyboardNav}
         className={s.dialog}
       >
         <p className="lbh-body-s">

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -140,11 +140,9 @@ const CaseNoteDialog = ({
     (e) => {
       let newId;
       if (e.key === 'ArrowLeft') {
-        console.log('<-');
         newId = caseNotes?.[i - 1]?.recordId; // previous/newer note
       }
       if (e.key === 'ArrowRight') {
-        console.log('->');
         if (caseNotes.length > i) {
           newId = caseNotes?.[i + 1]?.recordId; // next/older note
         }


### PR DESCRIPTION
https://trello.com/c/Dwn7mQiF/895-case-notes-arrows-get-stuck-on-non-case-notes

> this happens because workflows don't render a big chunk of the content inside the dialog, which is what the user was focused on. therefore focus is no longer "inside" the dialog when moving to a workflow, therefore the keyboard events aren't caught.
> we can prove this by clicking into the dialog of a workflow directly, or clicking on it after sliding into it with the keyboard. the arrows will then work again.


fixes it by moving the event listener off the dialog and onto the document element