### PR TITLE
feat: Add site wide warning

### DIFF
--- a/components/Layout/__snapshots__/index.spec.tsx.snap
+++ b/components/Layout/__snapshots__/index.spec.tsx.snap
@@ -9,6 +9,40 @@ exports[`Layout component should render properly 1`] = `
     Skip to main content
   </a>
   HeaderMockedPhaseBanner
+  <section
+    class="lbh-announcement lbh-announcement--site lbh-announcement--site--warning"
+  >
+    <div
+      class="lbh-container"
+    >
+      <h3
+        class="lbh-announcement__title"
+      >
+        DO 
+        <span
+          class="underline"
+        >
+          NOT
+        </span>
+         RECORD HERE !
+      </h3>
+      <div
+        class="lbh-announcement__content"
+      >
+        <p>
+          All information needs to be entered onto Mosaic only.
+          <br />
+          See the 
+          <a
+            href="https://intranet.hackney.gov.uk/mosaic-for-adults-social-care"
+          >
+             Adults Social Care Mosaic Pages 
+          </a>
+           on the intranet
+        </p>
+      </div>
+    </div>
+  </section>
   <div
     class="govuk-width-container"
   >

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -7,6 +7,7 @@ import Footer from './Footer/Footer';
 import OnboardingDialog from 'components/OnboardingDialog';
 import { User } from 'types';
 import { useAuth } from 'components/UserContext/UserContext';
+import SiteWideAnnouncement from 'components/SitewideAnnouncement/SitewideAnnouncement';
 
 export interface Props {
   children: React.ReactChild;
@@ -37,6 +38,7 @@ const Layout = ({
         faqLink={faqLink}
         handbookLink={handbookLink}
       />
+      <SiteWideAnnouncement />
       {goBackButton && <BackButton />}
 
       <div className="govuk-width-container">

--- a/components/ResidentPage/WorkflowTree.spec.tsx
+++ b/components/ResidentPage/WorkflowTree.spec.tsx
@@ -37,7 +37,7 @@ describe('WorkflowTree', () => {
     expect(screen.getAllByText('Unassigned').length).toBe(4);
 
     expect(
-      screen.queryByText('4 workflows started over over 1 year')
+      screen.queryByText('4 workflows started over about 2 years')
     ).toBeNull();
   });
 
@@ -45,7 +45,7 @@ describe('WorkflowTree', () => {
     render(
       <WorkflowTree workflows={mockTree} resident={mockedResident} summarise />
     );
-    expect(screen.getByText('4 workflows started over over 1 year'));
+    expect(screen.getByText('4 workflows started over about 2 years'));
   });
 
   it('marks in progress work differently', () => {

--- a/components/SitewideAnnouncement/SitewideAnnouncement.tsx
+++ b/components/SitewideAnnouncement/SitewideAnnouncement.tsx
@@ -1,0 +1,25 @@
+const SiteWideAnnouncement = (): React.ReactElement => {
+  return (
+    <section className="lbh-announcement lbh-announcement--site lbh-announcement--site--warning">
+      <div className="lbh-container">
+        <h3 className="lbh-announcement__title">
+          DO <span className="underline">NOT</span> RECORD HERE !
+        </h3>
+        <div className="lbh-announcement__content">
+          <p>
+            All information needs to be entered onto Mosaic only.
+            <br />
+            See the{' '}
+            <a href="https://intranet.hackney.gov.uk/mosaic-for-adults-social-care">
+              {' '}
+              Adults Social Care Mosaic Pages{' '}
+            </a>{' '}
+            on the intranet
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default SiteWideAnnouncement;

--- a/stylesheets/all.scss
+++ b/stylesheets/all.scss
@@ -256,3 +256,13 @@ input[type='time'] {
     }
   }
 }
+
+// site wide warning
+.lbh-announcement--site--warning {
+  border-color: lbh-colour('lbh-f03');
+  background: rgba(224, 60, 49, 0.2);
+}
+
+h3.lbh-announcement__title .underline {
+  text-decoration: underline;
+}


### PR DESCRIPTION
**What**  
Add site wide warning message asking users not to record anything in the application and advising them to view the intranet page for more information.

Also fix tests that were broken due to date time based checks.

**Why**  
ASC is migrating to Mosaic, so this application is no longer used as a recording tool
