### PR TITLE
feat(SCT-1823): Added support for teamAllocationStartDate

### DIFF
--- a/components/TeamPage/TeamAllocationsList/TeamAllocationsList.spec.tsx
+++ b/components/TeamPage/TeamAllocationsList/TeamAllocationsList.spec.tsx
@@ -64,6 +64,39 @@ describe('TeamAllocationsList component', () => {
     expect(queryByText('Worker allocation:')).toBeInTheDocument();
     expect(queryByText('#1')).toBeInTheDocument();
     expect(queryByText('Foo Bar')).toBeInTheDocument();
+    expect(queryByText('Team allocation:')).not.toBeInTheDocument();
+  });
+  it('displays the active cases with team allocation date correctly', async () => {
+    jest
+      .spyOn(teamWorkersAPI, 'useAllocationsByTeam')
+      .mockImplementation(() => {
+        const response = {
+          data: [
+            workerAllocationFactory.build({
+              allocations: [
+                allocationFactory.build({
+                  allocationStartDate: addDays(new Date(), -3).toISOString(),
+                  teamAllocationStartDate: addDays(
+                    new Date(),
+                    -10
+                  ).toISOString(),
+                }),
+              ],
+            }),
+          ],
+        } as unknown as SWRInfiniteResponse<AllocationData, Error>;
+
+        return response;
+      });
+    const { queryByText } = render(
+      <TeamAllocationsList teamId={123} type="allocated" />
+    );
+
+    expect(queryByText('Medium')).toBeInTheDocument();
+    expect(queryByText('Worker allocation:')).toBeInTheDocument();
+    expect(queryByText('#1')).toBeInTheDocument();
+    expect(queryByText('Foo Bar')).toBeInTheDocument();
+    expect(queryByText('Team allocation:')).toBeInTheDocument();
   });
   it('displays the sorting element correctly', async () => {
     jest
@@ -148,6 +181,10 @@ describe('TeamAllocationsList component', () => {
               allocations: [
                 allocationFactory.build({
                   allocationStartDate: addDays(new Date(), -3).toString(),
+                  teamAllocationStartDate: addDays(
+                    new Date(),
+                    -10
+                  ).toISOString(),
                 }),
               ],
             }),
@@ -162,6 +199,7 @@ describe('TeamAllocationsList component', () => {
     );
 
     expect(getByText(/3 days ago/i)).toBeInTheDocument();
+    expect(getByText(/10 days ago/i)).toBeInTheDocument();
   });
   it('displays (Today) if the date difference is 0', async () => {
     jest

--- a/components/TeamPage/TeamAllocationsList/TeamAllocationsList.tsx
+++ b/components/TeamPage/TeamAllocationsList/TeamAllocationsList.tsx
@@ -74,6 +74,25 @@ export const TeamAllocation = ({
       <>
         {residentLine}
         <div className={s.rowDescription}>
+          {allocation.teamAllocationStartDate && (
+            <>
+              <span className={s.workerAllocation}>
+                <b>Team allocation: </b>
+                <span data-testid="dateSpan" className={s.elementValue}>
+                  {isToday(new Date(allocation.teamAllocationStartDate))
+                    ? 'Today'
+                    : formatDistance(
+                        new Date(allocation.teamAllocationStartDate),
+                        new Date(),
+                        {
+                          addSuffix: true,
+                        }
+                      )}
+                </span>
+              </span>
+              <br />
+            </>
+          )}
           <span className={s.workerAllocation}>
             <b>Worker allocation:</b>
             <span data-testid="dateSpan" className={s.elementValue}>

--- a/components/TeamPage/TeamWorkerList/TeamWorkerList.spec.tsx
+++ b/components/TeamPage/TeamWorkerList/TeamWorkerList.spec.tsx
@@ -72,6 +72,7 @@ describe('TeamWorkerList component', () => {
           allocations: [
             allocationFactory.build({
               allocationStartDate: addDays(new Date(), -3).toString(),
+              teamAllocationStartDate: addDays(new Date(), -10).toISOString(),
             }),
           ],
         }),
@@ -92,6 +93,7 @@ describe('TeamWorkerList component', () => {
 
     fireEvent.click(screen.getByTestId(`expand_1`));
     expect(screen.queryByText(`Allocated to worker`)).toBeInTheDocument();
-    expect(screen.getByText(/3 days ago/i)).toBeInTheDocument();
+    expect(screen.queryByText(`Allocated to team`)).toBeInTheDocument();
+    expect(screen.getByText(/10 days ago/i)).toBeInTheDocument();
   });
 });

--- a/components/TeamPage/TeamWorkerList/TeamWorkerList.tsx
+++ b/components/TeamPage/TeamWorkerList/TeamWorkerList.tsx
@@ -39,6 +39,9 @@ const TeamMemberAllocations = ({ user }: TeamMemberProps) => {
               <th scope="col" className="govuk-table__header">
                 Allocated to worker
               </th>
+              <th scope="col" className="govuk-table__header">
+                Allocated to team
+              </th>
             </tr>
           </thead>
           <tbody className="govuk-table__body">
@@ -58,6 +61,18 @@ const TeamMemberAllocations = ({ user }: TeamMemberProps) => {
                     { addSuffix: true }
                   )}
                   {' )'}
+                </td>
+                <td className="govuk-table__cell">
+                  {allocation.teamAllocationStartDate &&
+                    formatDate(allocation.teamAllocationStartDate)}
+                  {allocation.teamAllocationStartDate && ' ('}
+                  {allocation.teamAllocationStartDate &&
+                    formatDistance(
+                      subDays(new Date(allocation.teamAllocationStartDate), 0),
+                      new Date(),
+                      { addSuffix: true }
+                    )}
+                  {allocation.teamAllocationStartDate && ')'}
                 </td>
               </tr>
             ))}

