### PR TITLE
chore: Gender Consolidation

### DIFF
--- a/data/forms/create-new-person.tsx
+++ b/data/forms/create-new-person.tsx
@@ -77,8 +77,9 @@ const formConfig: FormStep[] = [
         options: [
           { value: 'F', text: 'Female' },
           { value: 'M', text: 'Male' },
-          { value: 'U', text: 'Unknown' },
-          { value: 'I', text: 'Indeterminate' },
+          { value: 'Non-binary', text: 'Non-binary' },
+          { value: 'Other', text: 'Other' },
+          { value: 'Prefer not to say', text: 'Prefer not to say' },
         ],
         rules: { required: 'Please choose an option from the dropdown' },
       },


### PR DESCRIPTION
**What**  
Bringing "add new resident" page's Gender field into parity with the new Resident view

**Why**  
Because Trans and nonbinary people's lives matter

**Anything else?**

No tests as this was a small data change