### PR TITLE
fix: Update warning message on children records

### DIFF
--- a/components/StopDialog.spec.tsx
+++ b/components/StopDialog.spec.tsx
@@ -5,7 +5,7 @@ describe('StopDialog component', () => {
   it('displays the dialog ', () => {
     render(<StopDialog />);
 
-    expect(screen.getByText("You shouldn't make edits here any more"));
+    expect(screen.getByText("You shouldn't record here anymore"));
   });
 
   it("hides the dialog after they've clicked okay", () => {
@@ -13,8 +13,6 @@ describe('StopDialog component', () => {
 
     fireEvent.click(screen.getByRole('button'));
 
-    expect(
-      screen.queryByText("You shouldn't make edits here any more")
-    ).toBeNull();
+    expect(screen.queryByText("You shouldn't record here anymore")).toBeNull();
   });
 });

--- a/components/StopDialog.tsx
+++ b/components/StopDialog.tsx
@@ -14,7 +14,7 @@ const StopDialog = (): React.ReactElement | null => {
   if (isOpen)
     return (
       <Dialog
-        title="You shouldn't make edits here any more"
+        title="You shouldn't record here anymore"
         isOpen={true}
         onDismiss={() => setOpen(false)}
         showCloseButton={false}
@@ -22,12 +22,11 @@ const StopDialog = (): React.ReactElement | null => {
       >
         <>
           <p>
-            This is a child resident, so you must only use Mosaic for them from
-            now on.
+            If you are a CFS worker all of your work must be recorded on Mosaic.
           </p>
           <p className="govuk-!-margin-top-3">
-            The only exception is if you&apos;re about to turn this resident
-            into an adult.
+            If you are an ASC worker and need to record something about this
+            resident you need to first change the service context.
           </p>
 
           <button


### PR DESCRIPTION
**What**  
Small wording update to the message shown on children's records

**Why**  
This is so there's clearer messaging on the alert

