### PR TITLE
fix(SCT-1795): Added necessary parameters for children allocations/deallocations

### DIFF
--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.spec.tsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.spec.tsx
@@ -130,7 +130,7 @@ describe(`AddAllocatedWorker`, () => {
       allocatedTeamId: 3,
       allocatedWorkerId: 7,
       allocationStartDate: '2021-01-01',
-      ragRating: 'medium',
+      ragRating: 'none',
     });
   });
 });

--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.spec.tsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.spec.tsx
@@ -130,6 +130,7 @@ describe(`AddAllocatedWorker`, () => {
       allocatedTeamId: 3,
       allocatedWorkerId: 7,
       allocationStartDate: '2021-01-01',
+      ragRating: 'medium',
     });
   });
 });

--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.tsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.tsx
@@ -40,7 +40,7 @@ const AddAllocatedWorker = ({
         await addAllocatedWorker(personId, {
           allocatedTeamId: Number(teamId),
           allocatedWorkerId: Number(workerId),
-          ragRating: 'medium',
+          ragRating: 'none',
           allocationStartDate,
         });
         push(`/people/${personId}`);

--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.tsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.tsx
@@ -40,6 +40,7 @@ const AddAllocatedWorker = ({
         await addAllocatedWorker(personId, {
           allocatedTeamId: Number(teamId),
           allocatedWorkerId: Number(workerId),
+          ragRating: 'medium',
           allocationStartDate,
         });
         push(`/people/${personId}`);

--- a/components/AllocatedWorkers/DeallocateWorker/DeallocateWorker.tsx
+++ b/components/AllocatedWorkers/DeallocateWorker/DeallocateWorker.tsx
@@ -38,6 +38,7 @@ const DeallocatedWorkers = ({
     try {
       await deleteAllocation(personId, {
         id: allocationId,
+        deallocationScope: 'team',
         deallocationReason,
         deallocationDate,
       });


### PR DESCRIPTION
**What**  
This PR adds the necessary parameters for Children to add and remove allocations from the /people/{id}/allocations page

**Why**  
The structure of the (de)Allocation request in the BE has changed, but the /people/{id}/allocations form doesn't work as it uses the old request object.

**Anything else?**

- Have you added any new third-party libraries? X
- Are any new environment variables or configuration values needed? X
- Anything else in this PR that isn't covered by the what/why? X
