### PR TITLE
fix: Updating inline editor to use new PATCH endpoint

### DIFF
--- a/components/ResidentPage/InlineEditor.spec.tsx
+++ b/components/ResidentPage/InlineEditor.spec.tsx
@@ -8,7 +8,7 @@ jest.mock('utils/api/residents');
 (global.fetch as jest.Mock) = jest.fn(() =>
   Promise.resolve({
     json: () => Promise.resolve({}),
-    status: 200,
+    status: 204,
   })
 );
 
@@ -49,7 +49,6 @@ describe('InlineEditor', () => {
       },
       method: 'PATCH',
       body: JSON.stringify({
-        ...mockedResident,
         firstName: 'example value',
       }),
     });

--- a/components/ResidentPage/InlineEditor.tsx
+++ b/components/ResidentPage/InlineEditor.tsx
@@ -49,12 +49,11 @@ const InlineEditor = ({
       },
       method: 'PATCH',
       body: JSON.stringify({
-        ...resident,
         [name]: beforeSave ? beforeSave(data[name]) : data[name],
       }),
     });
     mutate(); // give it a kick
-    if (res.status === 200) {
+    if (res.status === 204) {
       onClose();
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lbh-social-care",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pages/api/residents/[id]/index.ts
+++ b/pages/api/residents/[id]/index.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { getResident, updateResident } from 'lib/residents';
+import { getResident, patchResident } from 'lib/residents';
 import { isAuthorised } from 'utils/auth';
 
 import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
@@ -45,7 +45,7 @@ const endpoint: NextApiHandler = async (
 
     case 'PATCH':
       try {
-        const data = await updateResident({
+        const data = await patchResident({
           id,
           ...req.body,
           createdBy: req.body.createdBy || user.email,

--- a/pages/api/residents/[id]/index.ts
+++ b/pages/api/residents/[id]/index.ts
@@ -1,6 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { getResident, patchResident } from 'lib/residents';
+import { getResident } from 'lib/residents';
+import { patchResident } from 'utils/api/residents';
 import { isAuthorised } from 'utils/auth';
 
 import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';

--- a/utils/api/residents.ts
+++ b/utils/api/residents.ts
@@ -32,3 +32,12 @@ export const updateResident = async (
   const { data } = await axios.patch(`/api/residents/${personId}`, formData);
   return { ref: data?.id, data };
 };
+
+export const patchResident = async (formData: {
+  id: number;
+  createdBy: string;
+  [key: string]: unknown;
+}): Promise<Record<string, unknown>> => {
+  const { data } = await axios.patch(`/api/residents`, formData);
+  return { ref: data?.id, data };
+};


### PR DESCRIPTION
**What**  
Updated inline editor to use a new PATCH endpoint
This will now only send edited information to the PATCH endpoint

**Why**  
We want to make use of a new PATCH endpoint that will update only edited information so that invalid fields do not prevent updating details
