### PR TITLE
fix: Team allocation display date

### DIFF
--- a/components/TeamPage/TeamAllocationsList/TeamAllocationsList.tsx
+++ b/components/TeamPage/TeamAllocationsList/TeamAllocationsList.tsx
@@ -102,6 +102,8 @@ export const TeamAllocation = ({
               <span className={s.workerAllocation}>
                 <b>Team allocation: </b>
                 <span data-testid="dateSpan" className={s.elementValue}>
+                  {allocationDate.toLocaleDateString()}
+                  {' ('}
                   {isToday(new Date(allocation.teamAllocationStartDate))
                     ? 'Today'
                     : formatDistance(
@@ -111,6 +113,7 @@ export const TeamAllocation = ({
                           addSuffix: true,
                         }
                       )}
+                  {') '}
                 </span>
               </span>
               <br />

--- a/components/WorkerView/WorkerAllocations/WorkerAllocations.tsx
+++ b/components/WorkerView/WorkerAllocations/WorkerAllocations.tsx
@@ -71,6 +71,8 @@ export const WorkerAllocations = ({
             <span className={s.workerAllocation}>
               <b>Team allocation: </b>
               <span data-testid="dateSpan" className={s.elementValue}>
+                {allocationDate.toLocaleDateString()}
+                {' ('}
                 {isToday(new Date(allocation.teamAllocationStartDate))
                   ? 'Today'
                   : formatDistance(
@@ -80,6 +82,7 @@ export const WorkerAllocations = ({
                         addSuffix: true,
                       }
                     )}
+                {') '}
               </span>
             </span>
             <br />


### PR DESCRIPTION
**What**  
Small UI fix that displays the team allocation date, together with how long ago that was done

<img width="865" alt="Screenshot 2022-05-04 at 15 59 18" src="https://user-images.githubusercontent.com/13645306/166709587-751925f9-01bc-4985-b32d-3c7ccd313353.png">

**Why**  
The UI was not showing the date, only how long ago it was allocated to the team

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
