### PR TITLE
fix(SCT-1848): Allocation count

### DIFF
--- a/components/TeamPage/Layout.spec.tsx
+++ b/components/TeamPage/Layout.spec.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import {
   mockedTeam,
   mockedTeamWorker,
-  workerAllocationFactory,
+  allocationDataFactory,
   allocationFactory,
 } from 'factories/teams';
 import * as teamWorkersAPI from 'utils/api/allocatedWorkers';
@@ -21,9 +21,12 @@ jest.mock('next/router', () => ({
 
 jest.spyOn(teamWorkersAPI, 'useAllocationsByTeam').mockImplementation(() => {
   const response = {
-    data: workerAllocationFactory.build({
-      allocations: [allocationFactory.build()],
-    }),
+    data: [
+      allocationDataFactory.build({
+        allocations: [allocationFactory.build()],
+        totalCount: 256,
+      }),
+    ],
   } as unknown as SWRInfiniteResponse<AllocationData, Error>;
 
   return response;
@@ -55,6 +58,23 @@ describe('TeamLayout component', () => {
       </TeamLayout>
     );
     expect(queryByText('Team members (1)')).toBeInTheDocument();
+  });
+
+  it('loads correctly the allocations count', async () => {
+    jest.spyOn(teamWorkersAPI, 'useTeamWorkers').mockImplementation(() => ({
+      data: [mockedTeamWorker],
+      revalidate: jest.fn(),
+      mutate: jest.fn(),
+      isValidating: false,
+    }));
+
+    const { queryByText } = render(
+      <TeamLayout team={mockedTeam}>
+        <></>
+      </TeamLayout>
+    );
+    expect(queryByText('Waiting list (256)')).toBeInTheDocument();
+    expect(queryByText('Active cases (256)')).toBeInTheDocument();
   });
 
   it('displays correctly children components', async () => {

--- a/components/TeamPage/Layout.tsx
+++ b/components/TeamPage/Layout.tsx
@@ -40,6 +40,13 @@ const TeamLayout = ({ team, children }: Props): React.ReactElement => {
   }
 
   const allocated = [] as Allocation[];
+  const totalAllocated = allocatedTeamData[0]
+    ? allocatedTeamData[0].totalCount
+    : 0;
+  const totalUnallocated = unallocatedTeamData[0]
+    ? unallocatedTeamData[0].totalCount
+    : 0;
+
   for (
     let i = 0;
     allocatedTeamData !== undefined && i < allocatedTeamData.length;
@@ -85,7 +92,7 @@ const TeamLayout = ({ team, children }: Props): React.ReactElement => {
           >
             <Link href={`/teams/${team.id}`} scroll={false}>
               <a className={`lbh-link lbh-link--no-visited-state ${s.link}`}>
-                Waiting list ({unallocated?.length})
+                Waiting list {totalUnallocated && `(${totalUnallocated})`}
               </a>
             </Link>
           </li>
@@ -97,7 +104,7 @@ const TeamLayout = ({ team, children }: Props): React.ReactElement => {
           >
             <Link href={`/teams/${team.id}/active`} scroll={false}>
               <a className={`lbh-link lbh-link--no-visited-state ${s.link}`}>
-                Active cases ({allocated?.length})
+                Active cases {totalAllocated && `(${totalAllocated})`}
               </a>
             </Link>
           </li>

--- a/factories/teams.ts
+++ b/factories/teams.ts
@@ -1,5 +1,11 @@
 import { Factory } from 'fishery';
-import { Team, Worker, Allocation, WorkerAllocation } from 'types';
+import {
+  Team,
+  Worker,
+  Allocation,
+  WorkerAllocation,
+  AllocationData,
+} from 'types';
 
 export const mockedTeamFactory = Factory.define<Team>(({ sequence }) => ({
   id: sequence,
@@ -32,12 +38,16 @@ export const allocationFactory = Factory.define<Allocation>(({ sequence }) => ({
   personAddress: '',
   ragRating: 'medium',
 }));
-export const workerAllocationFactory = Factory.define<WorkerAllocation>(
-  ({ sequence }) => ({
-    workers: [],
-    allocations: [],
-  })
-);
+export const workerAllocationFactory = Factory.define<WorkerAllocation>(() => ({
+  workers: [],
+  allocations: [],
+}));
+export const allocationDataFactory = Factory.define<AllocationData>(() => ({
+  allocations: [allocationFactory.build()],
+  totalCount: 0,
+  nextCursor: 0,
+  deletedRecordsCount: 0,
+}));
 
 export const mockedTeam = mockedTeamFactory.build();
 export const mockedTeamWorker = mockedTeamWorkerFactory.build();


### PR DESCRIPTION
**What**  
This PR fixes the bug in which the allocation count is limited to the paginated response.
This goes together with SCT-1849 which adds the parameter to the response from the backend

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
