### PR TITLE
chore: Banner updated to add links to FAQ, Handbook and Support

### DIFF
--- a/components/Layout/PhaseBanner/PhaseBanner.spec.tsx
+++ b/components/Layout/PhaseBanner/PhaseBanner.spec.tsx
@@ -5,7 +5,7 @@ import PhaseBanner from './PhaseBanner';
 describe('PhaseBanner', () => {
   it('should render properly', async () => {
     const { asFragment } = render(
-      <PhaseBanner phase="alpha" feedbackLink="foo" />
+      <PhaseBanner phase="alpha" faqLink="foo" handbookLink="bar" />
     );
     expect(asFragment()).toMatchSnapshot();
   });

--- a/components/Layout/PhaseBanner/PhaseBanner.tsx
+++ b/components/Layout/PhaseBanner/PhaseBanner.tsx
@@ -1,20 +1,32 @@
 interface Props {
   phase: string;
-  feedbackLink: string;
+  faqLink: string;
+  handbookLink: string;
 }
 
-const PhaseBanner = ({ phase, feedbackLink }: Props): React.ReactElement => (
+const PhaseBanner = ({
+  phase,
+  faqLink,
+  handbookLink,
+}: Props): React.ReactElement => (
   <div className="govuk-phase-banner lbh-phase-banner lbh-container">
     <p className="govuk-phase-banner__content">
       <strong className="govuk-tag govuk-phase-banner__content__tag">
         {phase}
       </strong>
       <span className="govuk-phase-banner__text">
-        This is a new service – your{' '}
-        <a className="govuk-link" href={feedbackLink}>
-          feedback
+        Not sure how to do something or need help? Check out the{' '}
+        <a className="govuk-link" href={faqLink}>
+          FAQ
         </a>{' '}
-        will help us to improve it.
+        or the{' '}
+        <a className="govuk-link" href={handbookLink}>
+          handbook.
+        </a>{' '}
+        If you don&apos;t find the answer, contact{' '}
+        <a href="mailto:social-care.support@hackney.gov.uk">
+          social-care.support@hackney.gov.uk
+        </a>{' '}
       </span>
     </p>
   </div>

--- a/components/Layout/PhaseBanner/PhaseBanner.tsx
+++ b/components/Layout/PhaseBanner/PhaseBanner.tsx
@@ -16,11 +16,21 @@ const PhaseBanner = ({
       </strong>
       <span className="govuk-phase-banner__text">
         Need help? Check out the{' '}
-        <a className="govuk-link" href={faqLink}>
+        <a
+          className="lbh-link lbh-link--no-visited-state"
+          target="_blank"
+          rel="noreferrer noopener"
+          href={faqLink}
+        >
           FAQ
         </a>{' '}
         or the{' '}
-        <a className="govuk-link" href={handbookLink}>
+        <a
+          className="lbh-link lbh-link--no-visited-state"
+          target="_blank"
+          rel="noreferrer noopener"
+          href={handbookLink}
+        >
           handbook
         </a>
         . If you don&apos;t find the answer, contact{' '}

--- a/components/Layout/PhaseBanner/PhaseBanner.tsx
+++ b/components/Layout/PhaseBanner/PhaseBanner.tsx
@@ -15,7 +15,7 @@ const PhaseBanner = ({
         {phase}
       </strong>
       <span className="govuk-phase-banner__text">
-        Not sure how to do something or need help? Check out the{' '}
+        Need help? Check out the{' '}
         <a className="govuk-link" href={faqLink}>
           FAQ
         </a>{' '}
@@ -24,9 +24,7 @@ const PhaseBanner = ({
           handbook.
         </a>{' '}
         If you don&apos;t find the answer, contact{' '}
-        <a href="mailto:social-care.support@hackney.gov.uk">
-          social-care.support@hackney.gov.uk
-        </a>{' '}
+        <a href="mailto:social-care.support@hackney.gov.uk">support</a>{' '}
       </span>
     </p>
   </div>

--- a/components/Layout/PhaseBanner/PhaseBanner.tsx
+++ b/components/Layout/PhaseBanner/PhaseBanner.tsx
@@ -21,9 +21,9 @@ const PhaseBanner = ({
         </a>{' '}
         or the{' '}
         <a className="govuk-link" href={handbookLink}>
-          handbook.
-        </a>{' '}
-        If you don&apos;t find the answer, contact{' '}
+          handbook
+        </a>
+        . If you don&apos;t find the answer, contact{' '}
         <a href="mailto:social-care.support@hackney.gov.uk">support</a>{' '}
       </span>
     </p>

--- a/components/Layout/PhaseBanner/__snapshots__/PhaseBanner.spec.tsx.snap
+++ b/components/Layout/PhaseBanner/__snapshots__/PhaseBanner.spec.tsx.snap
@@ -16,14 +16,27 @@ exports[`PhaseBanner should render properly 1`] = `
       <span
         class="govuk-phase-banner__text"
       >
-        This is a new service – your 
+        Need help? Check out the 
         <a
           class="govuk-link"
           href="foo"
         >
-          feedback
+          FAQ
         </a>
-         will help us to improve it.
+         or the 
+        <a
+          class="govuk-link"
+          href="bar"
+        >
+          handbook.
+        </a>
+         If you don't find the answer, contact 
+        <a
+          href="mailto:social-care.support@hackney.gov.uk"
+        >
+          support
+        </a>
+         
       </span>
     </p>
   </div>

--- a/components/Layout/PhaseBanner/__snapshots__/PhaseBanner.spec.tsx.snap
+++ b/components/Layout/PhaseBanner/__snapshots__/PhaseBanner.spec.tsx.snap
@@ -18,15 +18,19 @@ exports[`PhaseBanner should render properly 1`] = `
       >
         Need help? Check out the 
         <a
-          class="govuk-link"
+          class="lbh-link lbh-link--no-visited-state"
           href="foo"
+          rel="noreferrer noopener"
+          target="_blank"
         >
           FAQ
         </a>
          or the 
         <a
-          class="govuk-link"
+          class="lbh-link lbh-link--no-visited-state"
           href="bar"
+          rel="noreferrer noopener"
+          target="_blank"
         >
           handbook
         </a>

--- a/components/Layout/PhaseBanner/__snapshots__/PhaseBanner.spec.tsx.snap
+++ b/components/Layout/PhaseBanner/__snapshots__/PhaseBanner.spec.tsx.snap
@@ -28,9 +28,9 @@ exports[`PhaseBanner should render properly 1`] = `
           class="govuk-link"
           href="bar"
         >
-          handbook.
+          handbook
         </a>
-         If you don't find the answer, contact 
+        . If you don't find the answer, contact 
         <a
           href="mailto:social-care.support@hackney.gov.uk"
         >

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -22,16 +22,21 @@ const Layout = ({
   const { user } = useAuth() as { user: User };
 
   if (noLayout) return <>{children}</>;
-
-  const feedbackLink =
-    'https://docs.google.com/forms/d/e/1FAIpQLScILbPD1ioKHzp1D3HN4_DKaxV2tpWLMu8upSSqNgSPCo85cg/viewform';
+  const faqLink =
+    'https://docs.google.com/document/d/1eM2anY9Ddot79Gl1N386ANG6ahyn4gjZr6vsoQQGLZg/edit#';
+  const handbookLink =
+    'https://docs.google.com/presentation/d/1AiTljatPK58xBk2Y7R9h9mUwDpusekv2jkuCgwMWpGk/edit#slide=id.gebf6791975_1_135';
 
   return (
     <>
       <Seo title="Social Care Admin - Hackney Council" />
       <SkipLink />
       <Header serviceName="Social Care" />
-      <PhaseBanner phase="beta" feedbackLink={feedbackLink} />
+      <PhaseBanner
+        phase="support"
+        faqLink={faqLink}
+        handbookLink={handbookLink}
+      />
       {goBackButton && <BackButton />}
 
       <div className="govuk-width-container">


### PR DESCRIPTION
**What**  
Have updated the banner to link to the FAQ, handbook and support

**Why**  
These are the places where people should now be turning to for support

<img width="763" alt="image" src="https://user-images.githubusercontent.com/32848419/166491320-eab85416-3ed3-4ca0-820e-41cefd7f0dfb.png">

