### PR TITLE
fix: turn auth into a gate in the api wrapper

### DIFF
--- a/lib/apiHandler.ts
+++ b/lib/apiHandler.ts
@@ -1,8 +1,42 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { withSentry } from '@sentry/nextjs';
+import { isAuthorised } from '../utils/auth';
+import { StatusCodes } from 'http-status-codes';
+import { User } from '../types';
+
+export type AuthenticatedNextApiHandler<T = any> = (
+  req: NextApiRequest & { user: User },
+  res: NextApiResponse<T>
+) => void | Promise<void>;
 
 export const apiHandler =
-  (handler: (req: NextApiRequest, res: NextApiResponse) => void) =>
-  async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
-    await withSentry(handler)(req, res);
+  (handler: AuthenticatedNextApiHandler) =>
+  async (
+    req: NextApiRequest & { user: User },
+    res: NextApiResponse
+  ): Promise<void> => {
+    const user = isAuthorised(req);
+
+    if (!user) {
+      res.status(StatusCodes.UNAUTHORIZED);
+      return;
+    }
+    if (!user.isAuthorised) {
+      res.status(StatusCodes.FORBIDDEN);
+      return;
+    }
+
+    req.user = user;
+
+    await (
+      withSentry(
+        handler as (
+          req: NextApiRequest,
+          res: NextApiResponse
+        ) => void | Promise<void>
+      ) as (
+        req: NextApiRequest & { user: User },
+        res: NextApiResponse
+      ) => Promise<void>
+    )(req, res);
   };

--- a/lib/auth/test-functions.tsx
+++ b/lib/auth/test-functions.tsx
@@ -1,5 +1,6 @@
 import { NextApiRequest } from 'next';
 import { ParsedUrlQuery } from 'querystring';
