### PR TITLE
fix: AppConfigProvider errors on static pages

### DIFF
--- a/lib/appConfig.spec.tsx
+++ b/lib/appConfig.spec.tsx
@@ -12,18 +12,6 @@ describe('AppConfigContext', () => {
   });
 
   describe('useAppConfig', () => {
-    it('throws an error if the hook is used outside of the provider', () => {
-      const { result } = renderHook(() => useAppConfig(), {
-        wrapper: undefined,
-      });
-
-      expect(result.error).toEqual(
-        new Error(
-          'A <AppConfigProvider /> must be provided as a parent of this component'
-        )
-      );
-    });
-
     describe('getConfigValue', () => {
       it('returns the value from the appConfig that matches the identifier given', () => {
         const wrapper: React.FC = ({ children }) => (
@@ -38,6 +26,18 @@ describe('AppConfigContext', () => {
 
         expect(result.current.getConfigValue('someIdentifier')).toEqual(
           'someValue'
+        );
+      });
+
+      it('throws an error if the hook is used outside of the provider', () => {
+        const { result } = renderHook(() => useAppConfig(), {
+          wrapper: undefined,
+        });
+
+        expect(() =>
+          result.current.getConfigValue('someNonExistentIdentifier')
+        ).toThrowError(
+          'A <AppConfigProvider /> must be provided as a parent of this component'
         );
       });
 

--- a/lib/appConfig.tsx
+++ b/lib/appConfig.tsx
@@ -23,17 +23,17 @@ export const useAppConfig: () => {
 } = () => {
   const appConfig = useContext(AppConfigContext);
 
-  if (appConfig === undefined) {
-    throw new Error(
-      'A <AppConfigProvider /> must be provided as a parent of this component'
-    );
-  }
-
   return {
     getConfigValue: (identifier) => {
-      const configValue = appConfig[identifier];
+      const configValue = appConfig?.[identifier];
 
       if (configValue === undefined) {
+        if (appConfig === undefined) {
+          throw new Error(
+            'A <AppConfigProvider /> must be provided as a parent of this component'
+          );
+        }
+
         throw new Error(
           `A value for ${identifier} is not defined in the app config`
         );

--- a/zap-baseline.conf
+++ b/zap-baseline.conf
@@ -33,6 +33,8 @@
 10041	FAIL	(HTTP to HTTPS Insecure Transition in Form Post)
 10042	FAIL	(HTTPS to HTTP Insecure Transition in Form Post)
 10043	FAIL	(User Controllable JavaScript Event (XSS))
+# Getting false positives here, the sitemap does not return a body
+10044	OUTOFSCOPE	.*\/sitemap.xml
 10044	FAIL	(Big Redirect Detected (Potential Sensitive Information Leak))
 10050	FAIL	(Retrieved from Cache)
 10052	FAIL	(X-ChromeLogger-Data (XCOLD) Header Information Leak)


### PR DESCRIPTION
**What**  
Only throw an `AppConfigProvider` error when getting a config value, rather than when calling `useAppConfig()`.

**Why**  
Errors are thrown when static pages are loaded, even though they never actually pull data from the `AppConfigProvider`.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
