### PR TITLE
chore: Sorts the team worker list by firstname/lastname

### DIFF
--- a/components/TeamPage/TeamWorkerList/TeamWorkerList.tsx
+++ b/components/TeamPage/TeamWorkerList/TeamWorkerList.tsx
@@ -130,9 +130,15 @@ interface Props {
 
 const TeamWorkerList = ({ users }: Props): React.ReactElement => (
   <ul className="lbh-list govuk-!-margin-top-3">
-    {users?.map((user) => (
-      <TeamMember user={user} key={user.id} />
-    ))}
+    {users
+      ?.sort(
+        (a, b) =>
+          a.firstName.localeCompare(b.firstName) ||
+          a.lastName.localeCompare(b.lastName)
+      )
+      .map((user) => (
+        <TeamMember user={user} key={user.id} />
+      ))}
   </ul>
 );
 


### PR DESCRIPTION
**What**  
This PR sorts by firstname/lastname the worker list in the team view

<img width="841" alt="Screenshot 2022-05-04 at 17 24 56" src="https://user-images.githubusercontent.com/13645306/166726691-46b0bf41-5a34-42da-86bb-8b10184d4e60.png">

**Why**  
There was no ordering before

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
