### PR TITLE
feat: Added deallocationScope to dealllocation request object

### DIFF
--- a/components/Allocations/DeallocateTeamWorker/DeallocateTeamWorker.tsx
+++ b/components/Allocations/DeallocateTeamWorker/DeallocateTeamWorker.tsx
@@ -59,6 +59,7 @@ const DeallocateTeamWorker = ({
         id: Number(allocationId),
         deallocationReason: deallocationReason,
         deallocationDate: format(deallocationDate, 'yyyy-MM-dd'),
+        deallocationScope: type,
       });
 
       push(`/residents/${resident.id}/allocations`);


### PR DESCRIPTION
**What**  
This PR adds a `deallocationScope` parameter in the deallocateAllocation request.
This parameter can be either `worker` or `team` and it's placed in the body of the request

**Why**  
The BE will differentiate what to deallocate based on this parameter

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
