### PR TITLE
fix: Fixes for Worker and Team allocation

### DIFF
--- a/components/TeamPage/Layout.tsx
+++ b/components/TeamPage/Layout.tsx
@@ -60,13 +60,18 @@ const TeamLayout = ({ team, children }: Props): React.ReactElement => {
     <div className="govuk-breadcrumbs lbh-breadcrumbs lbh-container">
       <ol className="govuk-breadcrumbs__list">
         <li className="govuk-breadcrumbs__list-item">
-          <a className="govuk-breadcrumbs__link" href="/teams">
+          <a
+            className={`lbh-link lbh-link--no-visited-state ${s.link}`}
+            href="/teams"
+          >
             Teams
           </a>
         </li>
         <li className="govuk-breadcrumbs__list-item">{team.name}</li>
       </ol>
-      <h1 className="govuk-!-margin-top-1">{team.name}</h1>
+      <h1 className="govuk-!-margin-top-1 govuk-!-margin-bottom-7">
+        {team.name}
+      </h1>
 
       <div className="govuk-tabs lbh-tabs">
         <ul className={s.tabList}>

--- a/components/TeamPage/TeamAllocationsList/TeamAllocationsList.module.scss
+++ b/components/TeamPage/TeamAllocationsList/TeamAllocationsList.module.scss
@@ -27,7 +27,7 @@
 }
 
 .residentId {
-  color: grey;
+  color: #585d60;
   font-size: 15px;
 }
 
@@ -40,7 +40,7 @@
 }
 
 .elementValue {
-  color: grey;
+  color: #585d60;
 }
 
 .rowDescription {

--- a/components/TeamPage/TeamAllocationsList/TeamAllocationsList.spec.tsx
+++ b/components/TeamPage/TeamAllocationsList/TeamAllocationsList.spec.tsx
@@ -163,4 +163,29 @@ describe('TeamAllocationsList component', () => {
 
     expect(getByText(/3 days ago/i)).toBeInTheDocument();
   });
+  it('displays (Today) if the date difference is 0', async () => {
+    jest
+      .spyOn(teamWorkersAPI, 'useAllocationsByTeam')
+      .mockImplementation(() => {
+        const response = {
+          data: [
+            workerAllocationFactory.build({
+              allocations: [
+                allocationFactory.build({
+                  allocationStartDate: new Date().toString(),
+                }),
+              ],
+            }),
+          ],
+        } as unknown as SWRInfiniteResponse<AllocationData, Error>;
+
+        return response;
+      });
+
+    const { getByText } = render(
+      <TeamAllocationsList teamId={123} type="allocated" />
+    );
+
+    expect(getByText(/Today/i)).toBeInTheDocument();
+  });
 });

--- a/components/TeamPage/TeamAllocationsList/TeamAllocationsList.tsx
+++ b/components/TeamPage/TeamAllocationsList/TeamAllocationsList.tsx
@@ -41,7 +41,7 @@ export const TeamAllocation = ({
         </span>
       )}
       <span className={s.residentName}>
-        <Link href={`/residents/${allocation.personId}`}>
+        <Link href={`/residents/${allocation.personId}/allocations`}>
           <a
             className={classNames('lbh-link lbh-link--no-visited-state')}
             style={{ textDecoration: 'none' }}

--- a/components/TeamPage/TeamAllocationsList/TeamAllocationsList.tsx
+++ b/components/TeamPage/TeamAllocationsList/TeamAllocationsList.tsx
@@ -8,7 +8,7 @@ import { getRatingCSSColour } from 'components/PriorityRating/PriorityRating';
 import { capitalize } from 'lib/formatters';
 import classNames from 'classnames';
 import Link from 'next/link';
