### PR TITLE
fix: Fix case note tags

### DIFF
--- a/components/ResidentPage/CaseNoteDialog.spec.tsx
+++ b/components/ResidentPage/CaseNoteDialog.spec.tsx
@@ -23,7 +23,7 @@ jest.mock('utils/api/submissions');
 (useHistoricCaseNote as jest.Mock).mockReturnValue({
   data: {
     ...mockedHistoricCaseNote,
-    content: '<h1>\r\n\t&nbsp;foo historic</h1>',
+    content: '<h1>\r\n\r\n\r\n\t\t&nbsp;&nbsp;foo historic</h1>',
   },
 });
 (useSubmission as jest.Mock).mockReturnValue({

--- a/components/ResidentPage/CaseNoteDialog.spec.tsx
+++ b/components/ResidentPage/CaseNoteDialog.spec.tsx
@@ -23,7 +23,7 @@ jest.mock('utils/api/submissions');
 (useHistoricCaseNote as jest.Mock).mockReturnValue({
   data: {
     ...mockedHistoricCaseNote,
-    content: '<h1>\r\n\r\n\r\n\t\t&nbsp;&nbsp;foo historic</h1>',
+    content: '<h1>\r\n\r\n\r\n\t\t&nbsp;&nbsp;foo &amp; historic</h1>',
   },
 });
 (useSubmission as jest.Mock).mockReturnValue({
@@ -190,7 +190,7 @@ describe('CaseNoteDialog', () => {
       />
     );
 
-    expect(screen.getByText('foo historic'));
+    expect(screen.getByText('foo & historic'));
     expect(screen.queryByText('<h1>')).toBeNull();
     expect(screen.queryByText('</h1>')).toBeNull();
     expect(screen.queryByText('\r')).toBeNull();

--- a/components/ResidentPage/CaseNoteDialog.spec.tsx
+++ b/components/ResidentPage/CaseNoteDialog.spec.tsx
@@ -23,7 +23,7 @@ jest.mock('utils/api/submissions');
 (useHistoricCaseNote as jest.Mock).mockReturnValue({
   data: {
     ...mockedHistoricCaseNote,
-    content: '<h1>\r\n\r\n\r\n\t\t&nbsp;&nbsp;foo &amp; historic</h1>',
+    content: '<h1>\r\n\r\n\r\n\t\t&nbsp;&nbsp;foo &amp; historic&rsquo;s</h1>',
   },
 });
 (useSubmission as jest.Mock).mockReturnValue({
@@ -190,7 +190,7 @@ describe('CaseNoteDialog', () => {
       />
     );
 
-    expect(screen.getByText('foo & historic'));
+    expect(screen.getByText("foo & historic's"));
     expect(screen.queryByText('<h1>')).toBeNull();
     expect(screen.queryByText('</h1>')).toBeNull();
     expect(screen.queryByText('\r')).toBeNull();

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -79,7 +79,8 @@ const HistoricCaseContent = ({ recordId }: HistoricContentProps) => {
               .replace(/\\n/gm, '')
               .replace(/\\t/gm, '')
               .replace(/&nbsp;/gm, '')
-              .replace(/&amp;/gm, '&'),
+              .replace(/&amp;/gm, '&')
+              .replace(/&rsquo;/gm, "'"),
           ])
         )}
       />

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -78,7 +78,8 @@ const HistoricCaseContent = ({ recordId }: HistoricContentProps) => {
               .replace(/\\r/gm, '')
               .replace(/\\n/gm, '')
               .replace(/\\t/gm, '')
-              .replace(/&nbsp;/gm, ''),
+              .replace(/&nbsp;/gm, '')
+              .replace(/&amp;/gm, '&'),
           ])
         )}
       />

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -75,10 +75,10 @@ const HistoricCaseContent = ({ recordId }: HistoricContentProps) => {
             JSON.stringify(value)
               .replace(/"/g, '')
               .replace(/(<([^>]+)>)/gi, '')
-              .replace('\\r', '')
-              .replace('\\n', '')
-              .replace('\\t', '')
-              .replace('&nbsp;', ''),
+              .replace(/\\r/gm, '')
+              .replace(/\\n/gm, '')
+              .replace(/\\t/gm, '')
+              .replace(/&nbsp;/gm, ''),
           ])
         )}
       />


### PR DESCRIPTION
**What**  
Update the replace function to replace based on regex 

**Why**  
This ensures that all instances of special characters are replaced, rather than just the first instance

**Anything else?**
We've replaced the majority of special characters that we've seen but may need to do more in the future
