### PR TITLE
fix: custom editors send less data

### DIFF
--- a/components/ResidentPage/CustomAddressEditor.spec.tsx
+++ b/components/ResidentPage/CustomAddressEditor.spec.tsx
@@ -122,7 +122,6 @@ describe('CustomAddressEditor', () => {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        ...mockedResident,
         address: {
           ...mockedResident.address,
           postcode: 'A1 1AA',

--- a/components/ResidentPage/CustomAddressEditor.tsx
+++ b/components/ResidentPage/CustomAddressEditor.tsx
@@ -43,7 +43,6 @@ const CustomAddressEditor = (props: Props): React.ReactElement => {
       },
       method: 'PATCH',
       body: JSON.stringify({
-        ...props.resident,
         address: {
           address: data.address.address,
           postcode: data.address.postcode,

--- a/components/ResidentPage/CustomGPDetailsEditor.tsx
+++ b/components/ResidentPage/CustomGPDetailsEditor.tsx
@@ -36,7 +36,6 @@ const CustomGPDetailsEditor = (props: Props): React.ReactElement => {
       },
       method: 'PATCH',
       body: JSON.stringify({
-        ...props.resident,
         gpDetails: data.gpDetails,
       }),
     });

--- a/components/ResidentPage/CustomKeyContactsEditor.tsx
+++ b/components/ResidentPage/CustomKeyContactsEditor.tsx
@@ -34,7 +34,6 @@ const CustomKeyContactsEditor = (props: Props): React.ReactElement => {
       },
       method: 'PATCH',
       body: JSON.stringify({
-        ...props.resident,
         keyContacts: data?.keyContacts
           ?.filter((n) => n.name || n.email)
           .map((kc) => ({

--- a/components/ResidentPage/CustomPhoneNumberEditor.spec.tsx
+++ b/components/ResidentPage/CustomPhoneNumberEditor.spec.tsx
@@ -136,7 +136,6 @@ describe('CustomPhoneNumberEditor', () => {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        ...mockedResident,
         phoneNumbers: [
           {
             type: 'One',

--- a/components/ResidentPage/CustomPhoneNumberEditor.tsx
+++ b/components/ResidentPage/CustomPhoneNumberEditor.tsx
@@ -34,7 +34,6 @@ const CustomPhoneNumberEditor = (props: Props): React.ReactElement => {
       },
       method: 'PATCH',
       body: JSON.stringify({
-        ...props.resident,
         phoneNumbers: data?.phoneNumbers
           ?.filter((n) => n.type || n.number)
           ?.map((n) => ({


### PR DESCRIPTION
custom inline editors for gp details, phone numbers, key contacts and address now send only the data that's changed, not the full object