### PR TITLE
chore: Stop opening of case-note dialog on resident details page

### DIFF
--- a/components/ResidentPage/CaseNoteDialog.spec.tsx
+++ b/components/ResidentPage/CaseNoteDialog.spec.tsx
@@ -210,6 +210,7 @@ describe('CaseNoteDialog', () => {
   it('can be navigate to an older note by keyboard', () => {
     const mockReplace = jest.fn();
     (useRouter as jest.Mock).mockReturnValue({
+      pathname: '/case-notes',
       query: {
         case_note: 'abc',
       },
@@ -244,6 +245,7 @@ describe('CaseNoteDialog', () => {
   it('can be navigate to a newer note by keyboard', () => {
     const mockReplace = jest.fn();
     (useRouter as jest.Mock).mockReturnValue({
+      pathname: '/case-notes',
       query: {
         case_note: 'def',
       },

--- a/components/ResidentPage/CaseNoteDialog.tsx
+++ b/components/ResidentPage/CaseNoteDialog.tsx
@@ -118,7 +118,7 @@ const CaseNoteDialog = ({
   socialCareId,
   totalCount,
 }: Props): React.ReactElement | null => {
-  const { query, replace } = useRouter();
+  const { query, replace, pathname } = useRouter();
 
   const { mutate } = useCases({
     mosaic_id: socialCareId,
@@ -157,7 +157,7 @@ const CaseNoteDialog = ({
           newId = caseNotes?.[i + 1]?.recordId; // next/older note
         }
       }
-      if (newId)
+      if (newId && pathname.includes('case-notes'))
         replace(`${window.location.pathname}?case_note=${newId}`, undefined, {
           scroll: false,
         });


### PR DESCRIPTION
**What**  
This PR stops the keyboard navigation from opening the case notes dialog on the resident details by only updating the path to open a case note on the case-notes page on the resident view.
**Why**  
This is to stop users from being able to opening the case note dialog on any other page beside the case-notes page on the resident view.

**Anything else?**
Any suggestions to improve this would be helpful, I am not very knowledgeable on how events work.