-import { formatDistance, subDays } from 'date-fns';
+import { formatDistance, isToday } from 'date-fns';
 
 interface TeamAllocationsListProps {
   teamId: number;
@@ -54,6 +54,8 @@ export const TeamAllocation = ({
     </>
   );
 
+  const allocationDate = new Date(allocation.allocationStartDate);
+
   const elm =
     type == 'unallocated' ? (
       <>
@@ -63,7 +65,7 @@ export const TeamAllocation = ({
             <b>Added to waitlist:</b>
             <span className={s.elementValue}>
               {' '}
-              {new Date(allocation.allocationStartDate).toLocaleDateString()}
+              {allocationDate.toLocaleDateString()}
             </span>
           </span>
         </div>
@@ -78,13 +80,13 @@ export const TeamAllocation = ({
               {' '}
               {allocation.allocatedWorker}
               {' on '}
-              {new Date(allocation.allocationStartDate).toLocaleDateString()}
+              {allocationDate.toLocaleDateString()}
               {' ('}
-              {formatDistance(
-                subDays(new Date(allocation.allocationStartDate), 0),
-                new Date(),
-                { addSuffix: true }
-              )}
+              {isToday(allocationDate)
+                ? 'Today'
+                : formatDistance(allocationDate, new Date(), {
+                    addSuffix: true,
+                  })}
               {') '}
             </span>
           </span>

--- a/components/TeamPage/TeamWorkerList/TeamWorkerList.tsx
+++ b/components/TeamPage/TeamWorkerList/TeamWorkerList.tsx
@@ -114,7 +114,7 @@ interface Props {
 }
 
 const TeamWorkerList = ({ users }: Props): React.ReactElement => (
-  <ul className="lbh-list">
+  <ul className="lbh-list govuk-!-margin-top-3">
     {users?.map((user) => (
       <TeamMember user={user} key={user.id} />
     ))}

--- a/components/WorkerView/WorkerAllocations/WorkerAllocations.module.scss
+++ b/components/WorkerView/WorkerAllocations/WorkerAllocations.module.scss
@@ -26,21 +26,21 @@
   font-weight: 600;
 }
 
+.dateSpan,
 .residentId {
-  color: grey;
+  color: #585d60;
   font-size: 15px;
 }
 
 .dateAdded,
-.workerAllocation,
-.dateAdded {
+.workerAllocation {
   b {
     font-weight: 600;
   }
 }
 
 .elementValue {
-  color: grey;
+  color: #585d60;
 }
 
 .rowDescription {

--- a/components/WorkerView/WorkerAllocations/WorkerAllocations.spec.tsx
+++ b/components/WorkerView/WorkerAllocations/WorkerAllocations.spec.tsx
@@ -25,7 +25,7 @@ describe('WorkerAllocations component', () => {
     const { queryByText } = render(<WorkerAllocations workerId={123} />);
 
     expect(queryByText('Medium')).toBeInTheDocument();
-    expect(queryByText('Worker allocation:')).toBeInTheDocument();
+    expect(queryByText('Date allocated:')).toBeInTheDocument();
     expect(queryByText('foo')).toBeInTheDocument();
   });
   it('displays the sorting element correctly', async () => {

--- a/components/WorkerView/WorkerAllocations/WorkerAllocations.spec.tsx
+++ b/components/WorkerView/WorkerAllocations/WorkerAllocations.spec.tsx
@@ -1,8 +1,11 @@
 import WorkerAllocations from './WorkerAllocations';
 
 import { render } from '@testing-library/react';
-import { mockedAllocations } from 'factories/allocatedWorkers';
-
+import {
+  mockedAllocations,
+  mockedAllocation,
+} from 'factories/allocatedWorkers';
+import { addDays } from 'date-fns';
 import * as workerAPI from 'utils/api/allocatedWorkers';
 
 jest.mock('utils/api/allocatedWorkers');
@@ -55,5 +58,39 @@ describe('WorkerAllocations component', () => {
 
     const { queryByText } = render(<WorkerAllocations workerId={123} />);
     expect(queryByText('No people are assigned to you')).toBeInTheDocument();
+  });
+  it('displays the correct amount of days in the difference between today and allocation date', async () => {
+    mockedAllocation.allocationStartDate = addDays(new Date(), -3).toString();
+
+    jest.spyOn(workerAPI, 'useAllocationsByWorker').mockImplementation(() => ({
+      data: {
+        workers: [],
+        allocations: [mockedAllocation],
+      },
+      revalidate: jest.fn(),
+      mutate: jest.fn(),
+      isValidating: false,
+    }));
+
+    const { getByText } = render(<WorkerAllocations workerId={123} />);
+
+    expect(getByText(/3 days ago/i)).toBeInTheDocument();
+  });
+  it('displays (Today) if the date difference is 0', async () => {
+    mockedAllocation.allocationStartDate = new Date().toString();
+
+    jest.spyOn(workerAPI, 'useAllocationsByWorker').mockImplementation(() => ({
+      data: {
+        workers: [],
+        allocations: [mockedAllocation],
+      },
+      revalidate: jest.fn(),
+      mutate: jest.fn(),
+      isValidating: false,
+    }));
+
+    const { getByText } = render(<WorkerAllocations workerId={123} />);
+
+    expect(getByText(/Today/i)).toBeInTheDocument();
   });
 });

--- a/components/WorkerView/WorkerAllocations/WorkerAllocations.tsx
+++ b/components/WorkerView/WorkerAllocations/WorkerAllocations.tsx
@@ -8,7 +8,7 @@ import { getRatingCSSColour } from 'components/PriorityRating/PriorityRating';
 import { capitalize } from 'lib/formatters';
 import classNames from 'classnames';
 import Link from 'next/link';
-import { formatDistance, subDays } from 'date-fns';
+import { formatDistance, isToday } from 'date-fns';
 
 interface WorkerAllocationssListProps {
   workerId: number;
@@ -50,6 +50,8 @@ export const WorkerAllocations = ({
     </>
   );
 
+  const allocationDate = new Date(allocation.allocationStartDate);
+
   return (
     <>
       {residentLine}
@@ -60,13 +62,11 @@ export const WorkerAllocations = ({
             {' '}
             {allocation.allocatedWorker}
             {' on '}
-            {new Date(allocation.allocationStartDate).toLocaleDateString()}
+            {allocationDate.toLocaleDateString()}
             {' ('}
-            {formatDistance(
-              subDays(new Date(allocation.allocationStartDate), 0),
-              new Date(),
-              { addSuffix: true }
-            )}
+            {isToday(allocationDate)
+              ? 'Today'
+              : formatDistance(allocationDate, new Date(), { addSuffix: true })}
             {') '}
           </span>
         </span>

--- a/components/WorkerView/WorkerAllocations/WorkerAllocations.tsx
+++ b/components/WorkerView/WorkerAllocations/WorkerAllocations.tsx
@@ -57,11 +57,9 @@ export const WorkerAllocations = ({
       {residentLine}
       <div className={s.rowDescription}>
         <span className={s.workerAllocation}>
-          <b>Worker allocation:</b>
+          <b>Date allocated:</b>
           <span data-testid="dateSpan" className={s.elementValue}>
-            {' '}
-            {allocation.allocatedWorker}
-            {' on '}
+            {'  '}
             {allocationDate.toLocaleDateString()}
             {' ('}
             {isToday(allocationDate)

--- a/components/WorkerView/WorkerAllocations/WorkerAllocations.tsx
+++ b/components/WorkerView/WorkerAllocations/WorkerAllocations.tsx
@@ -37,7 +37,7 @@ export const WorkerAllocations = ({
         </span>
       )}
       <span className={s.residentName}>
-        <Link href={`/residents/${allocation.personId}`}>
+        <Link href={`/residents/${allocation.personId}/allocations`}>
           <a
             className={classNames('lbh-link lbh-link--no-visited-state')}
             style={{ textDecoration: 'none' }}


### PR DESCRIPTION
**What**  

- When an allocation is created the same day, the time difference was calculated from midnight. Now it displays "Today"
- The links now points to the allocation page, rather than the main resident
- Adjusted the text in Worker Allocation so it displays "Date allocated" instead of the redundant worker name
- Colour of small text is now  #585d60;
- Teams link is now always in non-visited state
- Added a bottom margin of 35px to the team name
- Added a top margin to the first element of the worker list

Now displays "today"
![Screenshot 2022-04-13 at 15 38 33](https://user-images.githubusercontent.com/13645306/163205376-0e7e6b6a-5bc8-4d98-b8fa-27641d7d7255.png)


Displays "Date allocated" instead of the worker name in Worker Allocation view
Colour is now #585d60
![Screenshot 2022-04-13 at 15 37 19](https://user-images.githubusercontent.com/13645306/163205050-f79611c0-0552-4489-b690-0d7e447a9aa5.png)

Teams link is now always in non-visited state
Bottom margin of 35px to the team name
![Screenshot 2022-04-13 at 15 44 41](https://user-images.githubusercontent.com/13645306/163206619-8a3ccf50-9deb-4f57-bea6-7eb450a47c15.png)

Added a top margin to the first element of the worker list
![Screenshot 2022-04-13 at 15 47 58](https://user-images.githubusercontent.com/13645306/163207628-9a40dd6f-33e0-4fb6-bc0f-50dd51d33870.png)


**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
