### PR TITLE
chore: Remove ability to click out of an input

### DIFF
--- a/components/ResidentPage/CustomGPDetailsEditor.tsx
+++ b/components/ResidentPage/CustomGPDetailsEditor.tsx
@@ -5,7 +5,6 @@ import { DataRow } from './DataBlock';
 import s from './CustomAddressEditor.module.scss';
 import { Field, Form, Formik, FormikProps } from 'formik';
 import { residentSchema } from 'lib/validators';
-import useClickOutside from 'hooks/useClickOutside';
 
 const Error = ({ error }: { error?: string }) =>
   error ? (
@@ -68,9 +67,6 @@ type InnerProps = Props & FormikProps<FormValues>;
 
 const InnerForm = ({ onClose, errors, touched, submitForm }: InnerProps) => {
   const ref = useRef<HTMLFormElement>(null);
-
-  useClickOutside(ref, onClose);
-
   const handleKeyup: KeyboardEventHandler = (e) => {
     if (e.key === 'Escape') onClose();
     if (e.key === 'Enter') submitForm();

--- a/components/ResidentPage/CustomKeyContactsEditor.tsx
+++ b/components/ResidentPage/CustomKeyContactsEditor.tsx
@@ -5,7 +5,6 @@ import { DataRow } from './DataBlock';
 import s from './CustomPhoneNumberEditor.module.scss';
 import { Field, FieldArray, Form, Formik, FormikProps, getIn } from 'formik';
 import { residentSchema } from 'lib/validators';
-import useClickOutside from 'hooks/useClickOutside';
 
 interface Props extends DataRow {
   onClose: () => void;
@@ -78,9 +77,6 @@ const InnerForm = ({
   touched,
 }: InnerProps): React.ReactElement => {
   const ref = useRef<HTMLFormElement>(null);
-
-  useClickOutside(ref, onClose);
-
   const handleKeyup: KeyboardEventHandler = (e) => {
     if (e.key === 'Escape') onClose();
     if (e.key === 'Enter') submitForm();

--- a/components/ResidentPage/CustomPhoneNumberEditor.tsx
+++ b/components/ResidentPage/CustomPhoneNumberEditor.tsx
@@ -5,7 +5,6 @@ import { DataRow } from './DataBlock';
 import s from './CustomPhoneNumberEditor.module.scss';
 import { Field, FieldArray, Form, Formik, FormikProps, getIn } from 'formik';
 import { residentSchema } from 'lib/validators';
-import useClickOutside from 'hooks/useClickOutside';
 
 interface Props extends DataRow {
   onClose: () => void;
@@ -78,9 +77,6 @@ const InnerForm = ({
   touched,
 }: InnerProps): React.ReactElement => {
   const ref = useRef<HTMLFormElement>(null);
-
-  useClickOutside(ref, onClose);
-
   const handleKeyup: KeyboardEventHandler = (e) => {
     if (e.key === 'Escape') onClose();
     if (e.key === 'Enter') submitForm();

--- a/components/ResidentPage/InlineEditor.tsx
+++ b/components/ResidentPage/InlineEditor.tsx
@@ -1,5 +1,4 @@
 import { Field, Form, Formik } from 'formik';
-import useClickOutside from 'hooks/useClickOutside';
 import { residentSchema } from 'lib/validators';
 import { useRef, KeyboardEvent } from 'react';
 import { Resident } from 'types';
@@ -37,8 +36,6 @@ const InlineEditor = ({
   const schema = residentSchema.pick([name]);
 
   const { mutate } = useResident(resident.id);
-
-  useClickOutside(ref, onClose);
 
   const handleSubmit = async (data: FormValues) => {
     const res = await fetch(`/api/residents/${resident.id}`, {


### PR DESCRIPTION
**What**  
This PR removes the usage of the hook `useClickOutside` on certain inputs on the resident details page.

**Why**  
This is to stop inputs on the page from closing if a user clicks anywhere outside the input. Now they will have to click the X icon to close the input.