### PR TITLE
fix: allow for normal new lines in case notes

### DIFF
--- a/components/ResidentPage/CaseNoteTile.spec.tsx
+++ b/components/ResidentPage/CaseNoteTile.spec.tsx
@@ -17,7 +17,7 @@ jest.mock('utils/api/submissions');
     id: mockedCaseNote.recordId,
     formAnswers: {
       singleStep: {
-        Body: 't&nbsp;\\t\\r\\n\\r\\n&nbsp;&nbsp;&nbsp;wo',
+        Body: 't\\t\\r\\n\\r\\nwo',
       },
     },
   },
@@ -45,10 +45,6 @@ describe('CaseNoteTile', () => {
       <CaseNoteTile
         c={{
           ...mockedCaseNote,
-          // caseFormData: {
-          //   ...mockedCaseNote.caseFormData,
-          //   note: '&nbsp;\\t\\r\\n\\r\\n&nbsp;&nbsp;&nbsp;I am the \r\n\r\n\tnote',
-          // },
           formType: 'flexible-form',
         }}
       />

--- a/lib/formatters.spec.ts
+++ b/lib/formatters.spec.ts
@@ -220,23 +220,23 @@ describe('tidyText', () => {
     expect(tidyText('input \\r\\nstring')).toBe('input string');
   });
   it('returns the string without special character when there is one special character with a single \\ in the string', () => {
-    expect(tidyText('input \r\nstring')).toBe('input string');
+    expect(tidyText('input \r\nstring')).toBe('input \r\nstring');
   });
   it('returns the string without special character when there is multiple special characters in the string', () => {
     expect(tidyText('input \\r\\n\r\n\t\\t\n\\n&nbsp;string')).toBe(
-      'input string'
+      'input \r\n\t\n string'
     );
   });
   it("returns the string with & and ' when there are &amp; and &rsquo; special characters in the string", () => {
     expect(
       tidyText('input&amp; \\r\\n\r\n\t\\t\n\\n &nbsp;str&rsquo;ing')
-    ).toBe("input&  str'ing");
+    ).toBe("input& \r\n\t\n  str'ing");
   });
   it("returns the string with & and ' replaced and special characters removed", () => {
     expect(
       tidyText(
-        '<h1>&nbsp;\\r\\n\\r\\n\\r\\n\\t\\r\\n\\t\\t\\r\\n\\t\\t\\t\\r\\n\\t\\t\\t&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;foo &amp; historic&rsquo;s</h1>'
+        '<h1>&nbsp;\\r\\n\\r\\n\\r\\n\\t\\r\\n\\t\\t\\r\\n\\t\\t\\t\\r\\n\\t\\t\\t&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;foo &amp; historic&rsquo;s</h1>'
       )
-    ).toBe("foo & historic's");
+    ).toBe("      foo & historic's");
   });
 });

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -90,11 +90,8 @@ export const tidyText = (inputText: string): string =>
     .replace(/\\r/gm, '')
     .replace(/\\\\n/gm, '')
     .replace(/\\n/gm, '')
-    .replace(/\r\n/gm, '')
-    .replace(/\n/gm, '')
     .replace(/\\\\t/gm, '')
     .replace(/\\t/gm, '')
-    .replace(/\t/gm, '')
-    .replace(/&nbsp;/gm, '')
+    .replace(/&nbsp;/gm, ' ')
     .replace(/&amp;/gm, '&')
     .replace(/&rsquo;/gm, "'");


### PR DESCRIPTION
**What**  
Allow for new lines to display on case notes.

**Why**  
We made a recent change to filter out escaped new lines but also covered normal new lines as part of this. This has lead to some case notes not rendering correctly.

**Anything else?**

- Have you added any new third-party libraries? ❌
- Are any new environment variables or configuration values needed? ❌
- Anything else in this PR that isn't covered by the what/why? ❌
