### PR TITLE
fix(SCT-1851): Don't display the date if it's the dummy imported one

### DIFF
--- a/components/TeamPage/TeamWorkerList/TeamWorkerList.tsx
+++ b/components/TeamPage/TeamWorkerList/TeamWorkerList.tsx
@@ -64,15 +64,25 @@ const TeamMemberAllocations = ({ user }: TeamMemberProps) => {
                 </td>
                 <td className="govuk-table__cell">
                   {allocation.teamAllocationStartDate &&
+                    allocation.teamAllocationStartDate !=
+                      '0001-01-01T00:00:00' &&
                     formatDate(allocation.teamAllocationStartDate)}
-                  {allocation.teamAllocationStartDate && ' ('}
                   {allocation.teamAllocationStartDate &&
+                    allocation.teamAllocationStartDate !=
+                      '0001-01-01T00:00:00' &&
+                    ' ('}
+                  {allocation.teamAllocationStartDate &&
+                    allocation.teamAllocationStartDate !=
+                      '0001-01-01T00:00:00' &&
                     formatDistance(
-                      subDays(new Date(allocation.teamAllocationStartDate), 0),
+                      new Date(allocation.teamAllocationStartDate),
                       new Date(),
                       { addSuffix: true }
                     )}
-                  {allocation.teamAllocationStartDate && ')'}
+                  {allocation.teamAllocationStartDate &&
+                    allocation.teamAllocationStartDate !=
+                      '0001-01-01T00:00:00' &&
+                    ')'}
                 </td>
               </tr>
             ))}

--- a/components/TeamPage/TeamWorkerList/TeamWorkerList.tsx
+++ b/components/TeamPage/TeamWorkerList/TeamWorkerList.tsx
@@ -66,23 +66,13 @@ const TeamMemberAllocations = ({ user }: TeamMemberProps) => {
                   {allocation.teamAllocationStartDate &&
                     allocation.teamAllocationStartDate !=
                       '0001-01-01T00:00:00' &&
-                    formatDate(allocation.teamAllocationStartDate)}
-                  {allocation.teamAllocationStartDate &&
-                    allocation.teamAllocationStartDate !=
-                      '0001-01-01T00:00:00' &&
-                    ' ('}
-                  {allocation.teamAllocationStartDate &&
-                    allocation.teamAllocationStartDate !=
-                      '0001-01-01T00:00:00' &&
-                    formatDistance(
+                    `${formatDate(
+                      allocation.teamAllocationStartDate
+                    )} (${formatDistance(
                       new Date(allocation.teamAllocationStartDate),
                       new Date(),
                       { addSuffix: true }
-                    )}
-                  {allocation.teamAllocationStartDate &&
-                    allocation.teamAllocationStartDate !=
-                      '0001-01-01T00:00:00' &&
-                    ')'}
+                    )})`}
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
**What**  
While importing data, we set some of the dates to 01-01-0001 as they were required by the system.
This PR hides that date from the UI as it doesn't make sense to display it.

![Screenshot 2022-05-05 at 09 56 47](https://user-images.githubusercontent.com/13645306/166891755-48a322a6-b061-46ad-bfd6-dbb92a407f5e.png)


**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
