### PR TITLE
feat: Workflow info labels

### DIFF
--- a/components/ResidentPage/CaseNoteDialog.spec.tsx
+++ b/components/ResidentPage/CaseNoteDialog.spec.tsx
@@ -362,7 +362,7 @@ describe('CaseNoteDialog', () => {
       },
     });
     (useWorkflowIds as jest.Mock).mockReturnValue({
-      data: { workflows: [{ ...mockWorkflow, type: 'Review' }] },
+      data: { workflow: { ...mockWorkflow, type: 'Review' } },
     });
 
     render(

--- a/components/ResidentPage/CaseNoteDialog.spec.tsx
+++ b/components/ResidentPage/CaseNoteDialog.spec.tsx
@@ -6,10 +6,14 @@ import { useRouter } from 'next/router';
 import { useCase, useCases, useHistoricCaseNote } from 'utils/api/cases';
 import { useSubmission } from 'utils/api/submissions';
 import { mockedHistoricCaseNote } from 'fixtures/cases.fixtures';
+import useWorkflowIds from '../../hooks/useWorkflowIds';
+import { mockWorkflow } from 'fixtures/workflows';
 
 jest.mock('next/router');
 jest.mock('utils/api/cases');
 jest.mock('utils/api/submissions');
+jest.mock('../../hooks/useWorkflowIds');
+(useWorkflowIds as jest.Mock).mockReturnValue({ error: new Error() });
 
 (useRouter as jest.Mock).mockReturnValue({
   query: {},
@@ -323,6 +327,62 @@ describe('CaseNoteDialog', () => {
         'Are you sure you want to remove this case note or record?'
       )
     );
+  });
+
+  it('does not show a workflow info badge by default', () => {
+    (useRouter as jest.Mock).mockReturnValueOnce({
+      query: {
+        case_note: mockedCaseNote.recordId,
+      },
+    });
+
+    render(
+      <CaseNoteDialog
+        totalCount={1}
+        caseNotes={[
+          {
+            ...mockedCaseNote,
+            caseFormData: {
+              ...mockedCaseNote.caseFormData,
+              form_url: 'https://example.com/foo',
+            },
+          },
+        ]}
+        socialCareId={123}
+      />
+    );
+
+    expect(screen.queryByTestId('workflow-info')).toBeNull();
+  });
+
+  it('does show a review workflow info badge if the workflow type is review', () => {
+    (useRouter as jest.Mock).mockReturnValueOnce({
+      query: {
+        case_note: mockedCaseNote.recordId,
+      },
+    });
+    (useWorkflowIds as jest.Mock).mockReturnValue({
+      data: { workflows: [{ ...mockWorkflow, type: 'Review' }] },
+    });
+
+    render(
+      <CaseNoteDialog
+        totalCount={1}
+        caseNotes={[
+          {
+            ...mockedCaseNote,
+            caseFormData: {
+              ...mockedCaseNote.caseFormData,
+              form_url: 'https://example.com/foo',
+            },
+          },
+        ]}
+        socialCareId={123}
+      />
+    );
+
+    expect(screen.queryByTestId('workflow-info')).not.toBeNull();
+    expect(screen.getByText('Review')).toBeVisible();
   });
 
   it.skip('only shows "Printable version" on records that have a full page version to go to', () => {

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -17,6 +17,7 @@ import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import RemoveCaseNoteDialog from './RemoveCaseNoteDialog';
 import { generateInternalLink } from 'utils/urls';
+import WorkflowInfoBadge from './WorkflowInfoBadge';
 
 interface SubmissionContentProps {
   submissionId: string;
@@ -206,6 +207,7 @@ const CaseNoteDialog = ({
         </p>
 
         <p className={`lbh-body-xs ${s.actions}`}>
+          <WorkflowInfoBadge workflowId={note?.caseFormData?.workflowId} />
           {isWorkflow ? (
             <Link
               href={`${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}/workflows/${note.caseFormData.workflowId}`}

--- a/components/ResidentPage/CaseNoteTile.spec.tsx
+++ b/components/ResidentPage/CaseNoteTile.spec.tsx
@@ -5,11 +5,15 @@ import { useWorker } from 'utils/api/workers';
 import { mockedWorker } from 'factories/workers';
 import { useSubmission } from 'utils/api/submissions';
 import { mockSubmission } from 'factories/submissions';
+import useWorkflowIds from '../../hooks/useWorkflowIds';
+import { mockWorkflow } from 'fixtures/workflows';
 
 jest.mock('utils/api/workers');
 jest.mock('utils/api/submissions');
+jest.mock('../../hooks/useWorkflowIds');
 
 (useWorker as jest.Mock).mockReturnValue({ data: [mockedWorker] });
+(useWorkflowIds as jest.Mock).mockReturnValue({ error: new Error() });
 
 (useSubmission as jest.Mock).mockReturnValue({
   data: {
@@ -51,5 +55,35 @@ describe('CaseNoteTile', () => {
     );
 
     expect(screen.getByText('two')).toBeVisible();
+  });
+
+  it('does not display a workflow info badge by default', () => {
+    render(
+      <CaseNoteTile
+        c={{
+          ...mockedCaseNote,
+          formType: 'flexible-form',
+        }}
+      />
+    );
+
+    expect(screen.queryByTestId('workflow-info')).toBeNull();
+  });
+
+  it('does display a workflow info badge if the workflow type is review', () => {
+    (useWorkflowIds as jest.Mock).mockReturnValue({
+      data: { workflows: [{ ...mockWorkflow, type: 'Review' }] },
+    });
+    render(
+      <CaseNoteTile
+        c={{
+          ...mockedCaseNote,
+          formType: 'flexible-form',
+        }}
+      />
+    );
+
+    expect(screen.queryByTestId('workflow-info')).not.toBeNull();
+    expect(screen.getByText('Review')).not.toBeNull();
   });
 });

--- a/components/ResidentPage/CaseNoteTile.spec.tsx
+++ b/components/ResidentPage/CaseNoteTile.spec.tsx
@@ -72,7 +72,7 @@ describe('CaseNoteTile', () => {
 
   it('does display a workflow info badge if the workflow type is review', () => {
     (useWorkflowIds as jest.Mock).mockReturnValue({
-      data: { workflows: [{ ...mockWorkflow, type: 'Review' }] },
+      data: { workflow: { ...mockWorkflow, type: 'Review' } },
     });
     render(
       <CaseNoteTile

--- a/components/ResidentPage/CaseNoteTile.tsx
+++ b/components/ResidentPage/CaseNoteTile.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { useWorker } from 'utils/api/workers';
 import cx from 'classnames';
 import { useSubmission } from 'utils/api/submissions';
+import WorkflowInfoBadge from './WorkflowInfoBadge';
 
 const prettyLink = (c: Case): string => {
   if (c?.caseFormData?.workflowId)
@@ -61,7 +62,7 @@ const CaseNoteTile = ({ c }: TileProps): React.ReactElement => {
         {isWorkflow && ` · Workflow`}
         {c.pinnedAt && ` · Pinned`}
       </p>
-      <h2 className="lbh-heading-h4">
+      <h2 className="lbh-heading-h4 govuk-!-margin-bottom-0">
         <Link href={prettyLink(c)} scroll={false}>
           <a className="lbh-link lbh-link--no-visited-state">
             {prettyCaseTitle(c)}
@@ -69,6 +70,7 @@ const CaseNoteTile = ({ c }: TileProps): React.ReactElement => {
         </Link>
       </h2>
 
+      <WorkflowInfoBadge workflowId={c?.caseFormData?.workflowId} />
       {c.formType === 'flexible-form' && (
         <SubmissionPreview submissionId={c.recordId} />
       )}

--- a/components/ResidentPage/WorkflowInfoBadge.module.scss
+++ b/components/ResidentPage/WorkflowInfoBadge.module.scss
@@ -1,0 +1,16 @@
+@import 'lbh-frontend/lbh/base';
+
+.badge{
+  margin-top: 8px;
+
+  span {
+    margin-top: 0px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 0px 5px;
+    margin-right: 10px;
+
+    &:last-child {
+      margin-right: 0;
+    }
+}}

--- a/components/ResidentPage/WorkflowInfoBadge.module.scss
+++ b/components/ResidentPage/WorkflowInfoBadge.module.scss
@@ -4,7 +4,7 @@
   margin-top: 8px;
 
   span {
-    margin-top: 0px;
+    margin-top: 1px;
     font-size: 0.9rem;
     font-weight: 600;
     padding: 0px 5px;

--- a/components/ResidentPage/WorkflowInfoBadge.spec.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.spec.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { mockWorkflow } from 'fixtures/workflows';
+import WorkflowInfoBadge from './WorkflowInfoBadge';
+
+describe('WorkflowInfoBadge', () => {
+  it('displays an unknown text if there is no workflow information', () => {
+    render(<WorkflowInfoBadge {...mockWorkflow.id} />);
+    const unknownLabel = screen.getByText('Unknown');
+    expect(unknownLabel).toBeVisible();
+    expect(
+      unknownLabel.className.includes('govuk-tag lbh-tag lbh-tag--grey')
+    ).toBe(true);
+  });
+  it('does not display a label if the workflow type is assessment', () => {
+    render(<WorkflowInfoBadge {...mockWorkflow.id} />);
+    const workflowLabel = screen.getByTestId('workflow-info');
+    expect(workflowLabel).toBeNull();
+  });
+});

--- a/components/ResidentPage/WorkflowInfoBadge.spec.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.spec.tsx
@@ -11,7 +11,7 @@ describe('WorkflowInfoBadge', () => {
 
     render(<WorkflowInfoBadge workflowId={mockWorkflow.id} />);
 
-    const unknownLabel = screen.getByText('Unknown');
+    const unknownLabel = screen.getByText('Unknown workflow type');
     expect(unknownLabel).toBeVisible();
     expect(unknownLabel.className).toBe('govuk-tag lbh-tag lbh-tag--grey');
   });

--- a/components/ResidentPage/WorkflowInfoBadge.spec.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.spec.tsx
@@ -1,19 +1,47 @@
 import { render, screen } from '@testing-library/react';
 import { mockWorkflow } from 'fixtures/workflows';
 import WorkflowInfoBadge from './WorkflowInfoBadge';
+import useWorkflowIds from '../../hooks/useWorkflowIds';
+
+jest.mock('../../hooks/useWorkflowIds');
 
 describe('WorkflowInfoBadge', () => {
   it('displays an unknown text if there is no workflow information', () => {
+    (useWorkflowIds as jest.Mock).mockReturnValue({ error: new Error() });
+
     render(<WorkflowInfoBadge {...mockWorkflow.id} />);
+
     const unknownLabel = screen.getByText('Unknown');
     expect(unknownLabel).toBeVisible();
-    expect(
-      unknownLabel.className.includes('govuk-tag lbh-tag lbh-tag--grey')
-    ).toBe(true);
+    expect(unknownLabel.className).toBe('govuk-tag lbh-tag lbh-tag--grey');
   });
+
   it('does not display a label if the workflow type is assessment', () => {
+    (useWorkflowIds as jest.Mock).mockReturnValue({
+      data: { workflows: [mockWorkflow] },
+    });
     render(<WorkflowInfoBadge {...mockWorkflow.id} />);
-    const workflowLabel = screen.getByTestId('workflow-info');
+    const workflowLabel = screen.queryByTestId('workflow-info');
     expect(workflowLabel).toBeNull();
+  });
+
+  it('displays a review label if the workflow type is review', () => {
+    (useWorkflowIds as jest.Mock).mockReturnValue({
+      data: { workflows: [{ ...mockWorkflow, type: 'Review' }] },
+    });
+    render(<WorkflowInfoBadge {...mockWorkflow.id} />);
+    const reviewLabel = screen.getByText('Review');
+    expect(reviewLabel).toBeVisible();
+    expect(reviewLabel.className).toBe('govuk-tag lbh-tag');
+  });
+
+  it('displays a reassessment label if the workflow type is reassessment', () => {
+    (useWorkflowIds as jest.Mock).mockReturnValue({
+      data: { workflows: [{ ...mockWorkflow, type: 'Reassessment' }] },
+    });
+    render(<WorkflowInfoBadge {...mockWorkflow.id} />);
+    const reviewLabel = screen.getByText('Reassessment');
+    expect(reviewLabel).toBeVisible();
+    expect(reviewLabel.className).toBe('govuk-tag lbh-tag');
   });
 });

--- a/components/ResidentPage/WorkflowInfoBadge.spec.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.spec.tsx
@@ -18,7 +18,7 @@ describe('WorkflowInfoBadge', () => {
 
   it('does not display a label if the workflow type is assessment', () => {
     (useWorkflowIds as jest.Mock).mockReturnValue({
-      data: { workflows: [mockWorkflow] },
+      data: { workflow: mockWorkflow },
     });
     render(<WorkflowInfoBadge workflowId={mockWorkflow.id} />);
     const workflowLabel = screen.queryByTestId('workflow-info');
@@ -34,7 +34,7 @@ describe('WorkflowInfoBadge', () => {
 
   it('displays a review label if the workflow type is review', () => {
     (useWorkflowIds as jest.Mock).mockReturnValue({
-      data: { workflows: [{ ...mockWorkflow, type: 'Review' }] },
+      data: { workflow: { ...mockWorkflow, type: 'Review' } },
     });
     render(<WorkflowInfoBadge workflowId={mockWorkflow.id} />);
     const reviewLabel = screen.getByText('Review');
@@ -44,7 +44,7 @@ describe('WorkflowInfoBadge', () => {
 
   it('displays a reassessment label if the workflow type is reassessment', () => {
     (useWorkflowIds as jest.Mock).mockReturnValue({
-      data: { workflows: [{ ...mockWorkflow, type: 'Reassessment' }] },
+      data: { workflow: { ...mockWorkflow, type: 'Reassessment' } },
     });
     render(<WorkflowInfoBadge workflowId={mockWorkflow.id} />);
     const reviewLabel = screen.getByText('Reassessment');

--- a/components/ResidentPage/WorkflowInfoBadge.spec.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.spec.tsx
@@ -6,10 +6,10 @@ import useWorkflowIds from '../../hooks/useWorkflowIds';
 jest.mock('../../hooks/useWorkflowIds');
 
 describe('WorkflowInfoBadge', () => {
-  it('displays an unknown text if there is no workflow information', () => {
+  it('displays an unknown text if there is a workflow id but an error from the api', () => {
     (useWorkflowIds as jest.Mock).mockReturnValue({ error: new Error() });
 
-    render(<WorkflowInfoBadge {...mockWorkflow.id} />);
+    render(<WorkflowInfoBadge workflowId={mockWorkflow.id} />);
 
     const unknownLabel = screen.getByText('Unknown');
     expect(unknownLabel).toBeVisible();
@@ -20,7 +20,14 @@ describe('WorkflowInfoBadge', () => {
     (useWorkflowIds as jest.Mock).mockReturnValue({
       data: { workflows: [mockWorkflow] },
     });
-    render(<WorkflowInfoBadge {...mockWorkflow.id} />);
+    render(<WorkflowInfoBadge workflowId={mockWorkflow.id} />);
+    const workflowLabel = screen.queryByTestId('workflow-info');
+    expect(workflowLabel).toBeNull();
+  });
+
+  it('does not display a label if the there is an error from the api and no workflowid', () => {
+    (useWorkflowIds as jest.Mock).mockReturnValue({ error: new Error() });
+    render(<WorkflowInfoBadge workflowId={undefined} />);
     const workflowLabel = screen.queryByTestId('workflow-info');
     expect(workflowLabel).toBeNull();
   });
@@ -29,7 +36,7 @@ describe('WorkflowInfoBadge', () => {
     (useWorkflowIds as jest.Mock).mockReturnValue({
       data: { workflows: [{ ...mockWorkflow, type: 'Review' }] },
     });
-    render(<WorkflowInfoBadge {...mockWorkflow.id} />);
+    render(<WorkflowInfoBadge workflowId={mockWorkflow.id} />);
     const reviewLabel = screen.getByText('Review');
     expect(reviewLabel).toBeVisible();
     expect(reviewLabel.className).toBe('govuk-tag lbh-tag');
@@ -39,7 +46,7 @@ describe('WorkflowInfoBadge', () => {
     (useWorkflowIds as jest.Mock).mockReturnValue({
       data: { workflows: [{ ...mockWorkflow, type: 'Reassessment' }] },
     });
-    render(<WorkflowInfoBadge {...mockWorkflow.id} />);
+    render(<WorkflowInfoBadge workflowId={mockWorkflow.id} />);
     const reviewLabel = screen.getByText('Reassessment');
     expect(reviewLabel).toBeVisible();
     expect(reviewLabel.className).toBe('govuk-tag lbh-tag');

--- a/components/ResidentPage/WorkflowInfoBadge.spec.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.spec.tsx
@@ -11,7 +11,7 @@ describe('WorkflowInfoBadge', () => {
 
     render(<WorkflowInfoBadge workflowId={mockWorkflow.id} />);
 
-    const unknownLabel = screen.getByText('Unknown workflow type');
+    const unknownLabel = screen.getByText("Couldn't fetch workflow type");
     expect(unknownLabel).toBeVisible();
     expect(unknownLabel.className).toBe('govuk-tag lbh-tag lbh-tag--grey');
   });

--- a/components/ResidentPage/WorkflowInfoBadge.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.tsx
@@ -10,7 +10,7 @@ interface Props {
 export const WorkflowInfoBadge = ({
   workflowId,
 }: Props): React.ReactElement => {
-  const { data, error } = useWorkflowIds(workflowId, 1);
+  const { data, error } = useWorkflowIds(workflowId);
 
   if (!data && !error) {
     return <></>;

--- a/components/ResidentPage/WorkflowInfoBadge.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.tsx
@@ -1,3 +1,4 @@
+import Tip from 'components/Tip/Tip';
 import useWorkflowIds from 'hooks/useWorkflowIds';
 import { WorkflowType } from './types';
 import s from './WorkflowInfoBadge.module.scss';
@@ -21,12 +22,14 @@ export const WorkflowInfoBadge = ({
       )}
 
       {workflowId && error && (
-        <span
-          className="govuk-tag lbh-tag lbh-tag--grey"
-          data-testid="workflow-info"
-        >
-          Unknown
-        </span>
+        <Tip content="There is workflow data that can not be retrieved currently">
+          <span
+            className="govuk-tag lbh-tag lbh-tag--grey"
+            data-testid="workflow-info"
+          >
+            Unknown workflow type
+          </span>
+        </Tip>
       )}
     </div>
   );

--- a/components/ResidentPage/WorkflowInfoBadge.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.tsx
@@ -12,27 +12,31 @@ export const WorkflowInfoBadge = ({
 }: Props): React.ReactElement => {
   const { data, error } = useWorkflowIds(workflowId, 1);
 
-  return (
-    <div className={s.badge}>
-      {(data?.workflows[0].type === WorkflowType.Review ||
-        data?.workflows[0].type === WorkflowType.Reassessment) && (
-        <span className="govuk-tag lbh-tag" data-testid="workflow-info">
-          {data?.workflows[0].type}
-        </span>
-      )}
-
-      {workflowId && error && (
-        <Tip content="There is workflow data that can not be retrieved currently">
-          <span
-            className="govuk-tag lbh-tag lbh-tag--grey"
-            data-testid="workflow-info"
-          >
-            Unknown workflow type
+  if (!data && !error) {
+    return <></>;
+  } else {
+    return (
+      <div className={s.badge}>
+        {(data?.workflows[0].type === WorkflowType.Review ||
+          data?.workflows[0].type === WorkflowType.Reassessment) && (
+          <span className="govuk-tag lbh-tag" data-testid="workflow-info">
+            {data?.workflows[0].type}
           </span>
-        </Tip>
-      )}
-    </div>
-  );
+        )}
+
+        {workflowId && error && (
+          <Tip content="There is workflow data that can not be retrieved currently">
+            <span
+              className="govuk-tag lbh-tag lbh-tag--grey"
+              data-testid="workflow-info"
+            >
+              Unknown workflow type
+            </span>
+          </Tip>
+        )}
+      </div>
+    );
+  }
 };
 
 export default WorkflowInfoBadge;

--- a/components/ResidentPage/WorkflowInfoBadge.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.tsx
@@ -30,7 +30,7 @@ export const WorkflowInfoBadge = ({
               className="govuk-tag lbh-tag lbh-tag--grey"
               data-testid="workflow-info"
             >
-              Unknown workflow type
+              Couldn&apos;t fetch workflow type
             </span>
           </Tip>
         )}

--- a/components/ResidentPage/WorkflowInfoBadge.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.tsx
@@ -1,0 +1,20 @@
+import useWorkflowIds from 'hooks/useWorkflowIds';
+import s from './WorkflowInfoBadge.module.scss';
+
+export const WorkflowInfoBadge = (workflowId?: string): React.ReactElement => {
+  //Get workflow assessment type
+  const { data, error } = useWorkflowIds(workflowId, 1000);
+
+  return (
+    <div className={s.badge}>
+      <span
+        className="govuk-tag lbh-tag lbh-tag--grey"
+        data-testid="workflow-info"
+      >
+        Unknown
+      </span>
+    </div>
+  );
+};
+
+export default WorkflowInfoBadge;

--- a/components/ResidentPage/WorkflowInfoBadge.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.tsx
@@ -2,7 +2,13 @@ import useWorkflowIds from 'hooks/useWorkflowIds';
 import { WorkflowType } from './types';
 import s from './WorkflowInfoBadge.module.scss';
 
-export const WorkflowInfoBadge = (workflowId: string): React.ReactElement => {
+interface Props {
+  workflowId?: string;
+}
+
+export const WorkflowInfoBadge = ({
+  workflowId,
+}: Props): React.ReactElement => {
   const { data, error } = useWorkflowIds(workflowId, 1);
 
   return (
@@ -14,7 +20,7 @@ export const WorkflowInfoBadge = (workflowId: string): React.ReactElement => {
         </span>
       )}
 
-      {error && (
+      {workflowId && error && (
         <span
           className="govuk-tag lbh-tag lbh-tag--grey"
           data-testid="workflow-info"

--- a/components/ResidentPage/WorkflowInfoBadge.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.tsx
@@ -1,18 +1,27 @@
 import useWorkflowIds from 'hooks/useWorkflowIds';
+import { WorkflowType } from './types';
 import s from './WorkflowInfoBadge.module.scss';
 
-export const WorkflowInfoBadge = (workflowId?: string): React.ReactElement => {
-  //Get workflow assessment type
-  const { data, error } = useWorkflowIds(workflowId, 1000);
+export const WorkflowInfoBadge = (workflowId: string): React.ReactElement => {
+  const { data, error } = useWorkflowIds(workflowId, 1);
 
   return (
     <div className={s.badge}>
-      <span
-        className="govuk-tag lbh-tag lbh-tag--grey"
-        data-testid="workflow-info"
-      >
-        Unknown
-      </span>
+      {(data?.workflows[0].type === WorkflowType.Review ||
+        data?.workflows[0].type === WorkflowType.Reassessment) && (
+        <span className="govuk-tag lbh-tag" data-testid="workflow-info">
+          {data?.workflows[0].type}
+        </span>
+      )}
+
+      {error && (
+        <span
+          className="govuk-tag lbh-tag lbh-tag--grey"
+          data-testid="workflow-info"
+        >
+          Unknown
+        </span>
+      )}
     </div>
   );
 };

--- a/components/ResidentPage/WorkflowInfoBadge.tsx
+++ b/components/ResidentPage/WorkflowInfoBadge.tsx
@@ -17,10 +17,10 @@ export const WorkflowInfoBadge = ({
   } else {
     return (
       <div className={s.badge}>
-        {(data?.workflows[0].type === WorkflowType.Review ||
-          data?.workflows[0].type === WorkflowType.Reassessment) && (
+        {(data?.workflow.type === WorkflowType.Review ||
+          data?.workflow.type === WorkflowType.Reassessment) && (
           <span className="govuk-tag lbh-tag" data-testid="workflow-info">
-            {data?.workflows[0].type}
+            {data?.workflow.type}
           </span>
         )}
 

--- a/hooks/useWorkflowIds.spec.tsx
+++ b/hooks/useWorkflowIds.spec.tsx
@@ -1,0 +1,16 @@
+import useWorkflowIds from './useWorkflowIds';
+import * as SWR from 'swr';
+
+jest.mock('swr');
+
+describe('useWorkflowIds', () => {
+  it('should work properly', async () => {
+    jest.spyOn(SWR, 'default');
+
+    useWorkflowIds('050001');
+    expect(SWR.default).toHaveBeenCalledWith(
+      `${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}/api/workflows/050001?per_page=20`,
+      expect.any(Function)
+    );
+  });
+});

--- a/hooks/useWorkflowIds.spec.tsx
+++ b/hooks/useWorkflowIds.spec.tsx
@@ -13,4 +13,10 @@ describe('useWorkflowIds', () => {
       expect.any(Function)
     );
   });
+  it('should handle no workflow id properly', async () => {
+    jest.spyOn(SWR, 'default');
+
+    useWorkflowIds();
+    expect(SWR.default).toHaveBeenCalledWith(null, expect.any(Function));
+  });
 });

--- a/hooks/useWorkflowIds.spec.tsx
+++ b/hooks/useWorkflowIds.spec.tsx
@@ -9,7 +9,7 @@ describe('useWorkflowIds', () => {
 
     useWorkflowIds('050001');
     expect(SWR.default).toHaveBeenCalledWith(
-      `${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}/api/workflows/050001?per_page=20`,
+      `${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}/api/workflows/050001`,
       expect.any(Function)
     );
   });

--- a/hooks/useWorkflowIds.ts
+++ b/hooks/useWorkflowIds.ts
@@ -8,13 +8,10 @@ interface Res {
 }
 
 /** get a resident's workflows, using their social care id */
-const useWorkflowIds = (
-  workflowId?: string,
-  limit = 20
-): SWRResponse<Res, Error> => {
+const useWorkflowIds = (workflowId?: string): SWRResponse<Res, Error> => {
   return useSWR(
     workflowId
-      ? `${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}/api/workflows/${workflowId}?per_page=${limit}`
+      ? `${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}/api/workflows/${workflowId}`
       : null,
     (resource, options) =>
       axios

--- a/hooks/useWorkflowIds.ts
+++ b/hooks/useWorkflowIds.ts
@@ -3,8 +3,7 @@ import { Workflow } from 'components/ResidentPage/types';
 import useSWR, { SWRResponse } from 'swr';
 
 interface Res {
-  workflows: Workflow[];
-  count: number;
+  workflow: Workflow;
 }
 
 /** get a resident's workflows, using their social care id */

--- a/hooks/useWorkflowIds.ts
+++ b/hooks/useWorkflowIds.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import { Workflow } from 'components/ResidentPage/types';
+import useSWR, { SWRResponse } from 'swr';
+
+interface Res {
+  workflows: Workflow[];
+  count: number;
+}
+
+/** get a resident's workflows, using their social care id */
+const useWorkflowIds = (
+  workflowId: string,
+  limit = 20
+): SWRResponse<Res, Error> => {
+  return useSWR(
+    `${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}/api/workflows/${workflowId}?per_page=${limit}`,
+    (resource, options) =>
+      axios
+        .get(resource, {
+          ...options,
+          withCredentials: true,
+        })
+        .then((res) => res.data)
+  );
+};
+
+export default useWorkflowIds;

--- a/hooks/useWorkflowIds.ts
+++ b/hooks/useWorkflowIds.ts
@@ -9,11 +9,13 @@ interface Res {
 
 /** get a resident's workflows, using their social care id */
 const useWorkflowIds = (
-  workflowId: string,
+  workflowId?: string,
   limit = 20
 ): SWRResponse<Res, Error> => {
   return useSWR(
-    `${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}/api/workflows/${workflowId}?per_page=${limit}`,
+    workflowId
+      ? `${process.env.NEXT_PUBLIC_CORE_PATHWAY_APP_URL}/api/workflows/${workflowId}?per_page=${limit}`
+      : null,
     (resource, options) =>
       axios
         .get(resource, {


### PR DESCRIPTION
**What**  
* Have added a new workflow information badge in to case note titles and case note dialog
* The information badge will only display information if the note is for a workflow and the workflow type is 'Review', 'Reassessment' or if it was not possible to get the workflow type
* A new hook has been made to enable this
* Additional tests have been written for this 

**Why**  
It was unclear to users when workflows were reviews or reassessments on the mainstream app, so this label was added to clarify this

**Anything else?**
We should check this once it's been deployed to staging to be sure that reviews, reassessments and assessments are all clear