--- a/components/WorkerView/WorkerAllocations/WorkerAllocations.spec.tsx
+++ b/components/WorkerView/WorkerAllocations/WorkerAllocations.spec.tsx
@@ -27,6 +27,28 @@ describe('WorkerAllocations component', () => {
     expect(queryByText('Medium')).toBeInTheDocument();
     expect(queryByText('Date allocated:')).toBeInTheDocument();
     expect(queryByText('foo')).toBeInTheDocument();
+    expect(queryByText('Team allocation:')).not.toBeInTheDocument();
+  });
+  it('displays the active cases when theres a team allocation correctly', async () => {
+    mockedAllocation.allocationStartDate = new Date().toString();
+    mockedAllocation.teamAllocationStartDate = new Date().toString();
+
+    jest.spyOn(workerAPI, 'useAllocationsByWorker').mockImplementation(() => ({
+      data: {
+        workers: [],
+        allocations: [mockedAllocation],
+      },
+      revalidate: jest.fn(),
+      mutate: jest.fn(),
+      isValidating: false,
+    }));
+
+    const { queryByText } = render(<WorkerAllocations workerId={123} />);
+
+    expect(queryByText('Medium')).toBeInTheDocument();
+    expect(queryByText('Date allocated:')).toBeInTheDocument();
+    expect(queryByText('Team allocation:')).toBeInTheDocument();
+    expect(queryByText('foo')).toBeInTheDocument();
   });
   it('displays the sorting element correctly', async () => {
     jest.spyOn(workerAPI, 'useAllocationsByWorker').mockImplementation(() => ({
@@ -61,6 +83,10 @@ describe('WorkerAllocations component', () => {
   });
   it('displays the correct amount of days in the difference between today and allocation date', async () => {
     mockedAllocation.allocationStartDate = addDays(new Date(), -3).toString();
+    mockedAllocation.teamAllocationStartDate = addDays(
+      new Date(),
+      -10
+    ).toString();
 
     jest.spyOn(workerAPI, 'useAllocationsByWorker').mockImplementation(() => ({
       data: {
@@ -75,6 +101,7 @@ describe('WorkerAllocations component', () => {
     const { getByText } = render(<WorkerAllocations workerId={123} />);
 
     expect(getByText(/3 days ago/i)).toBeInTheDocument();
+    expect(getByText(/10 days ago/i)).toBeInTheDocument();
   });
   it('displays (Today) if the date difference is 0', async () => {
     mockedAllocation.allocationStartDate = new Date().toString();

--- a/components/WorkerView/WorkerAllocations/WorkerAllocations.tsx
+++ b/components/WorkerView/WorkerAllocations/WorkerAllocations.tsx
@@ -56,6 +56,26 @@ export const WorkerAllocations = ({
     <>
       {residentLine}
       <div className={s.rowDescription}>
+        {allocation.teamAllocationStartDate && (
+          <>
+            <span className={s.workerAllocation}>
+              <b>Team allocation: </b>
+              <span data-testid="dateSpan" className={s.elementValue}>
+                {isToday(new Date(allocation.teamAllocationStartDate))
+                  ? 'Today'
+                  : formatDistance(
+                      new Date(allocation.teamAllocationStartDate),
+                      new Date(),
+                      {
+                        addSuffix: true,
+                      }
+                    )}
+              </span>
+            </span>
+            <br />
+          </>
+        )}
+
         <span className={s.workerAllocation}>
           <b>Date allocated:</b>
           <span data-testid="dateSpan" className={s.elementValue}>

--- a/types.ts
+++ b/types.ts
@@ -21,6 +21,7 @@ export interface Allocation {
   allocatedWorkerTeamId?: number;
   allocatedWorkerTeam: string;
   allocatedWorker: string;
+  teamAllocationStartDate?: string;
   allocationStartDate: string;
   allocationEndDate?: string;
   workerType: string;


### PR DESCRIPTION
**What**  
This PR adds support for the parameter `teamAllocationStartDate`.
This parameter is still not sent by the backend

**Why**  
There's no current support for the Team Allocation start date

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
