### PR TITLE
fix: Changed worker for Allocations e2e tests

### DIFF
--- a/cypress/integration/team_allocations.ts
+++ b/cypress/integration/team_allocations.ts
@@ -91,7 +91,7 @@ describe('Worker / team allocation', () => {
 
       cy.get('#priority_medium').click();
       cy.get('#allocateWorker').click();
-      cy.get('#149').click();
+      cy.get('#170').click();
       cy.get('button[type=submit]').click();
 
       cy.visitAs(


### PR DESCRIPTION
**What**  
This PR changes the worker that's used for e2e tests

**Why**  
The previous worker is not available anymore

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
