### PR TITLE
fix: Allocation cosmetics

### DIFF
--- a/components/Allocations/SelectWorker/SelectWorker.tsx
+++ b/components/Allocations/SelectWorker/SelectWorker.tsx
@@ -10,11 +10,13 @@ const ResultEntry = ({
 }): React.ReactElement => {
   const { id, firstName, lastName, allocationCount } = worker;
 
+  const styleBlock = { verticalAlign: 'middle', padding: '0px 20px 0px 0' };
+
   return (
     <>
       <tr className={cx('govuk-table__row')}>
-        <td className="govuk-table__cell">
-          <div className="govuk-radios__item">
+        <td className="govuk-table__cell" style={styleBlock}>
+          <div className="govuk-radios__item" style={{ marginTop: '5px' }}>
             <input
               id={String(id)}
               name="workerId"
@@ -36,10 +38,14 @@ const ResultEntry = ({
             </label>
           </div>
         </td>
-        <td data-testid="workerName" className="govuk-table__cell">
+        <td
+          data-testid="workerName"
+          className="govuk-table__cell"
+          style={styleBlock}
+        >
           {`${firstName} ${lastName}`}
         </td>
-        <td className="govuk-table__cell">
+        <td className="govuk-table__cell" style={styleBlock}>
           <label data-testid="allocationCount" htmlFor={String(id)}>
             {allocationCount}
           </label>

--- a/components/Allocations/SelectWorker/__snapshots__/SelectWorker.spec.tsx.snap
+++ b/components/Allocations/SelectWorker/__snapshots__/SelectWorker.spec.tsx.snap
@@ -44,9 +44,11 @@ exports[`SelectWorker component should render a worker 1`] = `
       >
         <td
           class="govuk-table__cell"
+          style="vertical-align: middle; padding: 0px 20px 0px 0px;"
         >
           <div
             class="govuk-radios__item"
+            style="margin-top: 5px;"
           >
             <input
               class="govuk-radios__input"
@@ -71,11 +73,13 @@ exports[`SelectWorker component should render a worker 1`] = `
         <td
           class="govuk-table__cell"
           data-testid="workerName"
+          style="vertical-align: middle; padding: 0px 20px 0px 0px;"
         >
           Foo Bar
         </td>
         <td
           class="govuk-table__cell"
+          style="vertical-align: middle; padding: 0px 20px 0px 0px;"
         >
           <label
             data-testid="allocationCount"

--- a/components/PriorityRating/PriorityRating.spec.tsx
+++ b/components/PriorityRating/PriorityRating.spec.tsx
@@ -33,7 +33,7 @@ describe('PriorityRating', () => {
     expect(getRatingString('high')).toBe('High');
     expect(getRatingString('medium')).toBe('Medium');
     expect(getRatingString('low')).toBe('Low');
-    expect(getRatingString('none')).toBe('No priority');
+    expect(getRatingString('none')).toBe('No priority set');
   });
 
   it('shows "no priority", grey dot and edit link in case a ragRating is not specified (legacy allocation)', () => {
@@ -43,7 +43,7 @@ describe('PriorityRating', () => {
         resident={mockedResident}
       />
     );
-    expect(screen.getByText('No priority')).toBeInTheDocument();
+    expect(screen.getByText('No priority set')).toBeInTheDocument();
     expect(screen.getByTestId('colourdot')).not.toBeNull();
     expect(screen.getByText('Edit')).toBeInTheDocument();
   });

--- a/components/PriorityRating/PriorityRating.tsx
+++ b/components/PriorityRating/PriorityRating.tsx
@@ -18,7 +18,7 @@ const ratingMapping = {
   high: 'High',
   medium: 'Medium',
   low: 'Low',
-  none: 'No priority',
+  none: 'No priority set',
 };
 
 const colorMapping = {

--- a/pages/residents/[id]/allocations.tsx
+++ b/pages/residents/[id]/allocations.tsx
@@ -128,6 +128,7 @@ const AllocationsPage = ({ resident }: Props): React.ReactElement => {
         ) : (
           <p>
             No one is allocated to this resident yet.
+            <br />
             {allocateButton}
           </p>
         )}


### PR DESCRIPTION
**What**  
This PR fixes some cosmetic bits around allocations:

- on the resident page, “no priority” should read “no priority set”
- when choosing a worker in a team, can we vertically centre the text in the row
- the button for “allocate a team/worker” is arranged in a weird place after removing all allocations

**Why**  
Adjusting cosmetics

**Anything else?**

- Have you added any new third-party libraries? X 
- Are any new environment variables or configuration values needed? X 
- Anything else in this PR that isn't covered by the what/why?X 
