### PR TITLE
fix: end responses when unauthed

### DIFF
--- a/lib/apiHandler.ts
+++ b/lib/apiHandler.ts
@@ -44,11 +44,11 @@ export const apiHandler =
     const user = isAuthorised(req);
 
     if (!user) {
-      res.status(StatusCodes.UNAUTHORIZED);
+      res.status(StatusCodes.UNAUTHORIZED).end();
       return;
     }
     if (!user.isAuthorised) {
-      res.status(StatusCodes.FORBIDDEN);
+      res.status(StatusCodes.FORBIDDEN).end();
       return;
     }
 


### PR DESCRIPTION
**What**  
Fix 502 errors when not authenticated.

**Why**  
Api handler needs responses to be ended, otherwise they stay open and time out.

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
