### PR TITLE
fix: allocation summary in header

### DIFF
--- a/components/NewPersonView/Layout.tsx
+++ b/components/NewPersonView/Layout.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { format } from 'date-fns';
 import { useRouter } from 'next/router';
-import { Allocation, Resident, User, CaseStatus } from 'types';
+import { Resident, User, CaseStatus } from 'types';
 import s from './index.module.scss';
 import { useRelationships } from 'utils/api/relationships';
 import { useAllocatedWorkers } from 'utils/api/allocatedWorkers';
@@ -14,6 +14,7 @@ import { canManageCases } from 'lib/permissions';
 import AddFormDialog from 'components/AddFormDialog/AddFormDialog';
 import { useState } from 'react';
 import Banner from 'components/FlexibleForms/Banner';
+import { summariseAllocations } from 'lib/formatters';
 import {
   ConditionalFeature,
   useFeatureFlags,
@@ -48,18 +49,6 @@ interface Props {
   person: Resident;
   children: React.ReactChild;
 }
-
-const summariseAllocations = (allocations: Allocation[]): string | null => {
-  if (allocations?.length === 1)
-    return ` · Allocated to ${allocations[0].allocatedWorker}`;
-  if (allocations?.length === 2)
-    return ` · Allocated to ${allocations[0].allocatedWorker} and 1 other`;
-  if (allocations?.length > 2)
-    return ` · Allocated to ${allocations[0].allocatedWorker} and ${
-      allocations?.length - 1
-    } others`;
-  return null;
-};
 
 const Layout = ({ person, children }: Props): React.ReactElement => {
   const { data: allocations } = useAllocatedWorkers(person.id);

--- a/lib/formatters.spec.ts
+++ b/lib/formatters.spec.ts
@@ -1,6 +1,7 @@
 import { mockedCaseNote } from 'factories/cases';
 import { mockedResident } from 'factories/residents';
 import { mockedWorker } from 'factories/workers';
+import { allocationFactory } from 'factories/allocatedWorkers';
 import { Resident } from 'types';
 import {
   prettyAddress,
@@ -8,6 +9,7 @@ import {
   prettyCaseTitle,
   prettyResidentName,
   prettyWorkerName,
+  summariseAllocations,
 } from './formatters';
 
 describe('prettyResidentName', () => {
@@ -86,5 +88,125 @@ describe('prettyCaseTitle', () => {
       formName: '',
     });
     expect(result).toBe('Unknown record');
+  });
+
+  it('displays the correct allocation in the header', () => {
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: 'Jon Doe',
+          allocatedWorkerTeam: 'The Best Team',
+        }),
+      ])
+    ).toBe(' · Allocated to Jon Doe (The Best Team)');
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: undefined,
+          allocatedWorkerTeam: 'The Best Team',
+        }),
+      ])
+    ).toBe(' · Allocated to The Best Team');
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: 'Jon Doe',
+          allocatedWorkerTeam: 'The Best Team',
+        }),
+      ])
+    ).toBe(' · Allocated to Jon Doe (The Best Team)');
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: undefined,
+          allocatedWorkerTeam: 'The Best Team',
+        }),
+      ])
+    ).toBe(' · Allocated to The Best Team');
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: 'Jon Doe',
+          allocatedWorkerTeam: 'The Best Team',
+        }),
+        allocationFactory.build({ allocatedWorker: 'Foo Bar' }),
+      ])
+    ).toBe(' · Allocated to Jon Doe (The Best Team) and 1 other');
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: undefined,
+          allocatedWorkerTeam: 'The Best Team',
+        }),
+        allocationFactory.build({ allocatedWorker: 'Foo Bar' }),
+      ])
+    ).toBe(' · Allocated to The Best Team and 1 other');
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: 'Jon Doe',
+          allocatedWorkerTeam: 'The Best Team',
+        }),
+        allocationFactory.build({ allocatedWorker: 'Foo Bar' }),
+      ])
+    ).toBe(' · Allocated to Jon Doe (The Best Team) and 1 other');
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: 'Jon Doe',
+          allocatedWorkerTeam: 'The Best Team',
+        }),
+        allocationFactory.build({ allocatedWorker: 'Foo Bar' }),
+        allocationFactory.build({ allocatedWorker: 'Agent Smith' }),
+      ])
+    ).toBe(' · Allocated to Jon Doe (The Best Team) and 2 others');
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: undefined,
+          allocatedWorkerTeam: 'The Best Team',
+        }),
+        allocationFactory.build({ allocatedWorker: 'Foo Bar' }),
+        allocationFactory.build({ allocatedWorker: 'Agent Smith' }),
+      ])
+    ).toBe(' · Allocated to The Best Team and 2 others');
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: 'Jon Doe',
+          allocatedWorkerTeam: 'The Best Team',
+        }),
+        allocationFactory.build({ allocatedWorker: 'Foo Bar' }),
+        allocationFactory.build({ allocatedWorker: 'Agent Smith' }),
+      ])
+    ).toBe(' · Allocated to Jon Doe (The Best Team) and 2 others');
+
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: 'Jon Doe',
+          allocatedWorkerTeam: undefined,
+        }),
+      ])
+    ).toBe(' · Allocated to Jon Doe');
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: 'Jon Doe',
+          allocatedWorkerTeam: undefined,
+        }),
+        allocationFactory.build({ allocatedWorker: 'Foo Bar' }),
+      ])
+    ).toBe(' · Allocated to Jon Doe and 1 other');
+    expect(
+      summariseAllocations([
+        allocationFactory.build({
+          allocatedWorker: 'Jon Doe',
+          allocatedWorkerTeam: undefined,
+        }),
+        allocationFactory.build({ allocatedWorker: 'Foo Bar' }),
+        allocationFactory.build({ allocatedWorker: 'Agent Smith' }),
+      ])
+    ).toBe(' · Allocated to Jon Doe and 2 others');
   });
 });

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -17,13 +17,35 @@ export const summariseAllocations = (
   allocations: Allocation[]
 ): string | null => {
   if (allocations?.length === 1)
-    return `Allocated to ${allocations[0].allocatedWorker}`;
+    return ` · Allocated to ${
+      allocations[0].allocatedWorker
+        ? `${allocations[0].allocatedWorker}${
+            allocations[0].allocatedWorkerTeam
+              ? ` (${allocations[0].allocatedWorkerTeam})`
+              : ''
+          }`
+        : allocations[0].allocatedWorkerTeam
+    }`;
   if (allocations?.length === 2)
-    return `Allocated to ${allocations[0].allocatedWorker} and 1 other`;
+    return ` · Allocated to ${
+      allocations[0].allocatedWorker
+        ? `${allocations[0].allocatedWorker}${
+            allocations[0].allocatedWorkerTeam
+              ? ` (${allocations[0].allocatedWorkerTeam})`
+              : ''
+          }`
+        : allocations[0].allocatedWorkerTeam
+    } and 1 other`;
   if (allocations?.length > 2)
-    return `Allocated to ${allocations[0].allocatedWorker} and ${
-      allocations?.length - 1
-    } others`;
+    return ` · Allocated to ${
+      allocations[0].allocatedWorker
+        ? `${allocations[0].allocatedWorker}${
+            allocations[0].allocatedWorkerTeam
+              ? ` (${allocations[0].allocatedWorkerTeam})`
+              : ''
+          }`
+        : allocations[0].allocatedWorkerTeam
+    } and ${allocations?.length - 1} others`;
   return null;
 };
 


### PR DESCRIPTION
**What**  
This PR fixes the displayed allocation in the header.
Code has been optimised as it was copy/pasted multiple time
Tests added

<img width="628" alt="Screenshot 2022-03-29 at 10 37 20" src="https://user-images.githubusercontent.com/13645306/160582137-57c16803-ccf9-4e8c-8940-45c96142d6df.png">

**Why**  
It was not supporting team-only allocation, so it was saying "Allocated to undefined" 

**Anything else?**

- Have you added any new third-party libraries? X 
- Are any new environment variables or configuration values needed? X 
- Anything else in this PR that isn't covered by the what/why? X
