### PR TITLE
fix(SCT-1826): Activity list bugs/tweaks

### DIFF
--- a/lib/allocatedWorkers.spec.ts
+++ b/lib/allocatedWorkers.spec.ts
@@ -42,13 +42,13 @@ describe('allocatedWorkersAPI', () => {
           ],
         },
       });
-      const data = await allocatedWorkersAPI.getResidentAllocation(123, 1);
+      const data = await allocatedWorkersAPI.getResidentAllocation(1);
       expect(data).toEqual({
         id: 1,
         allocationEndDate: null,
         caseStatus: 'Closed',
       });
-      const nodata = await allocatedWorkersAPI.getResidentAllocation(123, 3);
+      const nodata = await allocatedWorkersAPI.getResidentAllocation(3);
       expect(nodata).toEqual(undefined);
     });
   });

--- a/lib/allocatedWorkers.ts
+++ b/lib/allocatedWorkers.ts
@@ -10,6 +10,7 @@ const AWS_KEY = process.env.AWS_KEY;
 interface AllocationsParams {
   mosaic_id?: number;
   worker_id?: number;
+  allocation_id?: number;
   [key: string]: unknown;
 }
 
@@ -20,9 +21,8 @@ export const getAllocations = async (
 ): Promise<AllocationData> => {
   const urlParameters = {
     sort_by: sort_by ? sort_by : 'rag_rating',
-    status: showOnlyOpen ? 'open' : 'closed',
+    status: showOnlyOpen ? 'open' : undefined,
   };
-
   const { data } = await axios.get(
     `${ENDPOINT_API}/allocations?${getQueryString(urlParameters)}`,
     {
@@ -39,12 +39,14 @@ export const getResidentAllocatedWorkers = (
 ): Promise<AllocationData> => getAllocations({ mosaic_id, ...params });
 
 export const getResidentAllocation = async (
-  mosaic_id: number,
   allocation_id: number,
   params?: AllocationsParams
 ): Promise<Allocation | undefined> => {
   const showOnlyOpen = false;
-  const data = await getAllocations({ mosaic_id, ...params }, showOnlyOpen);
+  const data = await getAllocations(
+    { allocation_id: allocation_id, ...params },
+    showOnlyOpen
+  );
   return data?.allocations?.find(({ id }) => id === allocation_id);
 };
 export const getAllocationsByWorker = async (

--- a/pages/api/residents/[id]/allocations/[allocationId].ts
+++ b/pages/api/residents/[id]/allocations/[allocationId].ts
@@ -22,7 +22,6 @@ const endpoint: NextApiHandler = async (
     case 'GET':
       try {
         const data = await getResidentAllocation(
-          parseInt(req.query.id as string, 10),
           parseInt(req.query.allocationId as string, 10)
         );
         data

--- a/pages/residents/[id]/activity.tsx
+++ b/pages/residents/[id]/activity.tsx
@@ -6,18 +6,26 @@ import { Case, Resident } from 'types';
 import { useCases } from 'utils/api/cases';
 import { isAuthorised } from 'utils/auth';
 import { generateInternalLink } from 'utils/urls';
+import Spinner from 'components/Spinner/Spinner';
 
 interface Props {
   resident: Resident;
 }
 
 const ActivityPage = ({ resident }: Props): React.ReactElement => {
+  let showMore = false;
+
   const { data, size, setSize } = useCases({
     mosaic_id: resident.id,
   });
 
+  if (!data) {
+    return <Spinner />;
+  }
+
   let cases: Case[] = [];
   data?.map((page) => {
+    showMore = page.nextCursor ? true : false;
     if (page.cases) cases = cases.concat(page?.cases);
   });
 
@@ -67,12 +75,15 @@ const ActivityPage = ({ resident }: Props): React.ReactElement => {
           })}
         </tbody>
       </table>
-      <button
-        onClick={() => setSize(size + 1)}
-        className="govuk-button lbh-button"
-      >
-        Load more
-      </button>
+      {showMore && (
+        <button
+          onClick={() => setSize(size + 1)}
+          style={{ marginLeft: 'auto', marginRight: 'auto', display: 'flex' }}
+          className="govuk-button lbh-button"
+        >
+          Load more
+        </button>
+      )}
     </>
   );
 };

--- a/pagesTest/residents/[id]/activity.spec.tsx
+++ b/pagesTest/residents/[id]/activity.spec.tsx
@@ -6,26 +6,60 @@ import { AppConfigProvider } from 'lib/appConfig';
 
 import { mockedCaseNote } from 'factories/cases';
 jest.mock('utils/api/cases');
-(useCases as jest.Mock).mockReturnValue({
-  data: [
-    {
-      cases: [
-        mockedCaseNote,
-        {
-          ...mockedCaseNote,
-          recordId: '2',
-        },
-        {
-          ...mockedCaseNote,
-          recordId: '3',
-        },
-      ],
-    },
-  ],
-});
 
 describe('ActivityPage', () => {
   it('correctly renders a list of activity', () => {
+    (useCases as jest.Mock).mockReturnValue({
+      data: [
+        {
+          cases: [
+            mockedCaseNote,
+            {
+              ...mockedCaseNote,
+              recordId: '2',
+            },
+            {
+              ...mockedCaseNote,
+              recordId: '3',
+            },
+          ],
+        },
+      ],
+    });
+
+    render(
+      <AppConfigProvider appConfig={{}}>
+        <ActivityPage resident={mockedResident} />
+      </AppConfigProvider>
+    );
+
+    expect(screen.getByRole('table'));
+    expect(screen.getAllByRole('row').length).toBe(4);
+    expect(screen.getAllByRole('link').length).toBe(3);
+  });
+});
+
+describe('ActivityPage', () => {
+  it('correctly renders a long list of activity - adding load more button with cursor', () => {
+    (useCases as jest.Mock).mockReturnValue({
+      data: [
+        {
+          cases: [
+            mockedCaseNote,
+            {
+              ...mockedCaseNote,
+              recordId: '2',
+            },
+            {
+              ...mockedCaseNote,
+              recordId: '3',
+            },
+          ],
+          nextCursor: 123,
+        },
+      ],
+    });
+
     render(
       <AppConfigProvider appConfig={{}}>
         <ActivityPage resident={mockedResident} />


### PR DESCRIPTION
**What**  
API changes:

-Adjust the FE to load the allocation by ID when loading a timeline allocation element
-Changes the status parameter sent  when showOnlyOpen is set to false from "closed" to undefined, as the meaning of the boolean is "load all" and not "load only the closed ones"

UI changes:

-Check nextCursor existence and hide the button in case it’s null
-Add a spinner when loading data
-Center the Load More button


**Why**  
The Activity list stopped working properly because of the new Allocation system.
The UI was also not behaving properly

**Anything else?**

- Have you added any new third-party libraries? X 
- Are any new environment variables or configuration values needed? X
- Anything else in this PR that isn't covered by the what/why? X
