### PR TITLE
fix: Csrf token for Case Notes

### DIFF
--- a/components/GroupRecording/GroupRecordingWidget.spec.tsx
+++ b/components/GroupRecording/GroupRecordingWidget.spec.tsx
@@ -2,6 +2,7 @@ import GroupRecordingWidget from './GroupRecordingWidget';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { mockedResident, residentFactory } from 'factories/residents';
 import { useResidents } from 'utils/api/residents';
+import * as CSRFToken from 'lib/csrfToken';
 import axios from 'axios';
 
 jest.mock('next/router', () => ({
@@ -14,7 +15,6 @@ jest.mock('next/router', () => ({
 jest.mock('utils/api/residents', () => ({
   useResidents: jest.fn(),
 }));
-
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
@@ -41,6 +41,8 @@ describe('GroupRecordingWidget', () => {
       ],
     });
   });
+  const mock = jest.spyOn(CSRFToken, 'tokenFromMeta'); // spy on otherFn
+  mock.mockReturnValue('TEST_XSRF');
 
   it('should render properly', () => {
     const { asFragment } = render(
@@ -224,9 +226,13 @@ describe('GroupRecordingWidget', () => {
 
     fireEvent.click(screen.getByText('Add person'));
 
-    expect(mockedAxios.patch).toHaveBeenLastCalledWith('/api/submissions/1', {
-      residents: [mockedResident1.id, mockedResident2.id],
-    });
+    expect(mockedAxios.patch).toHaveBeenLastCalledWith(
+      '/api/submissions/1',
+      {
+        residents: [mockedResident1.id, mockedResident2.id],
+      },
+      { headers: { 'XSRF-TOKEN': 'TEST_XSRF' } }
+    );
   });
 
   it('displays the newly added resident', () => {
@@ -267,9 +273,13 @@ describe('GroupRecordingWidget', () => {
 
     fireEvent.click(screen.getAllByText('Remove')[0]);
 
-    expect(mockedAxios.patch).toHaveBeenLastCalledWith('/api/submissions/1', {
-      residents: [mockedResident2.id],
-    });
+    expect(mockedAxios.patch).toHaveBeenLastCalledWith(
+      '/api/submissions/1',
+      {
+        residents: [mockedResident2.id],
+      },
+      { headers: { 'XSRF-TOKEN': 'TEST_XSRF' } }
+    );
   });
 
   it('removes the removed resident from the group recording display', () => {

--- a/components/GroupRecording/GroupRecordingWidget.tsx
+++ b/components/GroupRecording/GroupRecordingWidget.tsx
@@ -5,7 +5,7 @@ import Dialog from './../Dialog/Dialog';
 import s from './GroupRecordingWidget.module.scss';
 import PersonSelect from './../PersonSelect/PersonSelect';
 import axios from 'axios';
-
+import { tokenFromMeta } from 'lib/csrfToken';
 import { useResidents as useIDSearch } from 'utils/api/residents';
 import { useResidents as useFirstNameSearch } from 'utils/api/residents';
 import { useResidents as useLastNameSearch } from 'utils/api/residents';
@@ -94,9 +94,17 @@ const GroupRecordingWidget = ({
   useEffect(() => {
     const residents = people.map((person) => mapPeopleToIds(person));
 
-    axios.patch(`/api/submissions/${submissionId}`, {
-      residents,
-    });
+    axios.patch(
+      `/api/submissions/${submissionId}`,
+      {
+        residents,
+      },
+      {
+        headers: {
+          'XSRF-TOKEN': tokenFromMeta(),
+        },
+      }
+    );
   }, [people, submissionId]);
 
   const handleAdd = (): void => {

--- a/pages/people/[id]/case-note.tsx
+++ b/pages/people/[id]/case-note.tsx
@@ -24,6 +24,7 @@ import {
 import { useState } from 'react';
 import { getResident } from 'lib/residents';
 import { User } from 'types';
+import { tokenFromMeta } from 'lib/csrfToken';
 
 interface Props extends Submission {
   params: {
@@ -59,14 +60,26 @@ const CaseNote = ({
   ) => {
     try {
       if (finished) {
-        await axios.post(`/api/case-note/${submissionId}`, values);
+        await axios.post(`/api/case-note/${submissionId}`, values, {
+          headers: {
+            'XSRF-TOKEN': tokenFromMeta(),
+          },
+        });
         router.push(`/residents/${params.id}/case-notes`);
       } else {
-        await axios.patch(`/api/case-note/${submissionId}`, {
-          values,
-          dateOfEventId: form.dateOfEvent?.associatedId,
-          titleId: form.title?.associatedId,
-        });
+        await axios.patch(
+          `/api/case-note/${submissionId}`,
+          {
+            values,
+            dateOfEventId: form.dateOfEvent?.associatedId,
+            titleId: form.title?.associatedId,
+          },
+          {
+            headers: {
+              'XSRF-TOKEN': tokenFromMeta(),
+            },
+          }
+        );
       }
     } catch (e) {
       setStatus((e as Error).toString());

--- a/pages/submissions/[id]/steps/[stepId].tsx
+++ b/pages/submissions/[id]/steps/[stepId].tsx
@@ -13,6 +13,7 @@ import { FormikValues, FormikHelpers } from 'formik';
 import { InitialValues } from 'lib/utils';
 import { AutosaveProvider, AutosaveIndicator } from 'contexts/autosaveContext';
 import GroupRecordingWidget from 'components/GroupRecording/GroupRecordingWidget';
+import { tokenFromMeta } from 'lib/csrfToken';
 
 interface Props {
   params: {
@@ -39,7 +40,12 @@ const StepPage = ({
     try {
       const { data } = await axios.patch(
         `/api/submissions/${params.id}/steps/${params.stepId}`,
-        values
+        values,
+        {
+          headers: {
+            'XSRF-TOKEN': tokenFromMeta(),
+          },
+        }
       );
       if (data.error) throw data.error;
     } catch (e) {


### PR DESCRIPTION
**What**  
This PR adds the XSRF-TOKEN for all the calls in Case Notes that don't use the standard API routes.

**Why**  
The offended rows were not implementing the token, so an error was returned

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