+import { User } from '../../types';
 
 export interface MakeNextApiRequestInput {
   method?:
@@ -21,6 +22,7 @@ export interface MakeNextApiRequestInput {
   cookies?: {
     [key: string]: string;
   };
+  user?: User;
 }
 
 export const makeNextApiRequest = ({
@@ -30,14 +32,16 @@ export const makeNextApiRequest = ({
   body = null,
   headers = {},
   cookies = { [process.env.HACKNEY_AUTH_COOKIE_NAME as string]: 'test-token' },
-}: MakeNextApiRequestInput): NextApiRequest => {
+  user,
+}: MakeNextApiRequestInput): NextApiRequest & { user: User } => {
   const request = {
     method,
     url,
     query,
     headers,
     cookies,
-  } as unknown as NextApiRequest;
+    user,
+  } as unknown as NextApiRequest & { user: User };
 
   if (body) request['body'] = JSON.stringify(body);
 

--- a/lib/csrfToken.ts
+++ b/lib/csrfToken.ts
@@ -1,5 +1,6 @@
 import Tokens from 'csrf';
 import { NextApiRequest, NextApiResponse } from 'next';
+import { User } from '../types';
 
 export class CSRFValidationError extends Error {
   message = 'invalid csrf token provided';
@@ -23,9 +24,18 @@ class CSRF {
   }
 
   middleware(
-    handler: (req: NextApiRequest, res: NextApiResponse) => void
-  ): (req: NextApiRequest, res: NextApiResponse) => Promise<void> {
-    return async (req: NextApiRequest, res: NextApiResponse) => {
+    handler: (
+      req: NextApiRequest & { user: User },
+      res: NextApiResponse
+    ) => void
+  ): (
+    req: NextApiRequest & { user: User },
+    res: NextApiResponse
+  ) => Promise<void> {
+    return async (
+      req: NextApiRequest & { user: User },
+      res: NextApiResponse
+    ) => {
       if (!this.ignoredMethods.includes(req.method as string))
         try {
           this.validate(req.headers['xsrf-token']);
@@ -51,9 +61,14 @@ export const { csrfFetch, init, middleware, token, tokenFromMeta, validate } = {
   token: (): string => new CSRF().token(),
   validate: (token: string): void => new CSRF().validate(token),
   middleware: (
-    handler: (req: NextApiRequest, res: NextApiResponse) => void
-  ): ((req: NextApiRequest, res: NextApiResponse) => Promise<void>) =>
-    new CSRF().middleware(handler),
+    handler: (
+      req: NextApiRequest & { user: User },
+      res: NextApiResponse
+    ) => void
+  ): ((
+    req: NextApiRequest & { user: User },
+    res: NextApiResponse
+  ) => Promise<void>) => new CSRF().middleware(handler),
   tokenFromMeta: (): string =>
     (document.querySelector('meta[http-equiv=XSRF-TOKEN]') as HTMLMetaElement)
       ?.content,

--- a/pages/api/case-note/[id].ts
+++ b/pages/api/case-note/[id].ts
@@ -1,20 +1,16 @@
-import { NextApiRequest, NextApiResponse } from 'next';
 import StatusCodes from 'http-status-codes';
 import { finishSubmission, patchSubmissionForStep } from 'lib/submissions';
 import { FormikValues } from 'formik';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
-import { isAuthorised } from 'utils/auth';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-const handler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
+const handler: AuthenticatedNextApiHandler = async (
+  req,
+  res
 ): Promise<void> => {
   try {
     const { id } = req.query;
-
-    const user = isAuthorised(req);
 
     switch (req.method) {
       case 'POST':
@@ -22,7 +18,7 @@ const handler = async (
           const values = req.body as FormikValues;
           const submission = await finishSubmission(
             String(id),
-            String(user?.email),
+            String(req.user.email),
             { singleStep: values }
           );
           res.json(submission);
@@ -39,7 +35,7 @@ const handler = async (
           const submission = await patchSubmissionForStep(
             String(id),
             'singleStep',
-            String(user?.email),
+            String(req.user.email),
             values,
             dateOfEventId,
             titleId

--- a/pages/api/cases/[caseId].ts
+++ b/pages/api/cases/[caseId].ts
@@ -1,25 +1,11 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { getCase } from 'lib/cases';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   const { caseId, residentId, ...params } = req.query;
   switch (req.method) {
     case 'GET':
@@ -29,9 +15,9 @@ const endpoint: NextApiHandler = async (
           {
             ...params,
             residentId: Number(residentId),
-            context_flag: user.permissionFlag,
+            context_flag: req.user?.permissionFlag,
           },
-          user
+          req.user
         );
         data
           ? res.status(StatusCodes.OK).json(data)

--- a/pages/api/cases/historic-note/[caseId].ts
+++ b/pages/api/cases/historic-note/[caseId].ts
@@ -1,31 +1,17 @@
 import { StatusCodes } from 'http-status-codes';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 import { getHistoricNote } from 'lib/cases';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   const { caseId, ...params } = req.query;
   switch (req.method) {
     case 'GET':
       try {
         const data = await getHistoricNote(caseId as string, {
           ...params,
-          context_flag: user.permissionFlag,
+          context_flag: req.user.permissionFlag,
         });
         data
           ? res.status(StatusCodes.OK).json(data)

--- a/pages/api/cases/historic-visit/[caseId].ts
+++ b/pages/api/cases/historic-visit/[caseId].ts
@@ -1,31 +1,17 @@
 import { StatusCodes } from 'http-status-codes';
 import { getHistoricVisit } from 'lib/cases';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   const { caseId, ...params } = req.query;
   switch (req.method) {
     case 'GET':
       try {
         const data = await getHistoricVisit(caseId as string, {
           ...params,
-          context_flag: user.permissionFlag,
+          context_flag: req.user.permissionFlag,
         });
         data
           ? res.status(StatusCodes.OK).json(data)

--- a/pages/api/cases/index.ts
+++ b/pages/api/cases/index.ts
@@ -1,32 +1,18 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { getCases, addCase } from 'lib/cases';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {
         const data = await getCases({
           ...req.query,
-          context_flag: user.permissionFlag,
+          context_flag: req.user.permissionFlag,
         });
         res.status(StatusCodes.OK).json(data);
       } catch (error) {

--- a/pages/api/casestatus/[id]/index.ts
+++ b/pages/api/casestatus/[id]/index.ts
@@ -1,27 +1,12 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { patchCaseStatus } from 'lib/caseStatus';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
-
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'PATCH':
       try {

--- a/pages/api/casestatus/index.ts
+++ b/pages/api/casestatus/index.ts
@@ -1,27 +1,10 @@
 import { StatusCodes } from 'http-status-codes';
-
 import { addCaseStatus } from 'lib/caseStatus';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
-
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
-
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'POST':
       try {

--- a/pages/api/casestatus/update/[caseStatusId]/index.ts
+++ b/pages/api/casestatus/update/[caseStatusId]/index.ts
@@ -1,26 +1,12 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { updateCaseStatus } from 'lib/caseStatus';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-  }
-
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'POST':
       try {

--- a/pages/api/check-auth.ts
+++ b/pages/api/check-auth.ts
@@ -1,10 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
-
 import { isAuthorised } from 'utils/auth';
-
 import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
-
 import { apiHandler } from 'lib/apiHandler';
 
 const endpoint: NextApiHandler = async (

--- a/pages/api/mash-referral/[id]/index.ts
+++ b/pages/api/mash-referral/[id]/index.ts
@@ -1,9 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
-
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import {
   patchReferralFinal,
   patchReferralInitial,
@@ -11,21 +8,9 @@ import {
   patchReferralContact,
 } from 'lib/mashReferral';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'PATCH':
       try {

--- a/pages/api/mash-referral/reset.ts
+++ b/pages/api/mash-referral/reset.ts
@@ -1,27 +1,11 @@
 import { StatusCodes } from 'http-status-codes';
-
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
-
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 
 import { AxiosError } from 'axios';
 import { resetDummyData } from 'lib/mashReferral';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'POST':
       try {

--- a/pages/api/me/index.ts
+++ b/pages/api/me/index.ts
@@ -5,14 +5,10 @@ import { getWorkerByEmail } from 'lib/workers';
 import { getAllocationsByWorker } from 'lib/allocatedWorkers';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   const user = isAuthorised(req);
   if (!user) {
     res.status(StatusCodes.UNAUTHORIZED);

--- a/pages/api/postcode/[postcode].ts
+++ b/pages/api/postcode/[postcode].ts
@@ -1,26 +1,11 @@
 import { StatusCodes } from 'http-status-codes';
-
-import { isAuthorised } from 'utils/auth';
 import { getAddresses } from 'lib/postcode';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {

--- a/pages/api/relationships/[id].ts
+++ b/pages/api/relationships/[id].ts
@@ -1,26 +1,12 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { removeRelationship } from 'lib/relationships';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'DELETE':
       try {

--- a/pages/api/relationships/index.ts
+++ b/pages/api/relationships/index.ts
@@ -1,26 +1,11 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { addRelationship } from 'lib/relationships';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
-
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'POST':
       try {

--- a/pages/api/residents/[id]/allocations/[allocationId].ts
+++ b/pages/api/residents/[id]/allocations/[allocationId].ts
@@ -1,25 +1,11 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { getResidentAllocation } from 'lib/allocatedWorkers';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {

--- a/pages/api/residents/[id]/cases/index.ts
+++ b/pages/api/residents/[id]/cases/index.ts
@@ -1,33 +1,19 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { getCasesByResident } from 'lib/cases';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   const { id, ...params } = req.query;
   switch (req.method) {
     case 'GET':
       try {
         const data = await getCasesByResident(parseInt(id as string, 10), {
           ...params,
-          context_flag: user.permissionFlag,
+          context_flag: req.user.permissionFlag,
         });
         res.status(StatusCodes.OK).json(data);
       } catch (error) {

--- a/pages/api/residents/[id]/casestatus/index.ts
+++ b/pages/api/residents/[id]/casestatus/index.ts
@@ -1,26 +1,12 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { getCaseStatusByPersonId } from 'lib/caseStatus';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {

--- a/pages/api/residents/[id]/relationships/index.ts
+++ b/pages/api/residents/[id]/relationships/index.ts
@@ -1,26 +1,12 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { getRelationshipByResident } from 'lib/relationships';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {

--- a/pages/api/residents/[id]/warningnotes/index.ts
+++ b/pages/api/residents/[id]/warningnotes/index.ts
@@ -1,26 +1,12 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { getWarningNotesByResident } from 'lib/warningNotes';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {

--- a/pages/api/search/person/index.ts
+++ b/pages/api/search/person/index.ts
@@ -1,27 +1,12 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { searchPerson } from 'lib/search';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
-
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {

--- a/pages/api/submissions/[id]/delete.ts
+++ b/pages/api/submissions/[id]/delete.ts
@@ -1,22 +1,18 @@
-import { NextApiRequest, NextApiResponse } from 'next';
 import StatusCodes from 'http-status-codes';
 import { deleteSubmission } from 'lib/submissions';
-import { isAuthorised } from 'utils/auth';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-const handler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
+const handler: AuthenticatedNextApiHandler = async (
+  req,
+  res
 ): Promise<void> => {
   switch (req.method) {
     case 'DELETE':
       {
-        const user = isAuthorised(req);
-
         const submissionid = req.query.id as string;
-        const deletedBy = user?.email as string;
+        const deletedBy = req.user.email as string;
         const deleteReason = req.query.deleteReason as string;
         const deleteRequestedBy = req.query.deleteRequestedBy as string;
 

--- a/pages/api/submissions/[id]/panel-approvals.ts
+++ b/pages/api/submissions/[id]/panel-approvals.ts
@@ -1,24 +1,20 @@
-import { NextApiRequest, NextApiResponse } from 'next';
 import StatusCodes from 'http-status-codes';
 import { panelApproveSubmission } from 'lib/submissions';
-import { isAuthorised } from 'utils/auth';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-const handler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
+const handler: AuthenticatedNextApiHandler = async (
+  req,
+  res
 ): Promise<void> => {
   const { id } = req.query;
-
-  const user = isAuthorised(req);
 
   switch (req.method) {
     case 'POST':
       {
         const submission = await panelApproveSubmission(
           String(id),
-          String(user?.email)
+          String(req.user.email)
         );
         res.json(submission);
       }

--- a/pages/api/submissions/[id]/steps/[stepId].ts
+++ b/pages/api/submissions/[id]/steps/[stepId].ts
@@ -1,16 +1,15 @@
-import { NextApiRequest, NextApiResponse } from 'next';
 import forms from 'data/flexibleForms';
 import { isAuthorised } from 'utils/auth';
 import { getSubmissionById, patchSubmissionForStep } from 'lib/submissions';
 import statusCodes from 'http-status-codes';
 import { Submission } from 'data/flexibleForms/forms.types';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-const handler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
+const endpoint: AuthenticatedNextApiHandler = async (
+  req,
+  res
 ): Promise<void> => {
   try {
     const { id, stepId } = req.query;
@@ -53,4 +52,4 @@ const handler = async (
   }
 };
 
-export default apiHandler(csrfMiddleware(handler));
+export default apiHandler(csrfMiddleware(endpoint));

--- a/pages/api/submissions/index.ts
+++ b/pages/api/submissions/index.ts
@@ -1,13 +1,12 @@
-import { NextApiRequest, NextApiResponse } from 'next';
 import StatusCodes from 'http-status-codes';
 import { startSubmission, getInProgressSubmissions } from 'lib/submissions';
 import { isAuthorised } from 'utils/auth';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-const handler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
+const handler: AuthenticatedNextApiHandler = async (
+  req,
+  res
 ): Promise<void> => {
   const user = isAuthorised(req);
   switch (req.method) {

--- a/pages/api/teams/[team_id]/allocations.ts
+++ b/pages/api/teams/[team_id]/allocations.ts
@@ -1,26 +1,12 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { getAllocationsByTeam } from 'lib/allocatedWorkers';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {

--- a/pages/api/teams/[team_id]/workers.ts
+++ b/pages/api/teams/[team_id]/workers.ts
@@ -1,25 +1,11 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { getWorkers } from 'lib/workers';
-import { isAuthorised } from 'utils/auth';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {

--- a/pages/api/teams/index.ts
+++ b/pages/api/teams/index.ts
@@ -1,31 +1,15 @@
 import { StatusCodes } from 'http-status-codes';
-
 import { getTeams } from 'lib/teams';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
-
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {
         const data = await getTeams({
-          context_flag: req.query?.ageContext || user.permissionFlag || 'B', //TODO fix this once 'B' has been added to the BE
+          context_flag: req.query?.ageContext || req.user.permissionFlag || 'B', //TODO fix this once 'B' has been added to the BE
         });
         res.status(StatusCodes.OK).json(data);
       } catch (error) {

--- a/pages/api/throw-error.ts
+++ b/pages/api/throw-error.ts
@@ -1,10 +1,6 @@
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
+const endpoint: AuthenticatedNextApiHandler = async () => {
   throw new Error('ErrorThrowingPage api error');
 };
 

--- a/pages/api/warningnotes/[warningNoteId].ts
+++ b/pages/api/warningnotes/[warningNoteId].ts
@@ -1,26 +1,12 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { getWarningNote, updateWarningNote } from 'lib/warningNotes';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {

--- a/pages/api/warningnotes/index.ts
+++ b/pages/api/warningnotes/index.ts
@@ -1,26 +1,12 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { addWarningNote } from 'lib/warningNotes';
-import { isAuthorised } from 'utils/auth';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'POST':
       try {

--- a/pages/api/workers/[id]/allocations.ts
+++ b/pages/api/workers/[id]/allocations.ts
@@ -1,39 +1,24 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { isAuthorised } from 'utils/auth';
 import { getWorker } from 'lib/workers';
 import { getAllocationsByWorker } from 'lib/allocatedWorkers';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
-
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {
         const workersData = getWorker(parseInt(req.query.id as string, 10), {
-          context_flag: user.permissionFlag,
+          context_flag: req.user.permissionFlag,
         });
         const allocationsData = getAllocationsByWorker(
           parseInt(req.query.id as string, 10),
           req.query.sort_by as string,
           {
-            context_flag: user.permissionFlag,
+            context_flag: req.user.permissionFlag,
           }
         );
 

--- a/pages/api/workers/[id]/index.ts
+++ b/pages/api/workers/[id]/index.ts
@@ -1,31 +1,17 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { isAuthorised } from 'utils/auth';
 import { getWorker, updateWorker } from 'lib/workers';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {
         const data = await getWorker(parseInt(req.query.id as string, 10), {
-          context_flag: user.permissionFlag,
+          context_flag: req.user.permissionFlag,
         });
         res.status(StatusCodes.OK).json(data);
       } catch (error) {

--- a/pages/api/workers/index.ts
+++ b/pages/api/workers/index.ts
@@ -1,26 +1,12 @@
 import { StatusCodes } from 'http-status-codes';
-import { isAuthorised } from 'utils/auth';
 
 import { getWorkers, addWorker } from 'lib/workers';
 import { middleware as csrfMiddleware } from 'lib/csrfToken';
 
-import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
 import { AxiosError } from 'axios';
-import { apiHandler } from 'lib/apiHandler';
+import { apiHandler, AuthenticatedNextApiHandler } from 'lib/apiHandler';
 
-const endpoint: NextApiHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => {
-  const user = isAuthorised(req);
-  if (!user) {
-    res.status(StatusCodes.UNAUTHORIZED);
-    return;
-  }
-  if (!user.isAuthorised) {
-    res.status(StatusCodes.FORBIDDEN);
-    return;
-  }
+const endpoint: AuthenticatedNextApiHandler = async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {


### PR DESCRIPTION
**What**  
Add an auth check and response end in case of unauthed users to the `apiHandler` wrapper.

**Why**  
A small number of API endpoints are pulling user credentials but then not validating and rejecting the request if the user is not authenticated.

**Anything else?**

Affected endpoints:

* /api/case-note/[id]
* /api/submissions/[id]/approvals
* /api/submissions/[id]/panel-approvals
* /api/submissions/[id]/delete
* /api/submissions/[id]/steps/[stepId]
* /api/submissions/[id]
* /api/submissions
