### PR TITLE
fix: Label review for residents workflows page

### DIFF
--- a/components/ResidentPage/WorkflowChunk.spec.tsx
+++ b/components/ResidentPage/WorkflowChunk.spec.tsx
@@ -24,6 +24,18 @@ describe('WorkflowChunk', () => {
     expect(screen.getByText('Reassessment'));
   });
 
+  it('marks a review', () => {
+    render(
+      <WorkflowChunk
+        workflow={{
+          ...mockWorkflow,
+          type: WorkflowType.Review,
+        }}
+      />
+    );
+    expect(screen.getByText('Review'));
+  });
+
   it('marks in progress', () => {
     render(<WorkflowChunk workflow={mockWorkflow} />);
     expect(screen.getByText('In progress'));

--- a/components/ResidentPage/WorkflowChunk.tsx
+++ b/components/ResidentPage/WorkflowChunk.tsx
@@ -20,6 +20,10 @@ export const WorkflowChunk = ({ workflow }: Props): React.ReactElement => (
       <span className="govuk-tag lbh-tag">Reassessment</span>
     )}
 
+    {workflow.type === WorkflowType.Review && (
+      <span className="govuk-tag lbh-tag">Review</span>
+    )}
+
     {!workflow.submittedAt && (
       <span className="govuk-tag lbh-tag lbh-tag--yellow">In progress</span>
     )}


### PR DESCRIPTION
**What**  
Label review for residents workflows page

**Why**  
workflows that are reviews that doesn't labelled as review 
