### PR TITLE
fix: ERR_STREAM_WRITE_AFTER_END thrown on unauthenticated API requests

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -103,10 +103,9 @@ CustomApp.getInitialProps = async (
     const redirect =
       appContext.ctx.req.url && shouldRedirect(appContext.ctx.req.url, user);
     if (redirect && appContext.ctx.res.writeHead) {
-      appContext.ctx.res.writeHead(302, {
-        Location: redirect,
-      });
-      appContext.ctx.res.end();
+      appContext.ctx.res.setHeader('Location', redirect);
+      appContext.ctx.res.statusCode = 302;
+      return { pageProps: {} };
     }
   }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -18,6 +18,7 @@ import { FeatureFlagProvider } from '../lib/feature-flags/feature-flags';
 import { getFeatureFlags } from 'features';
 import { useEffect } from 'react';
 import { AppConfigProvider } from 'lib/appConfig';
+import { StatusCodes } from 'http-status-codes';
 
 interface Props {
   user?: Partial<User>;
@@ -104,7 +105,7 @@ CustomApp.getInitialProps = async (
       appContext.ctx.req.url && shouldRedirect(appContext.ctx.req.url, user);
     if (redirect && appContext.ctx.res.writeHead) {
       appContext.ctx.res.setHeader('Location', redirect);
-      appContext.ctx.res.statusCode = 302;
+      appContext.ctx.res.statusCode = StatusCodes.TEMPORARY_REDIRECT;
       return { pageProps: {} };
     }
   }

--- a/pages/api/cases/[caseId].ts
+++ b/pages/api/cases/[caseId].ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   const { caseId, residentId, ...params } = req.query;
   switch (req.method) {

--- a/pages/api/cases/[caseId].ts
+++ b/pages/api/cases/[caseId].ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   const { caseId, residentId, ...params } = req.query;
   switch (req.method) {

--- a/pages/api/cases/historic-note/[caseId].ts
+++ b/pages/api/cases/historic-note/[caseId].ts
@@ -12,10 +12,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   const { caseId, ...params } = req.query;
   switch (req.method) {

--- a/pages/api/cases/historic-note/[caseId].ts
+++ b/pages/api/cases/historic-note/[caseId].ts
@@ -12,10 +12,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   const { caseId, ...params } = req.query;
   switch (req.method) {

--- a/pages/api/cases/historic-visit/[caseId].ts
+++ b/pages/api/cases/historic-visit/[caseId].ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   const { caseId, ...params } = req.query;
   switch (req.method) {

--- a/pages/api/cases/historic-visit/[caseId].ts
+++ b/pages/api/cases/historic-visit/[caseId].ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   const { caseId, ...params } = req.query;
   switch (req.method) {

--- a/pages/api/cases/index.ts
+++ b/pages/api/cases/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/cases/index.ts
+++ b/pages/api/cases/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/casestatus/[id]/index.ts
+++ b/pages/api/casestatus/[id]/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
 
   switch (req.method) {

--- a/pages/api/casestatus/[id]/index.ts
+++ b/pages/api/casestatus/[id]/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
 
   switch (req.method) {

--- a/pages/api/casestatus/index.ts
+++ b/pages/api/casestatus/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
 
   switch (req.method) {

--- a/pages/api/casestatus/index.ts
+++ b/pages/api/casestatus/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
 
   switch (req.method) {

--- a/pages/api/casestatus/update/[caseStatusId]/index.ts
+++ b/pages/api/casestatus/update/[caseStatusId]/index.ts
@@ -13,10 +13,11 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
   }
 
   switch (req.method) {

--- a/pages/api/casestatus/update/[caseStatusId]/index.ts
+++ b/pages/api/casestatus/update/[caseStatusId]/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
 
   switch (req.method) {

--- a/pages/api/check-auth.ts
+++ b/pages/api/check-auth.ts
@@ -15,10 +15,10 @@ const endpoint: NextApiHandler = async (
       try {
         const auth = isAuthorised(req);
         !auth
-          ? res.status(StatusCodes.UNAUTHORIZED).end()
+          ? res.status(StatusCodes.UNAUTHORIZED)
           : auth.isAuthorised
           ? res.status(StatusCodes.OK).json(auth)
-          : res.status(StatusCodes.FORBIDDEN).end();
+          : res.status(StatusCodes.FORBIDDEN);
       } catch (e) {
         console.error(e);
         res

--- a/pages/api/mash-referral/[id]/index.ts
+++ b/pages/api/mash-referral/[id]/index.ts
@@ -18,10 +18,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'PATCH':

--- a/pages/api/mash-referral/[id]/index.ts
+++ b/pages/api/mash-referral/[id]/index.ts
@@ -18,10 +18,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'PATCH':

--- a/pages/api/mash-referral/reset.ts
+++ b/pages/api/mash-referral/reset.ts
@@ -14,10 +14,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'POST':

--- a/pages/api/mash-referral/reset.ts
+++ b/pages/api/mash-referral/reset.ts
@@ -14,10 +14,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'POST':

--- a/pages/api/me/index.ts
+++ b/pages/api/me/index.ts
@@ -14,10 +14,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/me/index.ts
+++ b/pages/api/me/index.ts
@@ -14,10 +14,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/postcode/[postcode].ts
+++ b/pages/api/postcode/[postcode].ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/postcode/[postcode].ts
+++ b/pages/api/postcode/[postcode].ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/relationships/[id].ts
+++ b/pages/api/relationships/[id].ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'DELETE':

--- a/pages/api/relationships/[id].ts
+++ b/pages/api/relationships/[id].ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'DELETE':

--- a/pages/api/relationships/index.ts
+++ b/pages/api/relationships/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'POST':

--- a/pages/api/relationships/index.ts
+++ b/pages/api/relationships/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'POST':

--- a/pages/api/residents/[id]/allocations/[allocationId].ts
+++ b/pages/api/residents/[id]/allocations/[allocationId].ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/residents/[id]/allocations/[allocationId].ts
+++ b/pages/api/residents/[id]/allocations/[allocationId].ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/residents/[id]/allocations/index.ts
+++ b/pages/api/residents/[id]/allocations/index.ts
@@ -19,10 +19,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/residents/[id]/allocations/index.ts
+++ b/pages/api/residents/[id]/allocations/index.ts
@@ -19,10 +19,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/residents/[id]/cases/index.ts
+++ b/pages/api/residents/[id]/cases/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   const { id, ...params } = req.query;
   switch (req.method) {

--- a/pages/api/residents/[id]/cases/index.ts
+++ b/pages/api/residents/[id]/cases/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   const { id, ...params } = req.query;
   switch (req.method) {

--- a/pages/api/residents/[id]/casestatus/index.ts
+++ b/pages/api/residents/[id]/casestatus/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/residents/[id]/casestatus/index.ts
+++ b/pages/api/residents/[id]/casestatus/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/residents/[id]/index.ts
+++ b/pages/api/residents/[id]/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   const id = parseInt(req.query.id as string, 10);
   switch (req.method) {

--- a/pages/api/residents/[id]/index.ts
+++ b/pages/api/residents/[id]/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   const id = parseInt(req.query.id as string, 10);
   switch (req.method) {

--- a/pages/api/residents/[id]/relationships/index.ts
+++ b/pages/api/residents/[id]/relationships/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/residents/[id]/relationships/index.ts
+++ b/pages/api/residents/[id]/relationships/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/residents/[id]/warningnotes/index.ts
+++ b/pages/api/residents/[id]/warningnotes/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/residents/[id]/warningnotes/index.ts
+++ b/pages/api/residents/[id]/warningnotes/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/residents/index.ts
+++ b/pages/api/residents/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/residents/index.ts
+++ b/pages/api/residents/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/search/person/index.ts
+++ b/pages/api/search/person/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
 
   switch (req.method) {

--- a/pages/api/search/person/index.ts
+++ b/pages/api/search/person/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
 
   switch (req.method) {

--- a/pages/api/teams/[team_id]/allocations.ts
+++ b/pages/api/teams/[team_id]/allocations.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/teams/[team_id]/allocations.ts
+++ b/pages/api/teams/[team_id]/allocations.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/teams/[team_id]/workers.ts
+++ b/pages/api/teams/[team_id]/workers.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/teams/[team_id]/workers.ts
+++ b/pages/api/teams/[team_id]/workers.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/teams/index.ts
+++ b/pages/api/teams/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/teams/index.ts
+++ b/pages/api/teams/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/warningnotes/[warningNoteId].ts
+++ b/pages/api/warningnotes/[warningNoteId].ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/warningnotes/[warningNoteId].ts
+++ b/pages/api/warningnotes/[warningNoteId].ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/warningnotes/index.ts
+++ b/pages/api/warningnotes/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'POST':

--- a/pages/api/warningnotes/index.ts
+++ b/pages/api/warningnotes/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'POST':

--- a/pages/api/workers/[id]/allocations.ts
+++ b/pages/api/workers/[id]/allocations.ts
@@ -15,10 +15,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/workers/[id]/allocations.ts
+++ b/pages/api/workers/[id]/allocations.ts
@@ -15,10 +15,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/workers/[id]/index.ts
+++ b/pages/api/workers/[id]/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/workers/[id]/index.ts
+++ b/pages/api/workers/[id]/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/workers/index.ts
+++ b/pages/api/workers/index.ts
@@ -13,10 +13,12 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED);
+    res.status(StatusCodes.UNAUTHORIZED);
+    return;
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN);
+    res.status(StatusCodes.FORBIDDEN);
+    return;
   }
   switch (req.method) {
     case 'GET':

--- a/pages/api/workers/index.ts
+++ b/pages/api/workers/index.ts
@@ -13,10 +13,10 @@ const endpoint: NextApiHandler = async (
 ) => {
   const user = isAuthorised(req);
   if (!user) {
-    return res.status(StatusCodes.UNAUTHORIZED).end();
+    return res.status(StatusCodes.UNAUTHORIZED);
   }
   if (!user.isAuthorised) {
-    return res.status(StatusCodes.FORBIDDEN).end();
+    return res.status(StatusCodes.FORBIDDEN);
   }
   switch (req.method) {
     case 'GET':

--- a/zap-baseline.conf
+++ b/zap-baseline.conf
@@ -42,6 +42,7 @@
 10061	FAIL	(X-AspNet-Version Response Header)
 # getting false positives: https://github.com/LBHackney-IT/lbh-social-care-frontend/pull/844
 10062	OUTOFSCOPE	.*\/_next\/static\/.*\/_buildManifest.js
+10023	OUTOFSCOPE	.*\/sitemap.xml
 10062	FAIL	(PII Disclosure)
 10096	FAIL	(Timestamp Disclosure)
 10097	FAIL	(Hash Disclosure)
@@ -56,6 +57,7 @@
 90011	FAIL	(Charset Mismatch)
 # Next.js 11.1's `main.js` file contains the string "Internal Server Error" which falsely trips up rule 90022 below
 90022	OUTOFSCOPE	.*\/chunks\/.*\.js
+90022	OUTOFSCOPE	.*\/sitemap.xml
 90022	FAIL	(Application Error Disclosure)
 90030	FAIL	(WSDL File Detection)
 90033	FAIL	(Loosely Scoped Cookie)


### PR DESCRIPTION
**What**  
Removes calls to `.end()` from returned streams on unauthenticated requests.

**Why**  
This should fix the issue where errors are being posted after a 40X response from the API.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
